### PR TITLE
SDK-342: Using formatted address for address

### DIFF
--- a/yoti_test.go
+++ b/yoti_test.go
@@ -379,8 +379,8 @@ func TestYotiClient_MissingPostalAddress_UsesFormattedAddress(t *testing.T) {
 		"formatted_address": "` + formattedAddressText + `"
 	}
 	]`)
-	structuredAddress, err := unmarshallJSON(structuredAddressBytes)
 
+	structuredAddress, err := unmarshallJSON(structuredAddressBytes)
 	if err != nil {
 		t.Errorf("Failed to parse structured address, error was %q", err.Error())
 	}
@@ -392,7 +392,6 @@ func TestYotiClient_MissingPostalAddress_UsesFormattedAddress(t *testing.T) {
 		Address:                 ""}
 
 	address, err := getFormattedAddressIfAddressIsMissing(result)
-
 	if err != nil {
 		t.Errorf("Failed to add formatted address to address, error was %q", err.Error())
 	}

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -3,8 +3,8 @@ package yoti
 import (
 	"crypto/rsa"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -182,10 +182,10 @@ func getActivityDetails(requester httpRequester, encryptedToken, sdkID string, k
 				}
 			}
 			formattedAddress, err := getFormattedAddressIfAddressIsMissing(result)
-			if err == nil {
-				result.Address = formattedAddress
-			} else {
+			if err != nil {
 				log.Printf("Unable to get 'Formatted Address' from 'Structured Postal Address'. Error: %q", err)
+			} else if formattedAddress != "" {
+				result.Address = formattedAddress
 			}
 		}
 	} else {


### PR DESCRIPTION
- Added feature to take `formatted address` from `structured postal address` if `address` is missing
- Made a few changes based on `gometalinter`, there are lots more suggestions, I've added ticket SDK-449 to look at the rest of these