### PR TITLE
SDK-1252: Make embedded yotiprotoattr attribute a private member

### DIFF
--- a/attribute/attribute_details.go
+++ b/attribute/attribute_details.go
@@ -1,0 +1,42 @@
+package attribute
+
+import (
+	"github.com/getyoti/yoti-go-sdk/v2/anchor"
+)
+
+// Details is embedded in each attribute for fields common to all
+// attributes
+type Details struct {
+	name        string
+	contentType string
+	anchors     []*anchor.Anchor
+}
+
+// Name gets the attribute name
+func (a Details) Name() string {
+	return a.name
+}
+
+// ContentType gets the attribute's content type description
+func (a Details) ContentType() string {
+	return a.contentType
+}
+
+// Anchors are the metadata associated with an attribute. They describe
+// how an attribute has been provided to Yoti (SOURCE Anchor) and how
+// it has been verified (VERIFIER Anchor).
+func (a Details) Anchors() []*anchor.Anchor {
+	return a.anchors
+}
+
+// Sources returns the anchors which identify how and when an attribute value
+// was acquired.
+func (a Details) Sources() []*anchor.Anchor {
+	return anchor.GetSources(a.anchors)
+}
+
+// Verifiers returns the anchors which identify how and when an attribute value
+// was verified by another provider.
+func (a Details) Verifiers() []*anchor.Anchor {
+	return anchor.GetVerifiers(a.anchors)
+}

--- a/attribute/attribute_details.go
+++ b/attribute/attribute_details.go
@@ -4,39 +4,39 @@ import (
 	"github.com/getyoti/yoti-go-sdk/v2/anchor"
 )
 
-// Details is embedded in each attribute for fields common to all
+// attributeDetails is embedded in each attribute for fields common to all
 // attributes
