### PR TITLE
SDK-665: Change StructuredPostalAddress interface to map

### DIFF
--- a/attribute/json_attribute.go
+++ b/attribute/json_attribute.go
@@ -12,7 +12,7 @@ import (
 type JSONAttribute struct {
 	attributeDetails
 	// Value returns the value of a JSON attribute in the form of an interface
-	value interface{}
+	value map[string]interface{}
 }
 
 // NewJSON creates a new JSON attribute
@@ -36,8 +36,8 @@ func NewJSON(a *yotiprotoattr.Attribute) (*JSONAttribute, error) {
 }
 
 // UnmarshallJSON unmarshalls JSON into an interface
-func UnmarshallJSON(byteValue []byte) (result interface{}, err error) {
-	var unmarshalledJSON interface{}
+func UnmarshallJSON(byteValue []byte) (result map[string]interface{}, err error) {
+	var unmarshalledJSON map[string]interface{}
 	err = json.Unmarshal(byteValue, &unmarshalledJSON)
 
 	if err != nil {
@@ -48,6 +48,6 @@ func UnmarshallJSON(byteValue []byte) (result interface{}, err error) {
 }
 
 // Value returns the value of the JSONAttribute as an interface.
-func (a *JSONAttribute) Value() interface{} {
+func (a *JSONAttribute) Value() map[string]interface{} {
 	return a.value
 }

--- a/yoti_client_test.go
+++ b/yoti_client_test.go
@@ -522,7 +522,7 @@ func TestYotiClient_UnmarshallJSONValue_ValidValue(t *testing.T) {
 		nestedValue = "NestedValue"
 	)
 
-	var structuredAddress = []byte(`[
+	var structuredAddress = []byte(`
 	{
 		"address_format": 2,
 		"building": "House No.86-A",		
@@ -539,16 +539,13 @@ func TestYotiClient_UnmarshallJSONValue_ValidValue(t *testing.T) {
 			}
 		}
 	}
-	]`)
+	`)
 
 	parsedStructuredAddress, err := attribute.UnmarshallJSON(structuredAddress)
 
 	assert.Assert(t, is.Nil(err), "Failed to parse structured address")
 
-	parsedStructuredAddressInterfaceSlice := parsedStructuredAddress.([]interface{})
-
-	parsedStructuredAddressMap := parsedStructuredAddressInterfaceSlice[0].(map[string]interface{})
-	actualCountryIso := parsedStructuredAddressMap["country_iso"]
+	actualCountryIso := parsedStructuredAddress["country_iso"]
 
 	assert.Equal(t, countryIso, actualCountryIso)
 }


### PR DESCRIPTION
# Changed
 * `JSONAttribute.Value()` to return `map[string]interface{}`