### PR TITLE
SDK-1292: Load PEM file as part of client initialisation

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 )
 
-// LoadPEM loads a PEM encoded RSA private key
-func LoadPEM(keyBytes []byte) (*rsa.PrivateKey, error) {
+// loadRsaKey loads a PEM encoded RSA private key
+func loadRsaKey(keyBytes []byte) (*rsa.PrivateKey, error) {
 	// Extract the PEM-encoded data
 	block, _ := pem.Decode(keyBytes)
 

--- a/crypto.go
+++ b/crypto.go
@@ -11,21 +11,22 @@ import (
 	"fmt"
 )
 
-func loadRsaKey(keyBytes []byte) (*rsa.PrivateKey, error) {
+// LoadPEM loads a PEM encoded RSA private key
+func LoadPEM(keyBytes []byte) (*rsa.PrivateKey, error) {
 	// Extract the PEM-encoded data
 	block, _ := pem.Decode(keyBytes)
 
 	if block == nil {
-		return nil, errors.New("not PEM-encoded")
+		return nil, errors.New("Invalid Key: not PEM-encoded")
 	}
 
 	if block.Type != "RSA PRIVATE KEY" {
-		return nil, errors.New("not RSA private key")
+		return nil, errors.New("Invalid Key: not RSA private key")
 	}
 
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
-		return nil, errors.New("bad RSA private key")
+		return nil, errors.New("Invalid Key: bad RSA private key")
 	}
 
 	return key, nil

--- a/errors.go
+++ b/errors.go
@@ -1,8 +1,6 @@
 package yoti
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // TemporaryError indicates that a temporary outage has occured and the
 // previous request can be reattempted without modification.

--- a/examples/aml/main.go
+++ b/examples/aml/main.go
@@ -26,8 +26,7 @@ func main() {
 		return
 	}
 
-	rsaKey, err := yoti.LoadPEM(key)
-	client := yoti.NewClient(sdkID, rsaKey)
+	client, err := yoti.NewClient(sdkID, key)
 	if err != nil {
 		log.Printf("Problem initialising client: Error: `%s`", err)
 		return

--- a/examples/aml/main.go
+++ b/examples/aml/main.go
@@ -28,7 +28,12 @@ func main() {
 
 	client = &yoti.Client{
 		SdkID: sdkID,
-		Key:   key}
+	}
+	client.Key, err = yoti.LoadPEM(key)
+	if err != nil {
+		log.Printf("Problem initialising client: Error: `%s`", err)
+		return
+	}
 
 	givenNames := "Edward Richard George"
 	familyName := "Heath"

--- a/examples/aml/main.go
+++ b/examples/aml/main.go
@@ -26,10 +26,8 @@ func main() {
 		return
 	}
 
-	client = &yoti.Client{
-		SdkID: sdkID,
-	}
-	client.Key, err = yoti.LoadPEM(key)
+	rsaKey, err := yoti.LoadPEM(key)
+	client := yoti.NewClient(sdkID, rsaKey)
 	if err != nil {
 		log.Printf("Problem initialising client: Error: `%s`", err)
 		return

--- a/examples/profile/main.go
+++ b/examples/profile/main.go
@@ -118,10 +118,7 @@ func pageFromScenario(w http.ResponseWriter, req *http.Request, title string, sc
 		return
 	}
 
-	client := yoti.Client{
-		SdkID: sdkID,
-	}
-	client.Key, err = yoti.LoadPEM(key)
+	rsaKey, err := yoti.LoadPEM(key)
 	if err != nil {
 		errorPage(w, req.WithContext(context.WithValue(
 			req.Context(),
@@ -129,8 +126,9 @@ func pageFromScenario(w http.ResponseWriter, req *http.Request, title string, sc
 			fmt.Sprintf("%s", err),
 		)))
 	}
+	client := yoti.NewClient(sdkID, rsaKey)
 
-	share, err := yoti.CreateShareURL(&client, &scenario)
+	share, err := yoti.CreateShareURL(client, &scenario)
 	if err != nil {
 		errorPage(w, req.WithContext(context.WithValue(
 			req.Context(),
@@ -188,10 +186,7 @@ func profile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client = &yoti.Client{
-		SdkID: sdkID,
-	}
-	client.Key, err = yoti.LoadPEM(key)
+	rsaKey, err := yoti.LoadPEM(key)
 	if err != nil {
 		errorPage(w, r.WithContext(context.WithValue(
 			r.Context(),
@@ -199,6 +194,7 @@ func profile(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("%s", err),
 		)))
 	}
+	client = yoti.NewClient(sdkID, rsaKey)
 
 	yotiOneTimeUseToken := r.URL.Query().Get("token")
 

--- a/examples/profile/main.go
+++ b/examples/profile/main.go
@@ -118,7 +118,7 @@ func pageFromScenario(w http.ResponseWriter, req *http.Request, title string, sc
 		return
 	}
 
-	rsaKey, err := yoti.LoadPEM(key)
+	client, err := yoti.NewClient(sdkID, key)
 	if err != nil {
 		errorPage(w, req.WithContext(context.WithValue(
 			req.Context(),
@@ -126,7 +126,6 @@ func pageFromScenario(w http.ResponseWriter, req *http.Request, title string, sc
 			fmt.Sprintf("%s", err),
 		)))
 	}
-	client := yoti.NewClient(sdkID, rsaKey)
 
 	share, err := yoti.CreateShareURL(client, &scenario)
 	if err != nil {
@@ -186,7 +185,7 @@ func profile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rsaKey, err := yoti.LoadPEM(key)
+	client, err = yoti.NewClient(sdkID, key)
 	if err != nil {
 		errorPage(w, r.WithContext(context.WithValue(
 			r.Context(),
@@ -194,7 +193,6 @@ func profile(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("%s", err),
 		)))
 	}
-	client = yoti.NewClient(sdkID, rsaKey)
 
 	yotiOneTimeUseToken := r.URL.Query().Get("token")
 

--- a/examples/profile/main.go
+++ b/examples/profile/main.go
@@ -120,7 +120,14 @@ func pageFromScenario(w http.ResponseWriter, req *http.Request, title string, sc
 
 	client := yoti.Client{
 		SdkID: sdkID,
-		Key:   key,
+	}
+	client.Key, err = yoti.LoadPEM(key)
+	if err != nil {
+		errorPage(w, req.WithContext(context.WithValue(
+			req.Context(),
+			contextKey("yotiError"),
+			fmt.Sprintf("%s", err),
+		)))
 	}
 
 	share, err := yoti.CreateShareURL(&client, &scenario)
@@ -183,7 +190,15 @@ func profile(w http.ResponseWriter, r *http.Request) {
 
 	client = &yoti.Client{
 		SdkID: sdkID,
-		Key:   key}
+	}
+	client.Key, err = yoti.LoadPEM(key)
+	if err != nil {
+		errorPage(w, r.WithContext(context.WithValue(
+			r.Context(),
+			contextKey("yotiError"),
+			fmt.Sprintf("%s", err),
+		)))
+	}
 
 	yotiOneTimeUseToken := r.URL.Query().Get("token")
 

--- a/yoti_test.go
+++ b/yoti_test.go
@@ -95,21 +95,10 @@ func TestYotiClient_SetHTTPClientTimeout(t *testing.T) {
 }
 
 func TestYotiClient_KeyLoad_Failure(t *testing.T) {
+	var err error
 	key, _ := ioutil.ReadFile("test-key-invalid-format.pem")
 
-	client := Client{
-		Key: key,
-		HTTPClient: &mockHTTPClient{
-			do: func(*http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: 500,
-				}, nil
-			},
-		},
-	}
-
-	_, err := client.getActivityDetails(encryptedToken)
-
+	_, err = LoadPEM(key)
 	assert.Check(t, err != nil)
 	assert.Check(t, strings.HasPrefix(err.Error(), "Invalid Key"))
 	tempError, temporary := err.(interface {
@@ -119,10 +108,10 @@ func TestYotiClient_KeyLoad_Failure(t *testing.T) {
 }
 
 func TestYotiClient_InvalidToken(t *testing.T) {
+	var err error
 	key, _ := ioutil.ReadFile("test-key.pem")
 
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -131,8 +120,10 @@ func TestYotiClient_InvalidToken(t *testing.T) {
 			},
 		},
 	}
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
-	_, err := client.getActivityDetails("")
+	_, err = client.getActivityDetails("")
 
 	assert.Check(t, err != nil)
 	assert.Check(t, strings.HasPrefix(err.Error(), "Invalid Token"))
@@ -146,7 +137,6 @@ func TestYotiClient_HttpFailure_ReturnsFailure(t *testing.T) {
 	key, _ := ioutil.ReadFile("test-key.pem")
 
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -155,8 +145,11 @@ func TestYotiClient_HttpFailure_ReturnsFailure(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
-	_, err := client.getActivityDetails(encryptedToken)
+	_, err = client.getActivityDetails(encryptedToken)
 
 	assert.Check(t, err != nil)
 	assert.Check(t, strings.HasPrefix(err.Error(), "Unknown HTTP Error"))
@@ -171,7 +164,6 @@ func TestYotiClient_HttpFailure_ReturnsProfileNotFound(t *testing.T) {
 	key, _ := ioutil.ReadFile("test-key.pem")
 
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -180,8 +172,11 @@ func TestYotiClient_HttpFailure_ReturnsProfileNotFound(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
-	_, err := client.getActivityDetails(encryptedToken)
+	_, err = client.getActivityDetails(encryptedToken)
 
 	assert.Check(t, err != nil)
 	assert.Check(t, strings.HasPrefix(err.Error(), "Profile Not Found"))
@@ -195,7 +190,6 @@ func TestYotiClient_SharingFailure_ReturnsFailure(t *testing.T) {
 	key, _ := ioutil.ReadFile("test-key.pem")
 
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -205,8 +199,11 @@ func TestYotiClient_SharingFailure_ReturnsFailure(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
-	_, err := client.getActivityDetails(encryptedToken)
+	_, err = client.getActivityDetails(encryptedToken)
 
 	assert.Check(t, err != nil)
 	assert.Check(t, strings.HasPrefix(err.Error(), ErrSharingFailure.Error()))
@@ -222,7 +219,6 @@ func TestYotiClient_TokenDecodedSuccessfully(t *testing.T) {
 	expectedAbsoluteURL := "/api/v1/profile/" + token
 
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(request *http.Request) (*http.Response, error) {
 				parsed, err := url.Parse(request.URL.String())
@@ -235,8 +231,11 @@ func TestYotiClient_TokenDecodedSuccessfully(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
-	_, err := client.getActivityDetails(encryptedToken)
+	_, err = client.getActivityDetails(encryptedToken)
 
 	assert.Check(t, err != nil)
 	assert.Check(t, strings.HasPrefix(err.Error(), "Unknown HTTP Error"))
@@ -253,7 +252,6 @@ func TestYotiClient_ParseProfile_Success(t *testing.T) {
 	rememberMeID := "remember_me_id0123456789"
 
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -263,6 +261,9 @@ func TestYotiClient_ParseProfile_Success(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
 	activityDetails, errorStrings := client.getActivityDetails(encryptedToken)
 
@@ -313,7 +314,6 @@ func TestYotiClient_ParentRememberMeID(t *testing.T) {
 	parentRememberMeID := "parent_remember_me_id0123456789"
 
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -325,6 +325,9 @@ func TestYotiClient_ParentRememberMeID(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
 	activityDetails, errorStrings := client.getActivityDetails(encryptedToken)
 
@@ -345,7 +348,6 @@ func TestYotiClient_ParseWithoutProfile_Success(t *testing.T) {
 	for _, otherPartyProfileContent := range otherPartyProfileContents {
 
 		client := Client{
-			Key: key,
 			HTTPClient: &mockHTTPClient{
 				do: func(*http.Request) (*http.Response, error) {
 					return &http.Response{
@@ -356,10 +358,13 @@ func TestYotiClient_ParseWithoutProfile_Success(t *testing.T) {
 				},
 			},
 		}
+		var err error
+		client.Key, err = LoadPEM(key)
+		assert.NilError(t, err)
 
-		activityDetails, err := client.getActivityDetails(encryptedToken)
+		activityDetails, errStrings := client.getActivityDetails(encryptedToken)
 
-		assert.Assert(t, is.Nil(err))
+		assert.Assert(t, is.Nil(errStrings))
 		assert.Equal(t, activityDetails.RememberMeID(), rememberMeID)
 		assert.Equal(t, activityDetails.Timestamp(), timestamp)
 		assert.Equal(t, activityDetails.ReceiptID(), receiptID)
@@ -461,7 +466,6 @@ func TestYotiClient_ParseWithoutRememberMeID_Success(t *testing.T) {
 	for _, otherPartyProfileContent := range otherPartyProfileContents {
 
 		client := Client{
-			Key: key,
 			HTTPClient: &mockHTTPClient{
 				do: func(*http.Request) (*http.Response, error) {
 					return &http.Response{
@@ -472,10 +476,13 @@ func TestYotiClient_ParseWithoutRememberMeID_Success(t *testing.T) {
 				},
 			},
 		}
+		var err error
+		client.Key, err = LoadPEM(key)
+		assert.NilError(t, err)
 
-		_, err := client.getActivityDetails(encryptedToken)
+		_, errStrings := client.getActivityDetails(encryptedToken)
 
-		assert.Assert(t, is.Nil(err))
+		assert.Assert(t, is.Nil(errStrings))
 	}
 }
 
@@ -483,7 +490,6 @@ func TestYotiClient_PerformAmlCheck_Success(t *testing.T) {
 	key, _ := ioutil.ReadFile("test-key.pem")
 
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -493,6 +499,9 @@ func TestYotiClient_PerformAmlCheck_Success(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
 	result, err := client.PerformAmlCheck(createStandardAmlProfile())
 
@@ -507,7 +516,6 @@ func TestYotiClient_PerformAmlCheck_Success(t *testing.T) {
 func TestYotiClient_PerformAmlCheck_Unsuccessful(t *testing.T) {
 	key, _ := ioutil.ReadFile("test-key.pem")
 	client := Client{
-		Key: key,
 		HTTPClient: &mockHTTPClient{
 			do: func(*http.Request) (*http.Response, error) {
 				return &http.Response{
@@ -517,8 +525,11 @@ func TestYotiClient_PerformAmlCheck_Unsuccessful(t *testing.T) {
 			},
 		},
 	}
+	var err error
+	client.Key, err = LoadPEM(key)
+	assert.NilError(t, err)
 
-	_, err := client.PerformAmlCheck(createStandardAmlProfile())
+	_, err = client.PerformAmlCheck(createStandardAmlProfile())
 
 	var expectedErrString = "AML Check was unsuccessful"
 

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -55,11 +55,12 @@ type Client struct {
 }
 
 // NewClient constructs a Client object
-func NewClient(sdkID string, key *rsa.PrivateKey) *Client {
+func NewClient(sdkID string, key []byte) (*Client, error) {
+	decodedKey, err := loadRsaKey(key)
 	return &Client{
 		SdkID: sdkID,
-		Key:   key,
-	}
+		Key:   decodedKey,
+	}, err
 }
 
 func (client *Client) doRequest(request *http.Request) (*http.Response, error) {

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -54,6 +54,14 @@ type Client struct {
 	HTTPClient httpClient // Mockable HTTP Client Interface
 }
 
+// NewClient constructs a Client object
+func NewClient(sdkID string, key *rsa.PrivateKey) *Client {
+	return &Client{
+		SdkID: sdkID,
+		Key:   key,
+	}
+}
+
 func (client *Client) doRequest(request *http.Request) (*http.Response, error) {
 	if client.HTTPClient == nil {
 		client.HTTPClient = &http.Client{


### PR DESCRIPTION
Change type of Key in Client. Add LoadPEM method for loading Key from
PEM bytes