-type Details struct {
+type attributeDetails struct {
 	name        string
 	contentType string
 	anchors     []*anchor.Anchor
 }
 
 // Name gets the attribute name
-func (a Details) Name() string {
+func (a attributeDetails) Name() string {
 	return a.name
 }
 
 // ContentType gets the attribute's content type description
-func (a Details) ContentType() string {
+func (a attributeDetails) ContentType() string {
 	return a.contentType
 }
 
 // Anchors are the metadata associated with an attribute. They describe
 // how an attribute has been provided to Yoti (SOURCE Anchor) and how
 // it has been verified (VERIFIER Anchor).
-func (a Details) Anchors() []*anchor.Anchor {
+func (a attributeDetails) Anchors() []*anchor.Anchor {
 	return a.anchors
 }
 
 // Sources returns the anchors which identify how and when an attribute value
 // was acquired.
-func (a Details) Sources() []*anchor.Anchor {
+func (a attributeDetails) Sources() []*anchor.Anchor {
 	return anchor.GetSources(a.anchors)
 }
 
 // Verifiers returns the anchors which identify how and when an attribute value
 // was verified by another provider.
-func (a Details) Verifiers() []*anchor.Anchor {
+func (a attributeDetails) Verifiers() []*anchor.Anchor {
 	return anchor.GetVerifiers(a.anchors)
 }

--- a/attribute/documentdetailsattribute.go
+++ b/attribute/documentdetailsattribute.go
@@ -29,14 +29,24 @@ type DocumentDetails struct {
 
 // DocumentDetailsAttribute wraps a document details with anchor data
 type DocumentDetailsAttribute struct {
-	*yotiprotoattr.Attribute
-	value   DocumentDetails
-	anchors []*anchor.Anchor
+	attribute *yotiprotoattr.Attribute
+	value     DocumentDetails
+	anchors   []*anchor.Anchor
 }
 
 // Value returns the document details struct attached to this attribute
 func (attr *DocumentDetailsAttribute) Value() DocumentDetails {
 	return attr.value
+}
+
+// Name returns the name as a string
+func (a *DocumentDetailsAttribute) Name() string {
+	return a.attribute.Name
+}
+
+// ContentType returns the content type as a string
+func (a *DocumentDetailsAttribute) ContentType() string {
+	return a.attribute.ContentType.String()
 }
 
 // Anchors are the metadata associated with an attribute. They describe
@@ -67,7 +77,7 @@ func NewDocumentDetails(a *yotiprotoattr.Attribute) (*DocumentDetailsAttribute, 
 	}
 
 	return &DocumentDetailsAttribute{
-		Attribute: &yotiprotoattr.Attribute{
+		attribute: &yotiprotoattr.Attribute{
 			Name:        a.Name,
 			ContentType: a.ContentType,
 		},

--- a/attribute/documentdetailsattribute.go
+++ b/attribute/documentdetailsattribute.go
@@ -29,7 +29,7 @@ type DocumentDetails struct {
 
 // DocumentDetailsAttribute wraps a document details with anchor data
 type DocumentDetailsAttribute struct {
-	Details
+	attributeDetails
 	value DocumentDetails
 }
 
@@ -49,7 +49,7 @@ func NewDocumentDetails(a *yotiprotoattr.Attribute) (*DocumentDetailsAttribute, 
 	}
 
 	return &DocumentDetailsAttribute{
-		Details: Details{
+		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
 			anchors:     parsedAnchors,

--- a/attribute/documentdetailsattribute.go
+++ b/attribute/documentdetailsattribute.go
@@ -29,41 +29,13 @@ type DocumentDetails struct {
 
 // DocumentDetailsAttribute wraps a document details with anchor data
 type DocumentDetailsAttribute struct {
-	attribute *yotiprotoattr.Attribute
-	value     DocumentDetails
-	anchors   []*anchor.Anchor
+	Details
+	value DocumentDetails
 }
 
 // Value returns the document details struct attached to this attribute
 func (attr *DocumentDetailsAttribute) Value() DocumentDetails {
 	return attr.value
-}
-
-// Name returns the name as a string
-func (a *DocumentDetailsAttribute) Name() string {
-	return a.attribute.Name
-}
-
-// ContentType returns the content type as a string
-func (a *DocumentDetailsAttribute) ContentType() string {
-	return a.attribute.ContentType.String()
-}
-
-// Anchors are the metadata associated with an attribute. They describe
-// how an attribute has been provided to Yoti (SOURCE Anchor) and how
-// it has been verified (VERIFIER Anchor).
-func (attr *DocumentDetailsAttribute) Anchors() []*anchor.Anchor {
-	return attr.anchors
-}
-
-// Sources returns the anchors which identify how and when an attribute value was acquired.
-func (attr *DocumentDetailsAttribute) Sources() []*anchor.Anchor {
-	return anchor.GetSources(attr.anchors)
-}
-
-// Verifiers returns the anchors which identify how and when an attribute value was verified by another provider.
-func (attr *DocumentDetailsAttribute) Verifiers() []*anchor.Anchor {
-	return anchor.GetVerifiers(attr.anchors)
 }
 
 // NewDocumentDetails creates a DocumentDetailsAttribute which wraps a
@@ -77,12 +49,12 @@ func NewDocumentDetails(a *yotiprotoattr.Attribute) (*DocumentDetailsAttribute, 
 	}
 
 	return &DocumentDetailsAttribute{
-		attribute: &yotiprotoattr.Attribute{
-			Name:        a.Name,
-			ContentType: a.ContentType,
+		Details: Details{
+			name:        a.Name,
+			contentType: a.ContentType.String(),
+			anchors:     parsedAnchors,
 		},
-		value:   details,
-		anchors: parsedAnchors,
+		value: details,
 	}, nil
 }
 

--- a/attribute/genericattribute.go
+++ b/attribute/genericattribute.go
@@ -9,7 +9,7 @@ import (
 
 // GenericAttribute is a Yoti attribute which returns a generic value
 type GenericAttribute struct {
-	Details
+	attributeDetails
 	value interface{}
 }
 
@@ -25,7 +25,7 @@ func NewGeneric(a *yotiprotoattr.Attribute) *GenericAttribute {
 	var parsedAnchors []*anchor.Anchor = anchor.ParseAnchors(a.Anchors)
 
 	return &GenericAttribute{
-		Details: Details{
+		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
 			anchors:     parsedAnchors,

--- a/attribute/genericattribute.go
+++ b/attribute/genericattribute.go
@@ -9,9 +9,9 @@ import (
 
 // GenericAttribute is a Yoti attribute which returns a generic value
 type GenericAttribute struct {
-	*yotiprotoattr.Attribute
-	value   interface{}
-	anchors []*anchor.Anchor
+	attribute *yotiprotoattr.Attribute
+	value     interface{}
+	anchors   []*anchor.Anchor
 }
 
 // NewGeneric creates a new generic attribute
@@ -26,7 +26,7 @@ func NewGeneric(a *yotiprotoattr.Attribute) *GenericAttribute {
 	var parsedAnchors []*anchor.Anchor = anchor.ParseAnchors(a.Anchors)
 
 	return &GenericAttribute{
-		Attribute: &yotiprotoattr.Attribute{
+		attribute: &yotiprotoattr.Attribute{
 			Name:        a.Name,
 			ContentType: a.ContentType,
 		},
@@ -38,6 +38,16 @@ func NewGeneric(a *yotiprotoattr.Attribute) *GenericAttribute {
 // Value returns the value of the GenericAttribute as an interface
 func (a *GenericAttribute) Value() interface{} {
 	return a.value
+}
+
+// Name returns the name as a string
+func (a *GenericAttribute) Name() string {
+	return a.attribute.Name
+}
+
+// ContentType returns the content type as a string
+func (a *GenericAttribute) ContentType() string {
+	return a.attribute.ContentType.String()
 }
 
 // Anchors are the metadata associated with an attribute. They describe

--- a/attribute/genericattribute.go
+++ b/attribute/genericattribute.go
@@ -9,9 +9,8 @@ import (
 
 // GenericAttribute is a Yoti attribute which returns a generic value
 type GenericAttribute struct {
-	attribute *yotiprotoattr.Attribute
-	value     interface{}
-	anchors   []*anchor.Anchor
+	Details
+	value interface{}
 }
 
 // NewGeneric creates a new generic attribute
@@ -26,43 +25,16 @@ func NewGeneric(a *yotiprotoattr.Attribute) *GenericAttribute {
 	var parsedAnchors []*anchor.Anchor = anchor.ParseAnchors(a.Anchors)
 
 	return &GenericAttribute{
-		attribute: &yotiprotoattr.Attribute{
-			Name:        a.Name,
-			ContentType: a.ContentType,
+		Details: Details{
+			name:        a.Name,
+			contentType: a.ContentType.String(),
+			anchors:     parsedAnchors,
 		},
-		value:   value,
-		anchors: parsedAnchors,
+		value: value,
 	}
 }
 
 // Value returns the value of the GenericAttribute as an interface
 func (a *GenericAttribute) Value() interface{} {
 	return a.value
-}
-
-// Name returns the name as a string
-func (a *GenericAttribute) Name() string {
-	return a.attribute.Name
-}
-
-// ContentType returns the content type as a string
-func (a *GenericAttribute) ContentType() string {
-	return a.attribute.ContentType.String()
-}
-
-// Anchors are the metadata associated with an attribute. They describe
-// how an attribute has been provided to Yoti (SOURCE Anchor) and how
-// it has been verified (VERIFIER Anchor).
-func (a *GenericAttribute) Anchors() []*anchor.Anchor {
-	return a.anchors
-}
-
-// Sources returns the anchors which identify how and when an attribute value was acquired.
-func (a *GenericAttribute) Sources() []*anchor.Anchor {
-	return anchor.GetSources(a.anchors)
-}
-
-// Verifiers returns the anchors which identify how and when an attribute value was verified by another provider.
-func (a *GenericAttribute) Verifiers() []*anchor.Anchor {
-	return anchor.GetVerifiers(a.anchors)
 }

--- a/attribute/imageattribute.go
+++ b/attribute/imageattribute.go
@@ -7,9 +7,9 @@ import (
 
 // ImageAttribute is a Yoti attribute which returns an image as its value
 type ImageAttribute struct {
-	*yotiprotoattr.Attribute
-	value   *Image
-	anchors []*anchor.Anchor
+	attribute *yotiprotoattr.Attribute
+	value     *Image
+	anchors   []*anchor.Anchor
 }
 
 // NewImage creates a new Image attribute
@@ -22,7 +22,7 @@ func NewImage(a *yotiprotoattr.Attribute) (*ImageAttribute, error) {
 	}
 
 	return &ImageAttribute{
-		Attribute: &yotiprotoattr.Attribute{
+		attribute: &yotiprotoattr.Attribute{
 			Name:        a.Name,
 			ContentType: a.ContentType,
 		},
@@ -34,6 +34,16 @@ func NewImage(a *yotiprotoattr.Attribute) (*ImageAttribute, error) {
 // Value returns the value of the ImageAttribute as *Image
 func (a *ImageAttribute) Value() *Image {
 	return a.value
+}
+
+// Name returns the name as a string
+func (a *ImageAttribute) Name() string {
+	return a.attribute.Name
+}
+
+// ContentType returns the content type as a string
+func (a *ImageAttribute) ContentType() string {
+	return a.attribute.ContentType.String()
 }
 
 // Anchors are the metadata associated with an attribute. They describe

--- a/attribute/imageattribute.go
+++ b/attribute/imageattribute.go
@@ -7,9 +7,8 @@ import (
 
 // ImageAttribute is a Yoti attribute which returns an image as its value
 type ImageAttribute struct {
-	attribute *yotiprotoattr.Attribute
-	value     *Image
-	anchors   []*anchor.Anchor
+	Details
+	value *Image
 }
 
 // NewImage creates a new Image attribute
@@ -22,43 +21,16 @@ func NewImage(a *yotiprotoattr.Attribute) (*ImageAttribute, error) {
 	}
 
 	return &ImageAttribute{
-		attribute: &yotiprotoattr.Attribute{
-			Name:        a.Name,
-			ContentType: a.ContentType,
+		Details: Details{
+			name:        a.Name,
+			contentType: a.ContentType.String(),
+			anchors:     parsedAnchors,
 		},
-		value:   imageValue,
-		anchors: parsedAnchors,
+		value: imageValue,
 	}, nil
 }
 
 // Value returns the value of the ImageAttribute as *Image
 func (a *ImageAttribute) Value() *Image {
 	return a.value
-}
-
-// Name returns the name as a string
-func (a *ImageAttribute) Name() string {
-	return a.attribute.Name
-}
-
-// ContentType returns the content type as a string
-func (a *ImageAttribute) ContentType() string {
-	return a.attribute.ContentType.String()
-}
-
-// Anchors are the metadata associated with an attribute. They describe
-// how an attribute has been provided to Yoti (SOURCE Anchor) and how
-// it has been verified (VERIFIER Anchor).
-func (a *ImageAttribute) Anchors() []*anchor.Anchor {
-	return a.anchors
-}
-
-// Sources returns the anchors which identify how and when an attribute value was acquired.
-func (a *ImageAttribute) Sources() []*anchor.Anchor {
-	return anchor.GetSources(a.anchors)
-}
-
-// Verifiers returns the anchors which identify how and when an attribute value was verified by another provider.
-func (a *ImageAttribute) Verifiers() []*anchor.Anchor {
-	return anchor.GetVerifiers(a.anchors)
 }

--- a/attribute/imageattribute.go
+++ b/attribute/imageattribute.go
@@ -7,7 +7,7 @@ import (
 
 // ImageAttribute is a Yoti attribute which returns an image as its value
 type ImageAttribute struct {
-	Details
+	attributeDetails
 	value *Image
 }
 
@@ -21,7 +21,7 @@ func NewImage(a *yotiprotoattr.Attribute) (*ImageAttribute, error) {
 	}
 
 	return &ImageAttribute{
-		Details: Details{
+		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
 			anchors:     parsedAnchors,

--- a/attribute/imagesliceattribute.go
+++ b/attribute/imagesliceattribute.go
@@ -10,9 +10,9 @@ import (
 
 // ImageSliceAttribute is a Yoti attribute which returns a slice of images as its value
 type ImageSliceAttribute struct {
-	*yotiprotoattr.Attribute
-	value   []*Image
-	anchors []*anchor.Anchor
+	attribute *yotiprotoattr.Attribute
+	value     []*Image
+	anchors   []*anchor.Anchor
 }
 
 // NewImageSlice creates a new ImageSlice attribute
@@ -33,7 +33,7 @@ func NewImageSlice(a *yotiprotoattr.Attribute) (*ImageSliceAttribute, error) {
 	}
 
 	return &ImageSliceAttribute{
-		Attribute: &yotiprotoattr.Attribute{
+		attribute: &yotiprotoattr.Attribute{
 			Name:        a.Name,
 			ContentType: a.ContentType,
 		},
@@ -62,6 +62,16 @@ func CreateImageSlice(items []*Item) (result []*Image) {
 // Value returns the value of the ImageSliceAttribute as a string
 func (a *ImageSliceAttribute) Value() []*Image {
 	return a.value
+}
+
+// Name returns the name as a string
+func (a *ImageSliceAttribute) Name() string {
+	return a.attribute.Name
+}
+
+// ContentType returns the content type as a string
+func (a *ImageSliceAttribute) ContentType() string {
+	return a.attribute.ContentType.String()
 }
 
 // Anchors are the metadata associated with an attribute. They describe

--- a/attribute/imagesliceattribute.go
+++ b/attribute/imagesliceattribute.go
@@ -10,7 +10,7 @@ import (
 
 // ImageSliceAttribute is a Yoti attribute which returns a slice of images as its value
 type ImageSliceAttribute struct {
-	Details
+	attributeDetails
 	value []*Image
 }
 
@@ -32,7 +32,7 @@ func NewImageSlice(a *yotiprotoattr.Attribute) (*ImageSliceAttribute, error) {
 	}
 
 	return &ImageSliceAttribute{
-		Details: Details{
+		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
 			anchors:     anchor.ParseAnchors(a.Anchors),

--- a/attribute/imagesliceattribute.go
+++ b/attribute/imagesliceattribute.go
@@ -10,9 +10,8 @@ import (
 
 // ImageSliceAttribute is a Yoti attribute which returns a slice of images as its value
 type ImageSliceAttribute struct {
-	attribute *yotiprotoattr.Attribute
-	value     []*Image
-	anchors   []*anchor.Anchor
+	Details
+	value []*Image
 }
 
 // NewImageSlice creates a new ImageSlice attribute
@@ -33,12 +32,12 @@ func NewImageSlice(a *yotiprotoattr.Attribute) (*ImageSliceAttribute, error) {
 	}
 
 	return &ImageSliceAttribute{
-		attribute: &yotiprotoattr.Attribute{
-			Name:        a.Name,
-			ContentType: a.ContentType,
+		Details: Details{
+			name:        a.Name,
+			contentType: a.ContentType.String(),
+			anchors:     anchor.ParseAnchors(a.Anchors),
 		},
-		value:   imageSliceValue,
-		anchors: anchor.ParseAnchors(a.Anchors),
+		value: imageSliceValue,
 	}, nil
 }
 
@@ -62,31 +61,4 @@ func CreateImageSlice(items []*Item) (result []*Image) {
 // Value returns the value of the ImageSliceAttribute as a string
 func (a *ImageSliceAttribute) Value() []*Image {
 	return a.value
-}
-
-// Name returns the name as a string
-func (a *ImageSliceAttribute) Name() string {
-	return a.attribute.Name
-}
-
-// ContentType returns the content type as a string
-func (a *ImageSliceAttribute) ContentType() string {
-	return a.attribute.ContentType.String()
-}
-
-// Anchors are the metadata associated with an attribute. They describe
-// how an attribute has been provided to Yoti (SOURCE Anchor) and how
-// it has been verified (VERIFIER Anchor).
-func (a *ImageSliceAttribute) Anchors() []*anchor.Anchor {
-	return a.anchors
-}
-
-// Sources returns the anchors which identify how and when an attribute value was acquired.
-func (a *ImageSliceAttribute) Sources() []*anchor.Anchor {
-	return anchor.GetSources(a.anchors)
-}
-
-// Verifiers returns the anchors which identify how and when an attribute value was verified by another provider.
-func (a *ImageSliceAttribute) Verifiers() []*anchor.Anchor {
-	return anchor.GetVerifiers(a.anchors)
 }

--- a/attribute/jsonattribute.go
+++ b/attribute/jsonattribute.go
@@ -10,9 +10,9 @@ import (
 
 // JSONAttribute is a Yoti attribute which returns an interface as its value
 type JSONAttribute struct {
-	*yotiprotoattr.Attribute // Value returns the value of a JSON attribute in the form of an interface
-	value                    interface{}
-	anchors                  []*anchor.Anchor
+	attribute *yotiprotoattr.Attribute // Value returns the value of a JSON attribute in the form of an interface
+	value     interface{}
+	anchors   []*anchor.Anchor
 }
 
 // NewJSON creates a new JSON attribute
@@ -26,7 +26,7 @@ func NewJSON(a *yotiprotoattr.Attribute) (*JSONAttribute, error) {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &JSONAttribute{
-		Attribute: &yotiprotoattr.Attribute{
+		attribute: &yotiprotoattr.Attribute{
 			Name:        a.Name,
 			ContentType: a.ContentType,
 		},
@@ -50,6 +50,16 @@ func UnmarshallJSON(byteValue []byte) (result interface{}, err error) {
 // Value returns the value of the JSONAttribute as an interface.
 func (a *JSONAttribute) Value() interface{} {
 	return a.value
+}
+
+// Name returns the name as a string
+func (a *JSONAttribute) Name() string {
+	return a.attribute.Name
+}
+
+// ContentType returns the content type as a string
+func (a *JSONAttribute) ContentType() string {
+	return a.attribute.ContentType.String()
 }
 
 // Anchors are the metadata associated with an attribute. They describe

--- a/attribute/jsonattribute.go
+++ b/attribute/jsonattribute.go
@@ -10,9 +10,9 @@ import (
 
 // JSONAttribute is a Yoti attribute which returns an interface as its value
 type JSONAttribute struct {
-	attribute *yotiprotoattr.Attribute // Value returns the value of a JSON attribute in the form of an interface
-	value     interface{}
-	anchors   []*anchor.Anchor
+	Details
+	// Value returns the value of a JSON attribute in the form of an interface
+	value interface{}
 }
 
 // NewJSON creates a new JSON attribute
@@ -26,12 +26,12 @@ func NewJSON(a *yotiprotoattr.Attribute) (*JSONAttribute, error) {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &JSONAttribute{
-		attribute: &yotiprotoattr.Attribute{
-			Name:        a.Name,
-			ContentType: a.ContentType,
+		Details: Details{
+			name:        a.Name,
+			contentType: a.ContentType.String(),
+			anchors:     parsedAnchors,
 		},
-		value:   interfaceValue,
-		anchors: parsedAnchors,
+		value: interfaceValue,
 	}, nil
 }
 
@@ -50,31 +50,4 @@ func UnmarshallJSON(byteValue []byte) (result interface{}, err error) {
 // Value returns the value of the JSONAttribute as an interface.
 func (a *JSONAttribute) Value() interface{} {
 	return a.value
-}
-
-// Name returns the name as a string
-func (a *JSONAttribute) Name() string {
-	return a.attribute.Name
-}
-
-// ContentType returns the content type as a string
-func (a *JSONAttribute) ContentType() string {
-	return a.attribute.ContentType.String()
-}
-
-// Anchors are the metadata associated with an attribute. They describe
-// how an attribute has been provided to Yoti (SOURCE Anchor) and how
-// it has been verified (VERIFIER Anchor).
-func (a *JSONAttribute) Anchors() []*anchor.Anchor {
-	return a.anchors
-}
-
-// Sources returns the anchors which identify how and when an attribute value was acquired.
-func (a *JSONAttribute) Sources() []*anchor.Anchor {
-	return anchor.GetSources(a.anchors)
-}
-
-// Verifiers returns the anchors which identify how and when an attribute value was verified by another provider.
-func (a *JSONAttribute) Verifiers() []*anchor.Anchor {
-	return anchor.GetVerifiers(a.anchors)
 }

--- a/attribute/jsonattribute.go
+++ b/attribute/jsonattribute.go
@@ -10,7 +10,7 @@ import (
 
 // JSONAttribute is a Yoti attribute which returns an interface as its value
 type JSONAttribute struct {
-	Details
+	attributeDetails
 	// Value returns the value of a JSON attribute in the form of an interface
 	value interface{}
 }
@@ -26,7 +26,7 @@ func NewJSON(a *yotiprotoattr.Attribute) (*JSONAttribute, error) {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &JSONAttribute{
-		Details: Details{
+		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
 			anchors:     parsedAnchors,

--- a/attribute/multivalueattribute.go
+++ b/attribute/multivalueattribute.go
@@ -10,9 +10,9 @@ import (
 
 // MultiValueAttribute is a Yoti attribute which returns a multi-valued attribute
 type MultiValueAttribute struct {
-	*yotiprotoattr.Attribute
-	items   []*Item
-	anchors []*anchor.Anchor
+	attribute *yotiprotoattr.Attribute
+	items     []*Item
+	anchors   []*anchor.Anchor
 }
 
 // NewMultiValue creates a new MultiValue attribute
@@ -24,7 +24,7 @@ func NewMultiValue(a *yotiprotoattr.Attribute) (*MultiValueAttribute, error) {
 	}
 
 	return &MultiValueAttribute{
-		Attribute: &yotiprotoattr.Attribute{
+		attribute: &yotiprotoattr.Attribute{
 			Name:        a.Name,
 			ContentType: a.ContentType,
 		},
@@ -87,6 +87,16 @@ func unmarshallMultiValue(bytes []byte) (*yotiprotoattr.MultiValue, error) {
 // Value returns the value of the MultiValueAttribute as a string
 func (a *MultiValueAttribute) Value() []*Item {
 	return a.items
+}
+
+// Name returns the name as a string
+func (a *MultiValueAttribute) Name() string {
+	return a.attribute.Name
+}
+
+// ContentType returns the content type as a string
+func (a *MultiValueAttribute) ContentType() string {
+	return a.attribute.ContentType.String()
 }
 
 // Anchors are the metadata associated with an attribute. They describe

--- a/attribute/multivalueattribute.go
+++ b/attribute/multivalueattribute.go
@@ -10,7 +10,7 @@ import (
 
 // MultiValueAttribute is a Yoti attribute which returns a multi-valued attribute
 type MultiValueAttribute struct {
-	Details
+	attributeDetails
 	items []*Item
 }
 
@@ -23,7 +23,7 @@ func NewMultiValue(a *yotiprotoattr.Attribute) (*MultiValueAttribute, error) {
 	}
 
 	return &MultiValueAttribute{
-		Details: Details{
+		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
 			anchors:     anchor.ParseAnchors(a.Anchors),

--- a/attribute/multivalueattribute.go
+++ b/attribute/multivalueattribute.go
@@ -10,9 +10,8 @@ import (
 
 // MultiValueAttribute is a Yoti attribute which returns a multi-valued attribute
 type MultiValueAttribute struct {
-	attribute *yotiprotoattr.Attribute
-	items     []*Item
-	anchors   []*anchor.Anchor
+	Details
+	items []*Item
 }
 
 // NewMultiValue creates a new MultiValue attribute
@@ -24,12 +23,12 @@ func NewMultiValue(a *yotiprotoattr.Attribute) (*MultiValueAttribute, error) {
 	}
 
 	return &MultiValueAttribute{
-		attribute: &yotiprotoattr.Attribute{
-			Name:        a.Name,
-			ContentType: a.ContentType,
+		Details: Details{
+			name:        a.Name,
+			contentType: a.ContentType.String(),
+			anchors:     anchor.ParseAnchors(a.Anchors),
 		},
-		items:   attributeItems,
-		anchors: anchor.ParseAnchors(a.Anchors),
+		items: attributeItems,
 	}, nil
 }
 
@@ -87,31 +86,4 @@ func unmarshallMultiValue(bytes []byte) (*yotiprotoattr.MultiValue, error) {
 // Value returns the value of the MultiValueAttribute as a string
 func (a *MultiValueAttribute) Value() []*Item {
 	return a.items
-}
-
-// Name returns the name as a string
-func (a *MultiValueAttribute) Name() string {
-	return a.attribute.Name
-}
-
-// ContentType returns the content type as a string
-func (a *MultiValueAttribute) ContentType() string {
-	return a.attribute.ContentType.String()
-}
-
-// Anchors are the metadata associated with an attribute. They describe
-// how an attribute has been provided to Yoti (SOURCE Anchor) and how
-// it has been verified (VERIFIER Anchor).
-func (a *MultiValueAttribute) Anchors() []*anchor.Anchor {
-	return a.anchors
-}
-
-// Sources returns the anchors which identify how and when an attribute value was acquired.
-func (a *MultiValueAttribute) Sources() []*anchor.Anchor {
-	return anchor.GetSources(a.anchors)
-}
-
-// Verifiers returns the anchors which identify how and when an attribute value was verified by another provider.
-func (a *MultiValueAttribute) Verifiers() []*anchor.Anchor {
-	return anchor.GetVerifiers(a.anchors)
 }

--- a/attribute/stringattribute.go
+++ b/attribute/stringattribute.go
@@ -7,9 +7,8 @@ import (
 
 // StringAttribute is a Yoti attribute which returns a string as its value
 type StringAttribute struct {
-	attribute *yotiprotoattr.Attribute
-	value     string
-	anchors   []*anchor.Anchor
+	Details
+	value string
 }
 
 // NewString creates a new String attribute
@@ -17,43 +16,16 @@ func NewString(a *yotiprotoattr.Attribute) *StringAttribute {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &StringAttribute{
-		attribute: &yotiprotoattr.Attribute{
-			Name:        a.Name,
-			ContentType: a.ContentType,
+		Details: Details{
+			name:        a.Name,
+			contentType: a.ContentType.String(),
+			anchors:     parsedAnchors,
 		},
-		value:   string(a.Value),
-		anchors: parsedAnchors,
+		value: string(a.Value),
 	}
-}
-
-// Name returns the name of the StringAttribute as a string
-func (a *StringAttribute) Name() string {
-	return a.attribute.Name
-}
-
-// ContentType returns the content type of the StringAttribute as a string
-func (a *StringAttribute) ContentType() string {
-	return a.attribute.ContentType.String()
 }
 
 // Value returns the value of the StringAttribute as a string
 func (a *StringAttribute) Value() string {
 	return a.value
-}
-
-// Anchors are the metadata associated with an attribute. They describe
-// how an attribute has been provided to Yoti (SOURCE Anchor) and how
-// it has been verified (VERIFIER Anchor).
-func (a *StringAttribute) Anchors() []*anchor.Anchor {
-	return a.anchors
-}
-
-// Sources returns the anchors which identify how and when an attribute value was acquired.
-func (a *StringAttribute) Sources() []*anchor.Anchor {
-	return anchor.GetSources(a.anchors)
-}
-
-// Verifiers returns the anchors which identify how and when an attribute value was verified by another provider.
-func (a *StringAttribute) Verifiers() []*anchor.Anchor {
-	return anchor.GetVerifiers(a.anchors)
 }

--- a/attribute/stringattribute.go
+++ b/attribute/stringattribute.go
@@ -7,7 +7,7 @@ import (
 
 // StringAttribute is a Yoti attribute which returns a string as its value
 type StringAttribute struct {
-	Details
+	attributeDetails
 	value string
 }
 
@@ -16,7 +16,7 @@ func NewString(a *yotiprotoattr.Attribute) *StringAttribute {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &StringAttribute{
-		Details: Details{
+		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
 			anchors:     parsedAnchors,

--- a/attribute/stringattribute.go
+++ b/attribute/stringattribute.go
@@ -7,9 +7,9 @@ import (
 
 // StringAttribute is a Yoti attribute which returns a string as its value
 type StringAttribute struct {
-	*yotiprotoattr.Attribute
-	value   string
-	anchors []*anchor.Anchor
+	attribute *yotiprotoattr.Attribute
+	value     string
+	anchors   []*anchor.Anchor
 }
 
 // NewString creates a new String attribute
@@ -17,13 +17,23 @@ func NewString(a *yotiprotoattr.Attribute) *StringAttribute {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &StringAttribute{
-		Attribute: &yotiprotoattr.Attribute{
+		attribute: &yotiprotoattr.Attribute{
 			Name:        a.Name,
 			ContentType: a.ContentType,
 		},
 		value:   string(a.Value),
 		anchors: parsedAnchors,
 	}
+}
+
+// Name returns the name of the StringAttribute as a string
+func (a *StringAttribute) Name() string {
+	return a.attribute.Name
+}
+
+// ContentType returns the content type of the StringAttribute as a string
+func (a *StringAttribute) ContentType() string {
+	return a.attribute.ContentType.String()
 }
 
 // Value returns the value of the StringAttribute as a string

--- a/attribute/timeattribute.go
+++ b/attribute/timeattribute.go
@@ -10,9 +10,9 @@ import (
 
 // TimeAttribute is a Yoti attribute which returns a time as its value
 type TimeAttribute struct {
-	*yotiprotoattr.Attribute
-	value   *time.Time
-	anchors []*anchor.Anchor
+	attribute *yotiprotoattr.Attribute
+	value     *time.Time
+	anchors   []*anchor.Anchor
 }
 
 // NewTime creates a new Time attribute
@@ -27,7 +27,7 @@ func NewTime(a *yotiprotoattr.Attribute) (*TimeAttribute, error) {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &TimeAttribute{
-		Attribute: &yotiprotoattr.Attribute{
+		attribute: &yotiprotoattr.Attribute{
 			Name:        a.Name,
 			ContentType: a.ContentType,
 		},
@@ -39,6 +39,16 @@ func NewTime(a *yotiprotoattr.Attribute) (*TimeAttribute, error) {
 // Value returns the value of the TimeAttribute as *time.Time
 func (a *TimeAttribute) Value() *time.Time {
 	return a.value
+}
+
+// Name returns the name as a string
+func (a *TimeAttribute) Name() string {
+	return a.attribute.Name
+}
+
+// ContentType returns the content type as a string
+func (a *TimeAttribute) ContentType() string {
+	return a.attribute.ContentType.String()
 }
 
 // Anchors are the metadata associated with an attribute. They describe

--- a/attribute/timeattribute.go
+++ b/attribute/timeattribute.go
@@ -10,9 +10,8 @@ import (
 
 // TimeAttribute is a Yoti attribute which returns a time as its value
 type TimeAttribute struct {
-	attribute *yotiprotoattr.Attribute
-	value     *time.Time
-	anchors   []*anchor.Anchor
+	Details
+	value *time.Time
 }
 
 // NewTime creates a new Time attribute
@@ -27,43 +26,16 @@ func NewTime(a *yotiprotoattr.Attribute) (*TimeAttribute, error) {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &TimeAttribute{
-		attribute: &yotiprotoattr.Attribute{
-			Name:        a.Name,
-			ContentType: a.ContentType,
+		Details: Details{
+			name:        a.Name,
+			contentType: a.ContentType.String(),
+			anchors:     parsedAnchors,
 		},
-		value:   &parsedTime,
-		anchors: parsedAnchors,
+		value: &parsedTime,
 	}, nil
 }
 
 // Value returns the value of the TimeAttribute as *time.Time
 func (a *TimeAttribute) Value() *time.Time {
 	return a.value
-}
-
-// Name returns the name as a string
-func (a *TimeAttribute) Name() string {
-	return a.attribute.Name
-}
-
-// ContentType returns the content type as a string
-func (a *TimeAttribute) ContentType() string {
-	return a.attribute.ContentType.String()
-}
-
-// Anchors are the metadata associated with an attribute. They describe
-// how an attribute has been provided to Yoti (SOURCE Anchor) and how
-// it has been verified (VERIFIER Anchor).
-func (a *TimeAttribute) Anchors() []*anchor.Anchor {
-	return a.anchors
-}
-
-// Sources returns the anchors which identify how and when an attribute value was acquired.
-func (a *TimeAttribute) Sources() []*anchor.Anchor {
-	return anchor.GetSources(a.anchors)
-}
-
-// Verifiers returns the anchors which identify how and when an attribute value was verified by another provider.
-func (a *TimeAttribute) Verifiers() []*anchor.Anchor {
-	return anchor.GetVerifiers(a.anchors)
 }

--- a/attribute/timeattribute.go
+++ b/attribute/timeattribute.go
@@ -10,7 +10,7 @@ import (
 
 // TimeAttribute is a Yoti attribute which returns a time as its value
 type TimeAttribute struct {
-	Details
+	attributeDetails
 	value *time.Time
 }
 
@@ -26,7 +26,7 @@ func NewTime(a *yotiprotoattr.Attribute) (*TimeAttribute, error) {
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
 	return &TimeAttribute{
-		Details: Details{
+		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
 			anchors:     parsedAnchors,

--- a/yoti_test.go
+++ b/yoti_test.go
@@ -464,7 +464,7 @@ func TestYotiClient_MissingPostalAddress_UsesFormattedAddress(t *testing.T) {
 	structuredPostalAddress, err = profile.StructuredPostalAddress()
 
 	assert.Assert(t, is.Nil(err))
-	assert.Equal(t, structuredPostalAddress.ContentType, yotiprotoattr.ContentType_JSON, "Retrieved attribute does not have the correct type")
+	assert.Equal(t, structuredPostalAddress.ContentType(), yotiprotoattr.ContentType_JSON.String(), "Retrieved attribute does not have the correct type")
 }
 
 func TestYotiClient_PresentPostalAddress_DoesntUseFormattedAddress(t *testing.T) {
@@ -529,7 +529,7 @@ func TestProfile_GetAttribute_EmptyString(t *testing.T) {
 	result := createProfileWithSingleAttribute(attr)
 	att := result.GetAttribute(attributeName)
 
-	assert.Equal(t, att.Name, attributeName)
+	assert.Equal(t, att.Name(), attributeName)
 	assert.Equal(t, att.Value().(string), emptyString)
 }
 
@@ -542,7 +542,7 @@ func TestProfile_GetApplicationAttribute(t *testing.T) {
 
 	appProfile := createProfileWithSingleAttribute(attr)
 	attribute := appProfile.GetAttribute(attributeName)
-	assert.Equal(t, attribute.Name, attributeName)
+	assert.Equal(t, attribute.Name(), attributeName)
 }
 
 func TestProfile_GetApplicationName(t *testing.T) {
@@ -766,7 +766,7 @@ func TestProfile_GetAttribute_Undefined(t *testing.T) {
 	result := createProfileWithSingleAttribute(attr)
 	att := result.GetAttribute(attributeName)
 
-	assert.Equal(t, att.Name, attributeName)
+	assert.Equal(t, att.Name(), attributeName)
 	assert.Equal(t, att.Value().(string), attributeValueString)
 }
 func TestProfile_GetAttribute_ReturnsNil(t *testing.T) {
@@ -797,7 +797,7 @@ func TestProfile_StringAttribute(t *testing.T) {
 
 	assert.Equal(t, result.Nationality().Value(), attributeValueString)
 
-	assert.Equal(t, result.Nationality().ContentType, yotiprotoattr.ContentType_STRING)
+	assert.Equal(t, result.Nationality().ContentType(), yotiprotoattr.ContentType_STRING.String())
 }
 
 func TestProfile_AttributeProperty_RetrievesAttribute(t *testing.T) {
@@ -814,9 +814,9 @@ func TestProfile_AttributeProperty_RetrievesAttribute(t *testing.T) {
 	result := createProfileWithSingleAttribute(attributeImage)
 	selfie := result.Selfie()
 
-	assert.Equal(t, selfie.Name, attributeName)
+	assert.Equal(t, selfie.Name(), attributeName)
 	assert.DeepEqual(t, attributeValue, selfie.Value().Data)
-	assert.Equal(t, selfie.ContentType, yotiprotoattr.ContentType_PNG)
+	assert.Equal(t, selfie.ContentType(), yotiprotoattr.ContentType_PNG.String())
 }
 
 func TestAttributeImage_Image_Png(t *testing.T) {


### PR DESCRIPTION
Add Name() and ContentType() methods to expose functionality previously
accessed through the yotiprotoattr.Attribute interface