### PR TITLE
SDK-1347 timeattribute flexible parsing

### DIFF
--- a/attribute/date_attribute.go
+++ b/attribute/date_attribute.go
@@ -8,14 +8,14 @@ import (
 	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
-// TimeAttribute is a Yoti attribute which returns a time as its value
-type TimeAttribute struct {
+// DateAttribute is a Yoti attribute which returns a time as its value
+type DateAttribute struct {
 	attributeDetails
 	value *time.Time
 }
 
 // NewTime creates a new Time attribute
-func NewTime(a *yotiprotoattr.Attribute) (*TimeAttribute, error) {
+func NewDate(a *yotiprotoattr.Attribute) (*DateAttribute, error) {
 	parsedTime, err := time.Parse("2006-01-02", string(a.Value))
 	if err != nil {
 		log.Printf("Unable to parse time value of: %q. Error: %q", a.Value, err)
@@ -25,7 +25,7 @@ func NewTime(a *yotiprotoattr.Attribute) (*TimeAttribute, error) {
 
 	parsedAnchors := anchor.ParseAnchors(a.Anchors)
 
-	return &TimeAttribute{
+	return &DateAttribute{
 		attributeDetails: attributeDetails{
 			name:        a.Name,
 			contentType: a.ContentType.String(),
@@ -36,6 +36,6 @@ func NewTime(a *yotiprotoattr.Attribute) (*TimeAttribute, error) {
 }
 
 // Value returns the value of the TimeAttribute as *time.Time
-func (a *TimeAttribute) Value() *time.Time {
+func (a *DateAttribute) Value() *time.Time {
 	return a.value
 }

--- a/attribute/date_attribute.go
+++ b/attribute/date_attribute.go
@@ -8,7 +8,7 @@ import (
 	"github.com/getyoti/yoti-go-sdk/v2/yotiprotoattr"
 )
 
-// DateAttribute is a Yoti attribute which returns a time as its value
+// DateAttribute is a Yoti attribute which returns a date as *time.Time for its value
 type DateAttribute struct {
 	attributeDetails
 	value *time.Time

--- a/attribute/date_attribute_test.go
+++ b/attribute/date_attribute_test.go
@@ -9,12 +9,12 @@ import (
 	is "gotest.tools/assert/cmp"
 )
 
-func TestTimeAttribute_NewTime_DateOnly(t *testing.T) {
+func TestTimeAttribute_NewDate_DateOnly(t *testing.T) {
 	proto := yotiprotoattr.Attribute{
 		Value: []byte("2011-12-25"),
 	}
 
-	timeAttribute, err := NewTime(&proto)
+	timeAttribute, err := NewDate(&proto)
 	assert.NilError(t, err)
 
 	assert.Equal(t, *timeAttribute.Value(), time.Date(2011, 12, 25, 0, 0, 0, 0, time.UTC))
@@ -23,7 +23,7 @@ func TestTimeAttribute_NewTime_DateOnly(t *testing.T) {
 func TestTimeAttribute_DateOfBirth(t *testing.T) {
 	protoAttribute := createAttributeFromTestFile(t, "../test/fixtures/test_attribute_date_of_birth.txt")
 
-	dateOfBirthAttribute, err := NewTime(protoAttribute)
+	dateOfBirthAttribute, err := NewDate(protoAttribute)
 
 	assert.Assert(t, is.Nil(err))
 

--- a/attribute/date_attribute_test.go
+++ b/attribute/date_attribute_test.go
@@ -39,7 +39,7 @@ func TestNewTime_ShouldReturnErrorForInvalidDate(t *testing.T) {
 		Value:       []byte("2006-60-20"),
 		ContentType: yotiprotoattr.ContentType_DATE,
 	}
-	attribute, err := NewTime(&proto)
+	attribute, err := NewDate(&proto)
 	assert.Check(t, attribute == nil)
 	assert.ErrorContains(t, err, "month out of range")
 }

--- a/yoti_profile.go
+++ b/yoti_profile.go
@@ -50,10 +50,10 @@ func (p Profile) EmailAddress() *attribute.StringAttribute {
 
 // DateOfBirth represents the user's date of birth. Will be nil if not provided by Yoti.
 // Has an err value which will be filled if there is an error parsing the date.
-func (p Profile) DateOfBirth() (*attribute.TimeAttribute, error) {
+func (p Profile) DateOfBirth() (*attribute.DateAttribute, error) {
 	for _, a := range p.attributeSlice {
 		if a.Name == consts.AttrDateOfBirth {
-			return attribute.NewTime(a)
+			return attribute.NewDate(a)
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
### Add
 * Dependency on araddon/dateparser

### Change
 * TimeAttribute to support flexible parsing, allowing it to parse datetimes as well as dates.

### Comments
I'm not sure whether this is an approach we want to take with time attribute, as it doesn't contain information on what was parsed - since it leaves 'unused' attributes as the 0-value (or 1 for day) there's no way to tell the difference between 1st Jan and No Data.