### PR TITLE
SDK-895: Undefined content types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,10 @@ os:
   - linux
   - osx
 
-go_import_path: github.com/getyoti/yoti-go-sdk
-
 cache:
   directories:
     - $HOME/.cache/go-build
     - $HOME/gopath/pkg/mod
-    - $HOME/gopath/src/github.com/getyoti
     
 # Skip the installation step. Don't "go get" dependencies.
 install: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ os:
   - linux
   - osx
 
+go_import_path: github.com/getyoti/yoti-go-sdk
+
 cache:
   directories:
     - $HOME/.cache/go-build
@@ -19,7 +21,7 @@ cache:
     - $HOME/gopath/src/github.com/getyoti
     
 # Skip the installation step. Don't "go get" dependencies.
-install: true
+install: false
 
 # Only clone the most recent commit.
 git:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ The command `go get "github.com/getyoti/yoti-go-sdk/v2"` downloads the Yoti pack
 1) `go build` builds the package (then discards the results)
 1) `goimports` formats the code and sanitises imports
 1) `go vet` reports suspicious constructs
-1) `go test` to run the tests
-1) `go test -race` detects for race conditions
+1) `go test -race` to run the tests and detect race conditions
 1) `golangci-lint run` for [GolangCI-Lint](https://github.com/golangci/golangci-lint)
 1) `go mod tidy` prunes any no-longer-needed dependencies from `go.mod`, and adds any dependencies needed
 

--- a/attribute/parser.go
+++ b/attribute/parser.go
@@ -2,6 +2,7 @@ package attribute
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"time"
 
@@ -15,18 +16,18 @@ func parseValue(contentType yotiprotoattr.ContentType, byteValue []byte) (interf
 
 		if err == nil {
 			return &parsedTime, nil
-		} else {
-			return nil, fmt.Errorf("Unable to parse date value: %q. Error: %q", string(byteValue), err)
 		}
+
+		return nil, fmt.Errorf("Unable to parse date value: %q. Error: %q", string(byteValue), err)
 
 	case yotiprotoattr.ContentType_JSON:
 		unmarshalledJSON, err := UnmarshallJSON(byteValue)
 
 		if err == nil {
 			return unmarshalledJSON, nil
-		} else {
-			return nil, fmt.Errorf("Unable to parse JSON value: %q. Error: %q", string(byteValue), err)
 		}
+
+		return nil, fmt.Errorf("Unable to parse JSON value: %q. Error: %q", string(byteValue), err)
 
 	case yotiprotoattr.ContentType_STRING:
 		return string(byteValue), nil
@@ -39,16 +40,16 @@ func parseValue(contentType yotiprotoattr.ContentType, byteValue []byte) (interf
 		int, err := strconv.Atoi(stringValue)
 		if err == nil {
 			return int, nil
-		} else {
-			return nil, fmt.Errorf("Unable to parse INT value: %q. Error: %q", string(byteValue), err)
 		}
 
+		return nil, fmt.Errorf("Unable to parse INT value: %q. Error: %q", string(byteValue), err)
+
 	case yotiprotoattr.ContentType_JPEG,
-		yotiprotoattr.ContentType_PNG,
-		yotiprotoattr.ContentType_UNDEFINED:
+		yotiprotoattr.ContentType_PNG:
 		return byteValue, nil
 
 	default:
-		return byteValue, nil
+		log.Printf("Unknown type '%s', attempting to parse it as a String", contentType)
+		return string(byteValue), nil
 	}
 }

--- a/endpoint.go
+++ b/endpoint.go
@@ -1,0 +1,23 @@
+package yoti
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+func getProfileEndpoint(token, nonce, sdkID string) string {
+	timestamp := getTimestamp()
+
+	return fmt.Sprintf("/profile/%s?nonce=%s&timestamp=%s&appId=%s", token, nonce, timestamp, sdkID)
+}
+
+func getAMLEndpoint(nonce, sdkID string) string {
+	timestamp := getTimestamp()
+
+	return fmt.Sprintf("/aml-check?appId=%s&timestamp=%s&nonce=%s", sdkID, timestamp, nonce)
+}
+
+func getTimestamp() string {
+	return strconv.FormatInt(time.Now().Unix()*1000, 10)
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey = yoti-web-sdk:go
 sonar.projectName = go-sdk
-sonar.projectVersion = 2.4.0
+sonar.projectVersion = 2.5.0
 sonar.exclusions = **/yotiprotoattr/*.go,**/yotiprotocom/*.go,**/**_test.go
 sonar.links.scm = https://github.com/getyoti/yoti-go-sdk
 

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -21,7 +21,7 @@ import (
 const (
 	apiURL               = "https://api.yoti.com/api/v1"
 	sdkIdentifier        = "Go"
-	sdkVersionIdentifier = "2.4.0"
+	sdkVersionIdentifier = "2.5.0"
 
 	authKeyHeader              = "X-Yoti-Auth-Key"
 	authDigestHeader           = "X-Yoti-Auth-Digest"


### PR DESCRIPTION
After refactoring I got this error on the Travis builds:
```bash
./yoticlient.go:92:32: too many arguments in call to getProfileEndpoint
	have (string, string, string, string)
	want (string, string, string)
```
It looked like there was a clash between the previous version of the `getProfileEndpoint` method, and the current version. 

I ran the Travis docker image locally and looked at this build - 
I could see the updated version of the sdk in `~/getyoti/yoti-go-sdk`, but when I was in `~/gopath/src/github.com/getyoti/yoti-go-sdk`, that's where I could see the old one.

It looks like the old version is being cached in here, so I had to remove the caching. I wouldn't have thought that Go would prioritise looking in the gopath first, when GO111MODULE=on, for versions > 1.10.x, but it looks like it was! 

We can revisit this later, and definitely remove it once 1.10.x has stopped being supported, but it only seems to add a few seconds onto 4 of the builds in the job, so will leave like this for now. 