### PR TITLE
SDK-1367: Fix incorrect format being used to parse RFC3339

### DIFF
--- a/attribute/issuance_details.go
+++ b/attribute/issuance_details.go
@@ -78,7 +78,7 @@ func parseExpiryDate(expiryDateString string) (*time.Time, error) {
 		return nil, nil
 	}
 
-	parsedTime, err := time.Parse(time.RFC3339, expiryDateString)
+	parsedTime, err := time.Parse(time.RFC3339Nano, expiryDateString)
 	if err != nil {
 		log.Printf("Unable to parse time value of: %q. Error: %q", expiryDateString, err)
 		return nil, err

--- a/extension/third_party_attribute_extension.go
+++ b/extension/third_party_attribute_extension.go
@@ -57,7 +57,7 @@ func (extension ThirdPartyAttributeExtension) MarshalJSON() ([]byte, error) {
 	}{
 		Type: thirdPartyAttributeExentionTypeConst,
 		Content: thirdPartyAttributeExtension{
-			ExpiryDate:  extension.expiryDate.Format("2006-01-02T15:04:05.999Z"),
+			ExpiryDate:  extension.expiryDate.Format(time.RFC3339Nano),
 			Definitions: extension.definitions,
 		},
 	})

--- a/yoti_client.go
+++ b/yoti_client.go
@@ -257,7 +257,7 @@ func handleSuccessfulResponse(responseContent string, key *rsa.PrivateKey) (acti
 			err = yotierror.MultiError{This: errTemp, Next: err}
 		}
 
-		timestamp, err := time.Parse(time.RFC3339, parsedResponse.Receipt.Timestamp)
+		timestamp, err := time.Parse(time.RFC3339Nano, parsedResponse.Receipt.Timestamp)
 		if err != nil {
 			log.Printf("Unable to read timestamp. Error: %q", err)
 		}


### PR DESCRIPTION
In some places, a manually entered format string that did not support
timezones was being used, in others time.RFC3339 (which does not support
microseconds) was being used instead of time.RFC3339Nano (which does support
microseconds).

Fix all of these to use time.RFC3339Nano