### PR TITLE
SDK-849: Change how generic attribute parsing is handled in Go

### DIFF
--- a/attribute/imagesliceattribute.go
+++ b/attribute/imagesliceattribute.go
@@ -2,7 +2,6 @@ package attribute
 
 import (
 	"errors"
-	"log"
 
 	"github.com/getyoti/yoti-go-sdk/v2/anchor"
 	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
@@ -45,12 +44,7 @@ func NewImageSlice(a *yotiprotoattr.Attribute) (*ImageSliceAttribute, error) {
 func CreateImageSlice(items []*Item) (result []*Image) {
 	for _, item := range items {
 
-		imageValue, err := ParseImageValue(item.GetContentType(), item.GetValue().([]byte))
-
-		if err != nil {
-			log.Printf("error parsing image value. ContentType: %s, data: %v, error: %v", item.contentType, item.value.([]byte), err)
-			continue
-		}
+		imageValue := item.GetValue().(*Image)
 
 		result = append(result, imageValue)
 	}

--- a/attribute/parser.go
+++ b/attribute/parser.go
@@ -46,7 +46,7 @@ func parseValue(contentType yotiprotoattr.ContentType, byteValue []byte) (interf
 
 	case yotiprotoattr.ContentType_JPEG,
 		yotiprotoattr.ContentType_PNG:
-		return byteValue, nil
+		return ParseImageValue(contentType, byteValue)
 
 	default:
 		log.Printf("Unknown type '%s', attempting to parse it as a String", contentType)

--- a/attribute/parser.go
+++ b/attribute/parser.go
@@ -48,6 +48,10 @@ func parseValue(contentType yotiprotoattr.ContentType, byteValue []byte) (interf
 		yotiprotoattr.ContentType_PNG:
 		return ParseImageValue(contentType, byteValue)
 
+	case yotiprotoattr.ContentType_UNDEFINED:
+		log.Print("Content Type Undefined, attempting to parse it as a string")
+		return string(byteValue), nil
+
 	default:
 		log.Printf("Unknown type '%s', attempting to parse it as a String", contentType)
 		return string(byteValue), nil

--- a/yoti_test.go
+++ b/yoti_test.go
@@ -1287,6 +1287,19 @@ func TestInvalidMultiValueNotReturned(t *testing.T) {
 	assert.Assert(t, is.Nil(profile.GetAttribute(attributeName)))
 }
 
+func TestNewGeneric_ShouldParseUnknownTypeAsString(t *testing.T) {
+	value := []byte("value")
+	parsed := attribute.NewGeneric(&yotiprotoattr.Attribute{
+		ContentType: yotiprotoattr.ContentType_UNDEFINED,
+		Value:       value,
+	})
+
+	stringValue, ok := parsed.Value().(string)
+	assert.Check(t, ok)
+
+	assert.Equal(t, stringValue, string(value))
+}
+
 func TestNestedMultiValue(t *testing.T) {
 	var innerMultiValueProtoValue []byte = createAttributeFromTestFile(t, "testattributemultivalue.txt").Value
 

--- a/yoti_test.go
+++ b/yoti_test.go
@@ -794,6 +794,10 @@ func TestProfile_GetAttribute_Time(t *testing.T) {
 
 func TestProfile_GetAttribute_Jpeg(t *testing.T) {
 	attributeValue := []byte("value")
+	expected := attribute.Image{
+		Type: attribute.ImageTypeJpeg,
+		Data: attributeValue,
+	}
 
 	var attr = &yotiprotoattr.Attribute{
 		Name:        attributeName,
@@ -805,11 +809,15 @@ func TestProfile_GetAttribute_Jpeg(t *testing.T) {
 	result := createProfileWithSingleAttribute(attr)
 	att := result.GetAttribute(attributeName)
 
-	assert.DeepEqual(t, att.Value().([]byte), attributeValue)
+	assert.DeepEqual(t, att.Value().(*attribute.Image), &expected)
 }
 
 func TestProfile_GetAttribute_Png(t *testing.T) {
 	attributeValue := []byte("value")
+	expected := attribute.Image{
+		Type: attribute.ImageTypePng,
+		Data: attributeValue,
+	}
 
 	var attr = &yotiprotoattr.Attribute{
 		Name:        attributeName,
@@ -821,7 +829,7 @@ func TestProfile_GetAttribute_Png(t *testing.T) {
 	result := createProfileWithSingleAttribute(attr)
 	att := result.GetAttribute(attributeName)
 
-	assert.DeepEqual(t, att.Value().([]byte), attributeValue)
+	assert.DeepEqual(t, att.Value().(*attribute.Image), &expected)
 }
 
 func TestProfile_GetAttribute_Bool(t *testing.T) {
@@ -1313,10 +1321,10 @@ func TestNestedMultiValue(t *testing.T) {
 			for innerKey, item := range innerItems {
 				switch innerKey {
 				case 0:
-					assertIsExpectedImage(t, parseImage(t, item.GetValue()), "jpeg", "vWgD//2Q==")
+					assertIsExpectedImage(t, item.GetValue().(*attribute.Image), "jpeg", "vWgD//2Q==")
 
 				case 1:
-					assertIsExpectedImage(t, parseImage(t, item.GetValue()), "jpeg", "38TVEH/9k=")
+					assertIsExpectedImage(t, item.GetValue().(*attribute.Image), "jpeg", "38TVEH/9k=")
 				}
 			}
 		}


### PR DESCRIPTION
### Changed
 * `attribute.parseValue` parsed image types to `*attribute.Image`
 * `ContentType_UNDEFINED` explicitly parses attribute data to a string, without emitting warning logging