### PR TITLE
SDK-1283: Prevent Empty Wanted Attribute Names

### DIFF
--- a/requests/signed_message_test.go
+++ b/requests/signed_message_test.go
@@ -11,11 +11,15 @@ import (
 )
 
 func ExampleMergeHeaders() {
-	left := map[string][]string{"A": []string{"Value"}}
-	right := map[string][]string{"B": []string{"Value"}}
+	left := map[string][]string{"A": {"Value Of A"}}
+	right := map[string][]string{"B": {"Value Of B"}}
 
-	fmt.Println(MergeHeaders(left, right))
-	// Output: map[A:[Value] B:[Value]]
+	merged := MergeHeaders(left, right)
+	fmt.Println(merged["A"])
+	fmt.Println(merged["B"])
+	// Output:
+	// [Value Of A]
+	// [Value Of B]
 }
 
 func TestRequestShouldBuildForValid(t *testing.T) {

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,12 @@
+package yoti
+
+import (
+	"errors"
+)
+
+func notEmpty(validate, info string) error {
+	if validate == "" {
+		return errors.New(info)
+	}
+	return nil
+}

--- a/wantedattribute_test.go
+++ b/wantedattribute_test.go
@@ -2,6 +2,8 @@ package yoti
 
 import (
 	"fmt"
+	"gotest.tools/assert"
+	"testing"
 )
 
 func ExampleWantedAttributeBuilder_WithName() {
@@ -19,17 +21,25 @@ func ExampleWantedAttributeBuilder_WithDerivation() {
 
 func ExampleWantedAttributeBuilder_WithConstraint() {
 	constraint := (&SourceConstraintBuilder{}).New().Build()
-	attribute := (&WantedAttributeBuilder{}).New().WithConstraint(&constraint).Build()
+	attribute := (&WantedAttributeBuilder{}).New().WithName("attr").WithConstraint(&constraint).Build()
 
 	json, _ := attribute.MarshalJSON()
 	fmt.Println(string(json))
-	// Output: {"constraints":[{"type":"SOURCE","preferred_sources":{"anchors":[],"soft_preference":false}}]}
+	// Output: {"name":"attr","constraints":[{"type":"SOURCE","preferred_sources":{"anchors":[],"soft_preference":false}}]}
 }
 
 func ExampleWantedAttributeBuilder_WithAcceptSelfAsserted() {
-	attribute := (&WantedAttributeBuilder{}).New().WithAcceptSelfAsserted(true).Build()
+	attribute := (&WantedAttributeBuilder{}).New().WithName("attr").WithAcceptSelfAsserted(true).Build()
 
 	json, _ := attribute.MarshalJSON()
 	fmt.Println(string(json))
-	// Output: {"accept_self_asserted":true}
+	// Output: {"name":"attr","accept_self_asserted":true}
+}
+
+func TestWantedAttributeBuilderShouldRejectEmptyName(t *testing.T) {
+	attribute := (&WantedAttributeBuilder{}).New().Build()
+	json, err := attribute.MarshalJSON()
+	assert.Check(t, err != nil)
+	assert.Equal(t, err.Error(), "Wanted attribute names must not be empty")
+	assert.Equal(t, len(json), 0)
 }

--- a/wantedattributebuilder.go
+++ b/wantedattributebuilder.go
@@ -65,6 +65,10 @@ func (builder *WantedAttributeBuilder) Build() WantedAttribute {
 
 // MarshalJSON returns the JSON encoding
 func (attr *WantedAttribute) MarshalJSON() ([]byte, error) {
+	err := notEmpty(attr.name, "Wanted attribute names must not be empty")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(&struct {
 		Name               string                `json:"name,omitempty"`
 		Derivation         string                `json:"derivation,omitempty"`


### PR DESCRIPTION
### Additions
 * Add `validate.go` with `notEmpty` to verify a string is not empty
 * `WantedAttribute.MarshalJSON` returns an error message if `attr.name` is empty