### PR TITLE
SDK-1438: Add Load PEM helper to sandbox client

### DIFF
--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -2,10 +2,13 @@ package sandbox
 
 import (
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	yotirequest "github.com/getyoti/yoti-go-sdk/v2/requests"
 )
@@ -15,6 +18,29 @@ type Client struct {
 	AppID   string
 	Key     *rsa.PrivateKey
 	BaseURL string
+}
+
+// LoadPEMFile loads the Sandbox Client Key from a PEM file path
+func (client *Client) LoadPEMFile(filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+
+	buffer, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
+	block, _ := pem.Decode(buffer)
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return err
+	}
+
+	client.Key = key
+
+	return nil
 }
 
 // SetupSharingProfile creates a user profile in the sandbox instance

--- a/sandbox/client.go
+++ b/sandbox/client.go
@@ -33,6 +33,9 @@ func (client *Client) LoadPEMFile(filename string) error {
 	}
 
 	block, _ := pem.Decode(buffer)
+	if block == nil {
+		return fmt.Errorf("Could not decode PEM file")
+	}
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
 		return err

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestClient_LoadPEMFile(t *testing.T) {

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -30,4 +31,21 @@ func TestClient_LoadPEMFile(t *testing.T) {
 	err = client.LoadPEMFile(keyFileName)
 	assert.NilError(t, err)
 	assert.Check(t, client.Key != nil)
+}
+
+func TestClient_LoadPEMFile_ShouldFailForFileNotFound(t *testing.T) {
+	MissingFileName := "/tmp/file_not_found"
+	client := &Client{}
+	err := client.LoadPEMFile(MissingFileName)
+	assert.Check(t, err != nil)
+}
+
+func TestClient_LoadPEMFile_ShouldFailForInvalidFile(t *testing.T) {
+	InvalidFileName := "/tmp/invalid_file"
+	err := ioutil.WriteFile(InvalidFileName, []byte("Not a PEM"), 0644)
+	assert.NilError(t, err)
+
+	client := &Client{}
+	err = client.LoadPEMFile(InvalidFileName)
+	assert.Check(t, err != nil)
 }

--- a/sandbox/client_test.go
+++ b/sandbox/client_test.go
@@ -1,0 +1,33 @@
+package sandbox
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestClient_LoadPEMFile(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	assert.NilError(t, err)
+	block := pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	keyFileName := "tmpKey.pem"
+	keyFile, err := os.Create(keyFileName)
+	assert.NilError(t, err)
+	err = pem.Encode(keyFile, &block)
+	assert.NilError(t, err)
+	err = keyFile.Close()
+	assert.NilError(t, err)
+
+	client := &Client{}
+	err = client.LoadPEMFile(keyFileName)
+	assert.NilError(t, err)
+	assert.Check(t, client.Key != nil)
+}

--- a/sandbox/profile.go
+++ b/sandbox/profile.go
@@ -109,13 +109,9 @@ func (profile Profile) WithDocumentDetails(value string, anchors []Anchor) Profi
 	return profile.WithAttribute(yoti.AttrConstDocumentDetails, value, anchors)
 }
 
-// WithoutAttributes initialises a sandbox profile with the minimum to get
+// Deprecated WithoutAttributes initialises a sandbox profile with the minimum to get
 // a response from the sandbox server
 func (profile Profile) WithoutAttributes() Profile {
-	profile.Attributes = []Attribute{{
-		Name:    "unused",
-		Value:   "unused",
-		Anchors: make([]Anchor, 0),
-	}}
+	profile.Attributes = []Attribute{}
 	return profile
 }

--- a/sandbox/profile.go
+++ b/sandbox/profile.go
@@ -108,10 +108,3 @@ func (profile Profile) WithEmailAddress(value string, anchors []Anchor) Profile 
 func (profile Profile) WithDocumentDetails(value string, anchors []Anchor) Profile {
 	return profile.WithAttribute(yoti.AttrConstDocumentDetails, value, anchors)
 }
-
-// Deprecated WithoutAttributes initialises a sandbox profile with the minimum to get
-// a response from the sandbox server
-func (profile Profile) WithoutAttributes() Profile {
-	profile.Attributes = []Attribute{}
-	return profile
-}

--- a/sandbox/profile_test.go
+++ b/sandbox/profile_test.go
@@ -141,9 +141,3 @@ func ExampleProfile_WithDocumentDetails() {
 	fmt.Println(profile)
 	// Output: { [{document_details DRIVING_LICENCE - abc1234   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
 }
-
-func ExampleProfile_WithoutAttributes() {
-	profile := Profile{}.WithoutAttributes()
-	fmt.Println(profile)
-	// Output: { []}
-}

--- a/sandbox/profile_test.go
+++ b/sandbox/profile_test.go
@@ -145,5 +145,5 @@ func ExampleProfile_WithDocumentDetails() {
 func ExampleProfile_WithoutAttributes() {
 	profile := Profile{}.WithoutAttributes()
 	fmt.Println(profile)
-	// Output: { [{unused unused   []}]}
+	// Output: { []}
 }


### PR DESCRIPTION
### Add
 * `LoadPEMFile` helper added to `sandbox.Client` to read Sandbox App private key

### Changed
 * Workaround function `WithoutAttributes` no longer sets a dummy attribute as sandbox now supports a share with no attributes and no longer supports dummy attributes being set.

### Deprecated
 * `Profile::WithoutAttributes`