### PR TITLE
[SDK-609]: Create Yoti v2 module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,16 @@
 # Contributing
 
-The command `go get "github.com/getyoti/yoti-go-sdk"` downloads the Yoti package, along with its dependencies, and installs it.
+The command `go get "github.com/getyoti/yoti-go-sdk/v2"` downloads the Yoti package, along with its dependencies, and installs it.
 
 ## Commit Process
 
+1) `go build` builds the package (then discards the results)
 1) `goimports` formats the code and sanitises imports
 1) `go vet` reports suspicious constructs
 1) `go test` to run the tests
 1) `go test -race` detects for race conditions
 1) `golangci-lint run` for [GolangCI-Lint](https://github.com/golangci/golangci-lint)
+1) `go mod tidy` prunes any no-longer-needed dependencies from `go.mod`, and adds any dependencies needed
 
 ## VS Code
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Yoti also allows you to enable user details verification from your mobile app by
 
 ## Installing the SDK
 
-To download and install the Yoti SDK and its dependencies, simply run the following command from your terminal:
+_As of version **2.3.0**, [modules](https://github.com/golang/go/wiki/Modules) are used. This means it's not neccesary to get a copy or fetch all dependencies as instructed below, as the Go toolchain will fetch them as neccesary. You can simply add a `require github.com/getyoti/yoti-go-sdk/v2` to go.mod._
+
+To download and install the Yoti SDK and its dependencies, run the following command from your terminal:
 
 ```Go
 go get "github.com/getyoti/yoti-go-sdk/v2"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Yoti also allows you to enable user details verification from your mobile app by
 To download and install the Yoti SDK and its dependencies, simply run the following command from your terminal:
 
 ```Go
-go get "github.com/getyoti/yoti-go-sdk"
+go get "github.com/getyoti/yoti-go-sdk/v2"
 ```
 
 ## SDK Project import
@@ -64,7 +64,7 @@ go get "github.com/getyoti/yoti-go-sdk"
 You can reference the project URL by adding the following import:
 
 ```Go
-import "github.com/getyoti/yoti-go-sdk"
+import "github.com/getyoti/yoti-go-sdk/v2"
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Yoti also allows you to enable user details verification from your mobile app by
 
 ## Installing the SDK
 
-_As of version **2.3.0**, [modules](https://github.com/golang/go/wiki/Modules) are used. This means it's not neccesary to get a copy or fetch all dependencies as instructed below, as the Go toolchain will fetch them as neccesary. You can simply add a `require github.com/getyoti/yoti-go-sdk/v2` to go.mod._
+_As of version **2.4.0**, [modules](https://github.com/golang/go/wiki/Modules) are used. This means it's not necessary to get a copy or fetch all dependencies as instructed below, as the Go toolchain will fetch them as necessary. You can simply add a `require github.com/getyoti/yoti-go-sdk/v2` to go.mod._
 
 To download and install the Yoti SDK and its dependencies, run the following command from your terminal:
 

--- a/anchor/anchorparser.go
+++ b/anchor/anchorparser.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
-	"github.com/getyoti/yoti-go-sdk/yotiprotocom"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotocom"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/anchor/anchors.go
+++ b/anchor/anchors.go
@@ -3,7 +3,7 @@ package anchor
 import (
 	"crypto/x509"
 
-	"github.com/getyoti/yoti-go-sdk/yotiprotocom"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotocom"
 )
 
 // Anchor is the metadata associated with an attribute. It describes how an attribute has been provided

--- a/anchor/signedtimestamp.go
+++ b/anchor/signedtimestamp.go
@@ -3,7 +3,7 @@ package anchor
 import (
 	"time"
 
-	"github.com/getyoti/yoti-go-sdk/yotiprotocom"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotocom"
 )
 
 // SignedTimestamp is the object which contains a timestamp

--- a/attribute/genericattribute.go
+++ b/attribute/genericattribute.go
@@ -1,8 +1,8 @@
 package attribute
 
 import (
-	"github.com/getyoti/yoti-go-sdk/anchor"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 // GenericAttribute is a Yoti attribute which returns a generic value

--- a/attribute/image.go
+++ b/attribute/image.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 const (

--- a/attribute/imageattribute.go
+++ b/attribute/imageattribute.go
@@ -1,8 +1,8 @@
 package attribute
 
 import (
-	"github.com/getyoti/yoti-go-sdk/anchor"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 // ImageAttribute is a Yoti attribute which returns an image as its value

--- a/attribute/imagesliceattribute.go
+++ b/attribute/imagesliceattribute.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"log"
 
-	"github.com/getyoti/yoti-go-sdk/anchor"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 // ImageSliceAttribute is a Yoti attribute which returns a slice of images as its value

--- a/attribute/item.go
+++ b/attribute/item.go
@@ -1,7 +1,7 @@
 package attribute
 
 import (
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 // Item is a structure which contains information about an attribute value

--- a/attribute/jsonattribute.go
+++ b/attribute/jsonattribute.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/getyoti/yoti-go-sdk/anchor"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 // JSONAttribute is a Yoti attribute which returns an interface as its value

--- a/attribute/multivalueattribute.go
+++ b/attribute/multivalueattribute.go
@@ -3,8 +3,8 @@ package attribute
 import (
 	"log"
 
-	"github.com/getyoti/yoti-go-sdk/anchor"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/attribute/parser.go
+++ b/attribute/parser.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 func parseValue(contentType yotiprotoattr.ContentType, byteValue []byte) (result interface{}) {

--- a/attribute/stringattribute.go
+++ b/attribute/stringattribute.go
@@ -1,8 +1,8 @@
 package attribute
 
 import (
-	"github.com/getyoti/yoti-go-sdk/anchor"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 // StringAttribute is a Yoti attribute which returns a string as its value

--- a/attribute/timeattribute.go
+++ b/attribute/timeattribute.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/getyoti/yoti-go-sdk/anchor"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 // TimeAttribute is a Yoti attribute which returns a time as its value

--- a/examples/aml/main.go
+++ b/examples/aml/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	yoti "github.com/getyoti/yoti-go-sdk"
+	yoti "github.com/getyoti/yoti-go-sdk/v2"
 	_ "github.com/joho/godotenv/autoload"
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,0 +1,3 @@
+module github.com/getyoti/yoti-go-sdk/examples
+
+require github.com/joho/godotenv v1.3.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=

--- a/examples/profile/main.go
+++ b/examples/profile/main.go
@@ -14,7 +14,7 @@ import (
 	"path"
 	"strings"
 
-	yoti "github.com/getyoti/yoti-go-sdk"
+	yoti "github.com/getyoti/yoti-go-sdk/v2"
 	_ "github.com/joho/godotenv/autoload"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,3 @@ require (
 	github.com/google/go-cmp v0.2.0
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 )
-
-exclude github.com/getyoti/yoti-go-sdk/examples v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,7 @@ module github.com/getyoti/yoti-go-sdk/v2
 require (
 	github.com/golang/protobuf v1.2.0
 	github.com/google/go-cmp v0.2.0
-	github.com/joho/godotenv v1.3.0
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 )
 
-exclude (
-	github.com/getyoti/yoti-go-sdk/examples/aml v1.0.0
-	github.com/getyoti/yoti-go-sdk/examples/profile v1.0.0
-)
+exclude github.com/getyoti/yoti-go-sdk/examples v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/getyoti/yoti-go-sdk/v2
+
+require (
+	github.com/golang/protobuf v1.2.0
+	github.com/google/go-cmp v0.2.0
+	github.com/joho/godotenv v1.3.0
+	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
+)
+
+exclude (
+	github.com/getyoti/yoti-go-sdk/examples/aml v1.0.0
+	github.com/getyoti/yoti-go-sdk/examples/profile v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,5 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
-github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/yoti_test.go
+++ b/yoti_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/getyoti/yoti-go-sdk/anchor"
-	"github.com/getyoti/yoti-go-sdk/attribute"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+	"github.com/getyoti/yoti-go-sdk/v2/attribute"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 )

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getyoti/yoti-go-sdk/attribute"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
-	"github.com/getyoti/yoti-go-sdk/yotiprotocom"
+	"github.com/getyoti/yoti-go-sdk/v2/attribute"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotocom"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/yotiprofile.go
+++ b/yotiprofile.go
@@ -1,8 +1,8 @@
 package yoti
 
 import (
-	"github.com/getyoti/yoti-go-sdk/attribute"
-	"github.com/getyoti/yoti-go-sdk/yotiprotoattr"
+	"github.com/getyoti/yoti-go-sdk/v2/attribute"
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 const (


### PR DESCRIPTION
I've gone with the "Major branch" strategy outlined in the [Go wiki on Modules ](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher). This allows us to carry on working on master, and if we do need to change anything for version 2 (after we've released version 3), then we can make a branch for v2, and make any bug fixes there. 
I'll add further detail to a wiki shortly, including what we'll need to do with each minor and major release going forwards.

When we release the major version, it will just be a case of renaming the module, and changing the v2s to v3s (or using [this handy tool](https://github.com/marwan-at-work/mod)). 

Also updated some fields to make them read only. 

This will require an update to the developer docs. 