### PR TITLE
SDK-1305: Add goimports check to Travis, run goimports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,17 @@ jobs:
             GO111MODULE=off;
             go get -t -d ./...;
           fi
+        - go get golang.org/x/tools/cmd/goimports
       script:
         - ./.travis.gofmt.sh
-        - go generate -x ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code) # Check that go generate ./... produces a zero diff; clean up any changes afterwards.
+        - diff <(goimports -d $(find . -type f -name '*.go' -not -path "./yotiprotoattr/*" -not -path "./yotiprotocom/*" -not -path "./yotiprotoshare/*")) <(printf "")
+        # Check that go generate ./... produces a zero diff; clean up any changes afterwards.
+        - if [ $TRAVIS_GO_VERSION == "1.9.7" ] ||
+          [ $TRAVIS_GO_VERSION == "1.10.x" ]; then
+            go generate -x ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code) 
+          else
+            go generate -x ./... && go mod tidy && git diff --exit-code; code=$?; git checkout -- .; (exit $code) 
+          fi
         - go vet ./...
         - go test -v -race ./...
     - <<: *test

--- a/age_verifications.go
+++ b/age_verifications.go
@@ -1,9 +1,10 @@
 package yoti
 
 import (
-	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 	"strconv"
 	"strings"
+
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
 // AgeVerification encapsulates the result of a single age verification


### PR DESCRIPTION
- Adding `goimports` check to Travis, so we fail earlier (rather than on pipeline)
- This modifies the `go.mod` and `go.sum` files (which are checked in Travis), so we're having to add `go mod tidy` to the go generate command before comparing, but...
  - `go mod` isn't available in older versions, so we have to add an additional conditional compilation to avoid this in earlier versions