### PR TITLE
SDK-1077: signed request builder

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -8,14 +8,6 @@ func bytesToUtf8(bytes []byte) string {
 	return string(bytes)
 }
 
-func bytesToBase64(bytes []byte) string {
-	return base64.StdEncoding.EncodeToString(bytes)
-}
-
-func utfToBytes(utf8 string) []byte {
-	return []byte(utf8)
-}
-
 func base64ToBytes(base64Str string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(base64Str)
 }

--- a/crypto.go
+++ b/crypto.go
@@ -1,12 +1,10 @@
 package yoti
 
 import (
-	"crypto"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
@@ -86,43 +84,6 @@ func pkcs7Unpad(ciphertext []byte, blocksize int) (result []byte, err error) {
 		}
 	}
 	return ciphertext[:len(ciphertext)-n], nil
-}
-
-func signDigest(digest []byte, key *rsa.PrivateKey) ([]byte, error) {
-	hashed := sha256.Sum256(digest)
-
-	signedDigest, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hashed[:])
-	if err != nil {
-		return []byte{}, err
-	}
-
-	return signedDigest, nil
-}
-
-func getAuthKey(key *rsa.PrivateKey) (string, error) {
-	return getDerEncodedPublicKey(key)
-}
-
-func getDerEncodedPublicKey(key *rsa.PrivateKey) (result string, err error) {
-	var derEncodedBytes []byte
-	if derEncodedBytes, err = x509.MarshalPKIXPublicKey(key.Public()); err != nil {
-		return
-	}
-
-	result = bytesToBase64(derEncodedBytes)
-	return
-}
-
-func generateNonce() (string, error) {
-	b := make([]byte, 16)
-	_, err := rand.Read(b)
-	if err != nil {
-		return "", err
-	}
-
-	uuid := fmt.Sprintf("%X-%X-%X-%X-%X", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
-
-	return uuid, nil
 }
 
 func decryptToken(encryptedConnectToken string, key *rsa.PrivateKey) (result string, err error) {

--- a/endpoint.go
+++ b/endpoint.go
@@ -2,8 +2,6 @@ package yoti
 
 import (
 	"fmt"
-	"strconv"
-	"time"
 )
 
 func getProfileEndpoint(token, sdkID string) string {
@@ -12,10 +10,6 @@ func getProfileEndpoint(token, sdkID string) string {
 
 func getAMLEndpoint(sdkID string) string {
 	return fmt.Sprintf("/aml-check?appId=%s", sdkID)
-}
-
-func getTimestamp() string {
-	return strconv.FormatInt(time.Now().Unix()*1000, 10)
 }
 
 // GetDynamicShareEndpoint gets the Dynamic Share Endpoint URI

--- a/endpoint.go
+++ b/endpoint.go
@@ -6,16 +6,12 @@ import (
 	"time"
 )
 
-func getProfileEndpoint(token, nonce, sdkID string) string {
-	timestamp := getTimestamp()
-
-	return fmt.Sprintf("/profile/%s?nonce=%s&timestamp=%s&appId=%s", token, nonce, timestamp, sdkID)
+func getProfileEndpoint(token, sdkID string) string {
+	return fmt.Sprintf("/profile/%s?appId=%s", token, sdkID)
 }
 
-func getAMLEndpoint(nonce, sdkID string) string {
-	timestamp := getTimestamp()
-
-	return fmt.Sprintf("/aml-check?appId=%s&timestamp=%s&nonce=%s", sdkID, timestamp, nonce)
+func getAMLEndpoint(sdkID string) string {
+	return fmt.Sprintf("/aml-check?appId=%s", sdkID)
 }
 
 func getTimestamp() string {
@@ -24,16 +20,8 @@ func getTimestamp() string {
 
 // GetDynamicShareEndpoint gets the Dynamic Share Endpoint URI
 func getDynamicShareEndpoint(client clientInterface) (string, error) {
-	timestamp := getTimestamp()
-	nonce, err := generateNonce()
-	if err != nil {
-		return "", err
-	}
-
 	return fmt.Sprintf(
-		"/qrcodes/apps/%s?nonce=%s&timestamp=%s",
+		"/qrcodes/apps/%s",
 		client.GetSdkID(),
-		nonce,
-		timestamp,
 	), nil
 }

--- a/httpclient.go
+++ b/httpclient.go
@@ -1,0 +1,9 @@
+package yoti
+
+import (
+	"net/http"
+)
+
+type httpClient interface {
+	Do(*http.Request) (*http.Response, error)
+}

--- a/httprequester.go
+++ b/httprequester.go
@@ -1,13 +1,6 @@
 package yoti
 
-import (
-	"bytes"
-	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
-)
-
+// Deprecated
 const (
 	// HTTPMethodPost Post HTTP method
 	HTTPMethodPost = "POST"
@@ -18,55 +11,3 @@ const (
 	// HTTPMethodPatch Patch HTTP method
 	HTTPMethodPatch = "PATCH"
 )
-
-type httpResponse struct {
-	Success    bool
-	StatusCode int
-	Content    string
-}
-
-type httpRequester func(uri string, headers map[string]string, httpRequestMethod string, contentBytes []byte) (result *httpResponse, err error)
-
-func doRequest(uri string, headers map[string]string, httpRequestMethod string, contentBytes []byte) (result *httpResponse, err error) {
-	client := &http.Client{}
-
-	supportedHTTPMethods := map[string]bool{"GET": true, "POST": true, "PUT": true, "PATCH": true}
-
-	if !supportedHTTPMethods[httpRequestMethod] {
-		err = fmt.Errorf("HTTP Method: '%s' is unsupported", httpRequestMethod)
-		return
-	}
-
-	var req *http.Request
-	if req, err = http.NewRequest(
-		httpRequestMethod,
-		uri,
-		bytes.NewBuffer(contentBytes)); err != nil {
-		return
-	}
-
-	for key, value := range headers {
-		req.Header.Add(key, value)
-	}
-
-	var resp *http.Response
-	resp, err = client.Do(req)
-
-	if err != nil {
-		return
-	}
-
-	defer resp.Body.Close()
-
-	var responseBody []byte
-	if responseBody, err = ioutil.ReadAll(resp.Body); err != nil {
-		log.Printf("Unable to read the HTTP response, error: %s", err)
-	}
-
-	result = &httpResponse{
-		Success:    resp.StatusCode < 300,
-		StatusCode: resp.StatusCode,
-		Content:    string(responseBody)}
-
-	return
-}

--- a/httprequester.go
+++ b/httprequester.go
@@ -1,6 +1,7 @@
 package yoti
 
-// Deprecated
+// Deprecated will be removed in v3.0.0
+// Use http method constants from net/http
 const (
 	// HTTPMethodPost Post HTTP method
 	HTTPMethodPost = "POST"

--- a/requests/signed_message.go
+++ b/requests/signed_message.go
@@ -47,10 +47,10 @@ func getTimestamp() string {
 	return strconv.FormatInt(time.Now().Unix()*1000, 10)
 }
 
-func getNonce() string {
+func getNonce() (string, error) {
 	nonce := make([]byte, 16)
-	rand.Read(nonce)
-	return fmt.Sprintf("%X-%X-%X-%X-%X", nonce[0:4], nonce[4:6], nonce[6:8], nonce[8:10], nonce[10:])
+	_, err := rand.Read(nonce)
+	return fmt.Sprintf("%X-%X-%X-%X-%X", nonce[0:4], nonce[4:6], nonce[6:8], nonce[8:10], nonce[10:]), err
 }
 
 // Request builds a http.Request with signature headers
@@ -89,11 +89,15 @@ func (msg *SignedMessage) Request() (request *http.Request, err error) {
 		endpoint = endpoint + "&"
 	}
 
+	nonce, err := getNonce()
+	if err != nil {
+		return
+	}
 	endpoint = fmt.Sprintf(
 		"%stimestamp=%s&nonce=%s",
 		endpoint,
 		getTimestamp(),
-		getNonce(),
+		nonce,
 	)
 
 	// Generate and Sign the message digest

--- a/requests/signed_message.go
+++ b/requests/signed_message.go
@@ -22,7 +22,6 @@ type SignedRequest struct {
 	Key        *rsa.PrivateKey
 	HTTPMethod string
 	BaseURL    string
-	Port       int
 	Endpoint   string
 	Headers    map[string][]string
 	Params     map[string]string
@@ -88,14 +87,6 @@ func (msg SignedRequest) Request() (request *http.Request, err error) {
 		return
 	}
 
-	// Mangle BaseURL to allow for optional port number
-	baseURL := msg.BaseURL
-	if msg.Port != 0 {
-		parts := strings.Split(baseURL, "/")
-		parts[2] = fmt.Sprintf("%s:%d", parts[2], msg.Port)
-		baseURL = strings.Join(parts, "/")
-	}
-
 	if msg.Params == nil {
 		msg.Params = make(map[string]string)
 	}
@@ -151,7 +142,7 @@ func (msg SignedRequest) Request() (request *http.Request, err error) {
 	// Construct the HTTP Request
 	request, err = http.NewRequest(
 		msg.HTTPMethod,
-		baseURL+endpoint,
+		msg.BaseURL+endpoint,
 		bytes.NewReader(msg.Body),
 	)
 	if err != nil {

--- a/requests/signed_message.go
+++ b/requests/signed_message.go
@@ -69,7 +69,7 @@ func (msg SignedRequest) Request() (request *http.Request, err error) {
 	if msg.Error != nil {
 		return nil, msg.Error
 	}
-	// Check for mandatorys
+	// Check for mandatories
 	if msg.Key == nil {
 		err = fmt.Errorf("Missing Private Key")
 		return

--- a/requests/signed_message.go
+++ b/requests/signed_message.go
@@ -1,0 +1,137 @@
+package requests
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Predefined headers for common use cases
+var (
+	JSONHeaders = map[string][]string{
+		"Content-Type": {"application/json"},
+		"Accept":       {"application/json"},
+	}
+)
+
+// SignedMessage is a builder for constructing a http.Request with Yoti signing
+type SignedMessage struct {
+	Key        *rsa.PrivateKey
+	HTTPMethod string
+	BaseURL    string
+	Port       int
+	Endpoint   string
+	Headers    map[string][]string
+	Body       []byte
+}
+
+func (msg *SignedMessage) signDigest(digest []byte) (string, error) {
+	hash := sha256.Sum256(digest)
+	signed, err := rsa.SignPKCS1v15(rand.Reader, msg.Key, crypto.SHA256, hash[:])
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(signed), nil
+}
+
+func getTimestamp() string {
+	return strconv.FormatInt(time.Now().Unix()*1000, 10)
+}
+
+func getNonce() string {
+	nonce := make([]byte, 16)
+	rand.Read(nonce)
+	return fmt.Sprintf("%X-%X-%X-%X-%X", nonce[0:4], nonce[4:6], nonce[6:8], nonce[8:10], nonce[10:])
+}
+
+// Request builds a http.Request with signature headers
+func (msg *SignedMessage) Request() (request *http.Request, err error) {
+	// Check for mandatorys
+	if msg.Key == nil {
+		err = fmt.Errorf("Missing Private Key")
+		return
+	}
+	if msg.HTTPMethod == "" {
+		err = fmt.Errorf("Missing HTTPMethod")
+		return
+	}
+	if msg.BaseURL == "" {
+		err = fmt.Errorf("Missing BaseURL")
+		return
+	}
+	if msg.Endpoint == "" {
+		err = fmt.Errorf("Missing Endpoint")
+		return
+	}
+
+	// Mangle BaseURL to allow for optional port number
+	baseURL := msg.BaseURL
+	if msg.Port != 0 {
+		parts := strings.Split(baseURL, "/")
+		parts[2] = fmt.Sprintf("%s:%d", parts[2], msg.Port)
+		baseURL = strings.Join(parts, "/")
+	}
+
+	// Add Timestamp/Nonce to Endpoint
+	endpoint := msg.Endpoint
+	if !strings.Contains(endpoint, "?") {
+		endpoint = endpoint + "?"
+	} else {
+		endpoint = endpoint + "&"
+	}
+
+	endpoint = fmt.Sprintf(
+		"%stimestamp=%s&nonce=%s",
+		endpoint,
+		getTimestamp(),
+		getNonce(),
+	)
+
+	// Generate and Sign the message digest
+	var digest string
+	if msg.Body != nil {
+		digest = fmt.Sprintf(
+			"%s&%s&%s",
+			msg.HTTPMethod,
+			endpoint,
+			base64.StdEncoding.EncodeToString(msg.Body),
+		)
+	} else {
+		digest = fmt.Sprintf("%s&%s",
+			msg.HTTPMethod,
+			endpoint,
+		)
+	}
+	signedDigest, err := msg.signDigest([]byte(digest))
+	if err != nil {
+		return
+	}
+
+	// Construct the HTTP Request
+	request, err = http.NewRequest(
+		msg.HTTPMethod,
+		baseURL+endpoint,
+		bytes.NewReader(msg.Body),
+	)
+	if err != nil {
+		return
+	}
+	request.Header.Add("X-Yoti-Auth-Digest", signedDigest)
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&msg.Key.PublicKey)
+	request.Header.Add("X-Yoti-Auth-Key", base64.StdEncoding.EncodeToString(publicKeyBytes))
+	for key, values := range msg.Headers {
+		for _, value := range values {
+			request.Header.Add(key, value)
+		}
+	}
+	return request, err
+}

--- a/requests/signed_message.go
+++ b/requests/signed_message.go
@@ -15,14 +15,6 @@ import (
 	"time"
 )
 
-// Predefined headers for common use cases
-var (
-	JSONHeaders = map[string][]string{
-		"Content-Type": {"application/json"},
-		"Accept":       {"application/json"},
-	}
-)
-
 // SignedMessage is a builder for constructing a http.Request with Yoti signing
 type SignedMessage struct {
 	Key        *rsa.PrivateKey

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -188,14 +188,14 @@ func (client *Client) makeRequest(httpMethod, endpoint string, payload []byte, h
 		return
 	}
 
-	request, err := (&requests.SignedMessage{
+	request, err := requests.SignedRequest{
 		Key:        key,
 		HTTPMethod: httpMethod,
 		BaseURL:    client.getAPIURL(),
 		Endpoint:   endpoint,
 		Headers:    client.getDefaultHeaders(),
 		Body:       payload,
-	}).Request()
+	}.Request()
 
 	if err != nil {
 		return

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -180,8 +180,6 @@ func (client *Client) getDefaultHeaders() (headers map[string][]string) {
 	return
 }
 
-// MakeRequest is used by other yoti Packages to make requests using a single
-// common client object. Users should not use this function directly
 func (client *Client) makeRequest(httpMethod, endpoint string, payload []byte, httpErrorMessages ...map[int]string) (responseData string, err error) {
 	key, err := loadRsaKey(client.Key)
 	if err != nil {


### PR DESCRIPTION
### TODO
 * [x] Replace requester method with http.Client mockable interface
 * [x] Refactor code to send the built http Request directly using the mockable http.Client
 * [x] Merge SDK-723 Dynamic Scenarios
 * [x] Merge SDK-1119 Source Constraints

### Dependencies
 * SDK-723
 * SDK-1119
### Additions
 * Added SignedMessage builder for signed requests (using Golang http request type)
 * Update Client.makeRequest to use SignedMesssage builder to create the headers and twiddle the endpoint to include timestamp and nonce magically
 * Remove timestamp/nonce from endpoints.go 's responsibilities.
 * Remove digest generation from yoticlient.go's responsibilities.
 * Client's makeRequest receiver now takes http.Request as parameter (i.e. a SignedMessage), instead of attempting to build its own http Request object from parameters.
 * Client embeds a http.Client to allow mocking of http transport/response by unit tests.

---

## Code Examples
### Doc Scan
```
pemBytes, err := ioutil.ReadFile(pemFile)
request, err := requests.SignedRequest{
    HTTPMethod: http.MethodPost,
    BaseURL: docScanURL,
    Endpoint: "/sessions",
    Params: map[string]string{
        "sdkID": sdkID,
    },
    Headers: map[string][]string{
        "Content-Type": {"application/json"},
        "Accept": {"application/json"},
    },
    Body: jsonBody,
}.WithPemFile(pemBytes).Request()
response, err := (&http.Client{}).Do(request) 
```

### AML Request
```
pemBytes, err := ioutil.ReadFile(pemFile)
request, err := requests.SignedRequest{
    HTTPMethod: http.MethodPost,
    BaseURL: yotiAPI,
    Endpoint: "/aml-check",
    Params: map[string]string{
        "sdkID": sdkID,
    },
    Headers: map[string][]string{
        "Content-Type": {"application/json"},
        "Accept": {"application/json"},
    },
    Body: jsonBody,
}.WithPemFile(pemBytes).Request()
response, err := (&http.Client{}).Do(request) 
```

### Profile Request
```
pemBytes, err := ioutil.ReadFile(pemFile)
request, err := requests.SignedRequest{
    HTTPMethod: http.MethodGet,
    BaseURL: yotiAPI,
    Endpoint: fmt.Sprintf("/profile/%s", token),
    Params: map[string]string{
        "appId": sdkID,
    },
    Headers: map[string][]string{
        "Content-Type": {"application/json"},
        "Accept": {"application/json"},
    },
}.WithPemFile(pemBytes).Request()
response, err := (&http.Client{}).Do(request) 
```