### PR TITLE
SDK-1104: Requests to our API shold time out if unavailable

### DIFF
--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	yotirequest "github.com/getyoti/yoti-go-sdk/v2/requests"
 )
@@ -37,7 +38,9 @@ func (client *Client) SetupSharingProfile(profile Profile) (token string, err er
 		return
 	}
 
-	response, err := (&http.Client{}).Do(request)
+	response, err := (&http.Client{
+		Timeout: time.Second * 10,
+	}).Do(request)
 	if err != nil {
 		return
 	}

--- a/yoti_test.go
+++ b/yoti_test.go
@@ -38,6 +38,25 @@ func (mock *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
 	return nil, nil
 }
 
+func TestYotiClient_DefaultHTTPClientShouldTimeout(t *testing.T) {
+	client := Client{}
+	defer func() {
+		_ = recover()
+		assert.Assert(t, client.HTTPClient.(*http.Client).Timeout == 10*time.Second)
+	}()
+	_, _ = client.doRequest(nil)
+}
+
+func TestYotiClient_SetHTTPClientTimeout(t *testing.T) {
+	client := Client{}
+	client.HTTPClient = &http.Client{Timeout: 12 * time.Minute}
+	defer func() {
+		_ = recover()
+		assert.Assert(t, client.HTTPClient.(*http.Client).Timeout == 12*time.Minute)
+	}()
+	_, _ = client.doRequest(nil)
+}
+
 func TestYotiClient_KeyLoad_Failure(t *testing.T) {
 	key, _ := ioutil.ReadFile("test-key-invalid-format.pem")
 

--- a/yoti_test.go
+++ b/yoti_test.go
@@ -43,7 +43,7 @@ func TestYotiClient_KeyLoad_Failure(t *testing.T) {
 
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 500,
@@ -63,7 +63,7 @@ func TestYotiClient_HttpFailure_ReturnsFailure(t *testing.T) {
 
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 500,
@@ -83,7 +83,7 @@ func TestYotiClient_HttpFailure_ReturnsProfileNotFound(t *testing.T) {
 
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 404,
@@ -103,7 +103,7 @@ func TestYotiClient_SharingFailure_ReturnsFailure(t *testing.T) {
 
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
@@ -126,7 +126,7 @@ func TestYotiClient_TokenDecodedSuccessfully(t *testing.T) {
 
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(request *http.Request) (*http.Response, error) {
 				parsed, err := url.Parse(request.URL.String())
 				assert.Assert(t, is.Nil(err), "Yoti API did not generate a valid URI.")
@@ -153,7 +153,7 @@ func TestYotiClient_ParseProfile_Success(t *testing.T) {
 
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
@@ -220,7 +220,7 @@ func TestYotiClient_ParentRememberMeID(t *testing.T) {
 
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
@@ -252,7 +252,7 @@ func TestYotiClient_ParseWithoutProfile_Success(t *testing.T) {
 
 		client := Client{
 			Key: key,
-			httpClient: &mockHTTPClient{
+			HTTPClient: &mockHTTPClient{
 				do: func(*http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: 200,
@@ -284,7 +284,7 @@ func TestYotiClient_ParseWithoutRememberMeID_Success(t *testing.T) {
 
 		client := Client{
 			Key: key,
-			httpClient: &mockHTTPClient{
+			HTTPClient: &mockHTTPClient{
 				do: func(*http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: 200,
@@ -306,7 +306,7 @@ func TestYotiClient_PerformAmlCheck_Success(t *testing.T) {
 
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
@@ -330,7 +330,7 @@ func TestYotiClient_PerformAmlCheck_Unsuccessful(t *testing.T) {
 	key, _ := ioutil.ReadFile("test-key.pem")
 	client := Client{
 		Key: key,
-		httpClient: &mockHTTPClient{
+		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 503,

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -57,16 +57,16 @@ type Client struct {
 	Key []byte
 
 	apiURL     string
-	httpClient // Mockable HTTP Client Interface
+	HTTPClient httpClient // Mockable HTTP Client Interface
 }
 
 func (client *Client) doRequest(request *http.Request) (*http.Response, error) {
-	if client.httpClient == nil {
-		client.httpClient = &http.Client{
+	if client.HTTPClient == nil {
+		client.HTTPClient = &http.Client{
 			Timeout: time.Second * 10,
 		}
 	}
-	return client.httpClient.Do(request)
+	return client.HTTPClient.Do(request)
 }
 
 // OverrideAPIURL overrides the default API URL for this Yoti Client to permit

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -62,7 +62,9 @@ type Client struct {
 
 func (client *Client) doRequest(request *http.Request) (*http.Response, error) {
 	if client.httpClient == nil {
-		client.httpClient = &http.Client{}
+		client.httpClient = &http.Client{
+			Timeout: time.Second * 10,
+		}
 	}
 	return client.httpClient.Do(request)
 }


### PR DESCRIPTION
### Changed
 * `http.Client` instantiations in `yoticlient.go` and `sandbox/client.go` set Timeout attribute