### PR TITLE
SDK-1027: Change anchor value to be a single string

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ var givenNamesFirstAnchor *anchor.Anchor = givenNamesAnchors[0]
 var anchorType anchor.Type = givenNamesFirstAnchor.Type()
 var signedTimestamp *time.Time = givenNamesFirstAnchor.SignedTimestamp().Timestamp()
 var subType string = givenNamesFirstAnchor.SubType()
-var value []string = givenNamesFirstAnchor.Value()
+var value string = givenNamesFirstAnchor.Value()
 ```
 
 ## Handling Users

--- a/anchor/anchor_parser.go
+++ b/anchor/anchor_parser.go
@@ -26,11 +26,12 @@ var (
 func ParseAnchors(protoAnchors []*yotiprotoattr.Anchor) []*Anchor {
 	var processedAnchors []*Anchor
 	for _, protoAnchor := range protoAnchors {
-		var extensions []string
+		var extension string
 		var (
 			anchorType  = AnchorTypeUnknown
 			parsedCerts = parseCertificates(protoAnchor.OriginServerCerts)
 		)
+	certs:
 		for _, cert := range parsedCerts {
 			for _, ext := range cert.Extensions {
 				var (
@@ -45,11 +46,12 @@ func ParseAnchors(protoAnchors []*yotiprotoattr.Anchor) []*Anchor {
 					continue
 				}
 				anchorType = parsedAnchorType
-				extensions = append(extensions, value)
+				extension = value
+				break certs
 			}
 		}
 
-		processedAnchor := newAnchor(anchorType, parsedCerts, parseSignedTimestamp(protoAnchor.SignedTimeStamp), protoAnchor.SubType, extensions)
+		processedAnchor := newAnchor(anchorType, parsedCerts, parseSignedTimestamp(protoAnchor.SignedTimeStamp), protoAnchor.SubType, extension)
 
 		processedAnchors = append(processedAnchors, processedAnchor)
 	}

--- a/anchor/anchor_parser_test.go
+++ b/anchor/anchor_parser_test.go
@@ -65,7 +65,7 @@ func TestAnchorParser_Passport(t *testing.T) {
 	assert.Equal(t, actualAnchor.SubType(), expectedSubType)
 
 	expectedValue := "PASSPORT"
-	assert.Equal(t, actualAnchor.Value()[0], expectedValue)
+	assert.Equal(t, actualAnchor.Value(), expectedValue)
 
 	actualSerialNo := actualAnchor.OriginServerCerts()[0].SerialNumber
 	assertServerCertSerialNo(t, "277870515583559162487099305254898397834", actualSerialNo)
@@ -87,7 +87,7 @@ func TestAnchorParser_DrivingLicense(t *testing.T) {
 	assert.Equal(t, resultAnchor.SubType(), expectedSubType)
 
 	expectedValue := "DRIVING_LICENCE"
-	assert.Equal(t, resultAnchor.Value()[0], expectedValue)
+	assert.Equal(t, resultAnchor.Value(), expectedValue)
 
 	actualSerialNo := resultAnchor.OriginServerCerts()[0].SerialNumber
 	assertServerCertSerialNo(t, "46131813624213904216516051554755262812", actualSerialNo)
@@ -106,7 +106,7 @@ func TestAnchorParser_UnknownAnchor(t *testing.T) {
 	expectedType := AnchorTypeUnknown
 	assert.Equal(t, resultAnchor.SubType(), expectedSubType)
 	assert.Equal(t, resultAnchor.Type(), expectedType)
-	assert.Equal(t, len(resultAnchor.Value()), 0)
+	assert.Equal(t, resultAnchor.Value(), "")
 }
 
 func TestAnchorParser_YotiAdmin(t *testing.T) {
@@ -124,7 +124,7 @@ func TestAnchorParser_YotiAdmin(t *testing.T) {
 	assert.Equal(t, resultAnchor.SubType(), expectedSubType)
 
 	expectedValue := "YOTI_ADMIN"
-	assert.Equal(t, resultAnchor.Value()[0], expectedValue)
+	assert.Equal(t, resultAnchor.Value(), expectedValue)
 
 	actualSerialNo := resultAnchor.OriginServerCerts()[0].SerialNumber
 	assertServerCertSerialNo(t, "256616937783084706710155170893983549581", actualSerialNo)

--- a/anchor/anchors.go
+++ b/anchor/anchors.go
@@ -16,10 +16,10 @@ type Anchor struct {
 	originServerCerts []*x509.Certificate
 	signedTimestamp   SignedTimestamp
 	subtype           string
-	value             []string
+	value             string
 }
 
-func newAnchor(anchorType Type, originServerCerts []*x509.Certificate, signedTimestamp yotiprotocom.SignedTimestamp, subtype string, value []string) *Anchor {
+func newAnchor(anchorType Type, originServerCerts []*x509.Certificate, signedTimestamp yotiprotocom.SignedTimestamp, subtype string, value string) *Anchor {
 	return &Anchor{
 		anchorType:        anchorType,
 		originServerCerts: originServerCerts,
@@ -79,9 +79,9 @@ func (a Anchor) SubType() string {
 }
 
 // Value identifies the provider that either sourced or verified the attribute value.
-// The range of possible values is not limited. For a SOURCE anchor, expect values like
-// PASSPORT, DRIVING_LICENSE. For a VERIFIER anchor expect valuues like YOTI_ADMIN.
-func (a Anchor) Value() []string {
+// The range of possible values is not limited. For a SOURCE anchor, expect a value like
+// PASSPORT, DRIVING_LICENSE. For a VERIFIER anchor, expect a value like YOTI_ADMIN.
+func (a Anchor) Value() string {
 	return a.value
 }
 

--- a/attribute/image_slice_attribute_test.go
+++ b/attribute/image_slice_attribute_test.go
@@ -27,7 +27,7 @@ func assertIsExpectedDocumentImagesAttribute(t *testing.T, actualDocumentImages 
 	assertIsExpectedImage(t, actualDocumentImages[1], "jpeg", "38TVEH/9k=")
 
 	expectedValue := "NATIONAL_ID"
-	assert.Equal(t, anchor.Value()[0], expectedValue)
+	assert.Equal(t, anchor.Value(), expectedValue)
 
 	expectedSubType := "STATE_ID"
 	assert.Equal(t, anchor.SubType(), expectedSubType)

--- a/attribute/string_attribute_test.go
+++ b/attribute/string_attribute_test.go
@@ -14,9 +14,9 @@ func TestStringAttribute_NewThirdPartyAttribute(t *testing.T) {
 	assert.Equal(t, stringAttribute.Value(), "test-third-party-attribute-0")
 	assert.Equal(t, stringAttribute.Name(), "com.thirdparty.id")
 
-	assert.Equal(t, stringAttribute.Sources()[0].Value()[0], "THIRD_PARTY")
+	assert.Equal(t, stringAttribute.Sources()[0].Value(), "THIRD_PARTY")
 	assert.Equal(t, stringAttribute.Sources()[0].SubType(), "orgName")
 
-	assert.Equal(t, stringAttribute.Verifiers()[0].Value()[0], "THIRD_PARTY")
+	assert.Equal(t, stringAttribute.Verifiers()[0].Value(), "THIRD_PARTY")
 	assert.Equal(t, stringAttribute.Verifiers()[0].SubType(), "orgName")
 }


### PR DESCRIPTION
We'll need to update the dev docs after this change too. 