### PR TITLE
SDK-903: Update timestamp for ActivityDetails to time.Time object

### DIFF
--- a/activitydetails.go
+++ b/activitydetails.go
@@ -1,13 +1,16 @@
 package yoti
 
 import "github.com/getyoti/yoti-go-sdk/v2/share"
+import (
+	"time"
+)
 
 // ActivityDetails represents the result of an activity between a user and the application.
 type ActivityDetails struct {
 	UserProfile        Profile
 	rememberMeID       string
 	parentRememberMeID string
-	timestamp          string
+	timestamp          time.Time
 	receiptID          string
 	ApplicationProfile ApplicationProfile
 	extraData          *share.ExtraData
@@ -29,7 +32,7 @@ func (a ActivityDetails) ParentRememberMeID() string {
 }
 
 // Timestamp is the Time and date of the sharing activity
-func (a ActivityDetails) Timestamp() string {
+func (a ActivityDetails) Timestamp() time.Time {
 	return a.timestamp
 }
 

--- a/activitydetails.go
+++ b/activitydetails.go
@@ -1,8 +1,9 @@
 package yoti
 
-import "github.com/getyoti/yoti-go-sdk/v2/share"
 import (
 	"time"
+
+	"github.com/getyoti/yoti-go-sdk/v2/share"
 )
 
 // ActivityDetails represents the result of an activity between a user and the application.

--- a/attribute/timeattribute_test.go
+++ b/attribute/timeattribute_test.go
@@ -1,0 +1,20 @@
+package attribute
+
+import (
+	"testing"
+	"time"
+
+	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
+	"gotest.tools/assert"
+)
+
+func TestTimeAttribute_NewTime_DateOnly(t *testing.T) {
+	proto := yotiprotoattr.Attribute{
+		Value: []byte("2011-12-25"),
+	}
+
+	timeAttribute, err := NewTime(&proto)
+	assert.NilError(t, err)
+
+	assert.Equal(t, *timeAttribute.Value(), time.Date(2011, 12, 25, 0, 0, 0, 0, time.UTC))
+}

--- a/yoti_test.go
+++ b/yoti_test.go
@@ -335,7 +335,10 @@ func TestYotiClient_ParentRememberMeID(t *testing.T) {
 func TestYotiClient_ParseWithoutProfile_Success(t *testing.T) {
 	key, _ := ioutil.ReadFile("test-key.pem")
 	rememberMeID := "remember_me_id0123456789"
-	timestamp := "123456789"
+	timestamp := time.Date(1973, 11, 29, 9, 33, 9, 0, time.UTC)
+	timestampString := func(a []byte, _ error) string {
+		return string(a)
+	}(timestamp.MarshalText())
 	receiptID := "receipt_id123"
 
 	var otherPartyProfileContents = []string{
@@ -351,7 +354,7 @@ func TestYotiClient_ParseWithoutProfile_Success(t *testing.T) {
 					return &http.Response{
 						StatusCode: 200,
 						Body: ioutil.NopCloser(strings.NewReader(`{"receipt":{"wrapped_receipt_key": "` + wrappedReceiptKey + `",` +
-							otherPartyProfileContent + `"remember_me_id":"` + rememberMeID + `", "sharing_outcome":"SUCCESS", "timestamp":"` + timestamp + `", "receipt_id":"` + receiptID + `"}}`)),
+							otherPartyProfileContent + `"remember_me_id":"` + rememberMeID + `", "sharing_outcome":"SUCCESS", "timestamp":"` + timestampString + `", "receipt_id":"` + receiptID + `"}}`)),
 					}, nil
 				},
 			},

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -274,11 +274,16 @@ func handleSuccessfulResponse(responseContent string, key *rsa.PrivateKey) (acti
 			err = MultiError{This: errTemp, Next: err}
 		}
 
+		timestamp, err := time.Parse(time.RFC3339, parsedResponse.Receipt.Timestamp)
+		if err != nil {
+			log.Printf("Unable to read timestamp. Error: %q", err)
+		}
+
 		activityDetails = ActivityDetails{
 			UserProfile:        profile,
 			rememberMeID:       id,
 			parentRememberMeID: parsedResponse.Receipt.ParentRememberMeID,
-			timestamp:          parsedResponse.Receipt.Timestamp,
+			timestamp:          timestamp,
 			receiptID:          parsedResponse.Receipt.ReceiptID,
 			ApplicationProfile: appProfile,
 			extraData:          extraData,


### PR DESCRIPTION
### TODO
 * [ ] Merge SDK-1292

### Changed
 * `ActivityDetails.Timestamp()` returns `time.Time`
 * `TestYotiClient_ParseWithoutProfile_Success` uses a real RFC3339 timestamp, instead of a dummy value (123456789)
