### PR TITLE
SDK-1500: Use .env `YOTI_API_URL` for calls through YotiClient

### DIFF
--- a/profile/sandbox/client.go
+++ b/profile/sandbox/client.go
@@ -27,8 +27,8 @@ type Client struct {
 // SetupSharingProfile creates a user profile in the sandbox instance
 func (client *Client) SetupSharingProfile(tokenRequest TokenRequest) (token string, err error) {
 	if client.BaseURL == "" {
-		if os.Getenv("YOTI_API_URL") != "" {
-			client.BaseURL = os.Getenv("YOTI_API_URL")
+		if value, exists := os.LookupEnv("YOTI_API_URL"); exists && value != "" {
+			client.BaseURL = value
 		} else {
 			client.BaseURL = "https://api.yoti.com/sandbox/v1"
 		}

--- a/profile/sandbox/client_test.go
+++ b/profile/sandbox/client_test.go
@@ -32,8 +32,19 @@ func TestClient_SetupSharingProfileUsesEnvVariable(t *testing.T) {
 	assert.Equal(t, "envBaseUrl", client.BaseURL)
 }
 
-func TestClient_SetupSharingProfileUsesDefaultUrlAsFallback(t *testing.T) {
+func TestClient_SetupSharingProfileUsesDefaultUrlAsFallbackWithEmptyEnvValue(t *testing.T) {
 	os.Setenv("YOTI_API_URL", "")
+
+	client := createSandboxClient(t, "")
+
+	_, err := client.SetupSharingProfile(TokenRequest{})
+	assert.NilError(t, err)
+
+	assert.Equal(t, "https://api.yoti.com/sandbox/v1", client.BaseURL)
+}
+
+func TestClient_SetupSharingProfileUsesDefaultUrlAsFallbackWithNoEnvValue(t *testing.T) {
+	os.Unsetenv("YOTI_API_URL")
 
 	client := createSandboxClient(t, "")
 

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -67,8 +68,7 @@ func (client *Client) doRequest(request *http.Request) (*http.Response, error) {
 	return client.httpClient.Do(request)
 }
 
-// OverrideAPIURL overrides the default API URL for this Yoti Client to permit
-// testing
+// OverrideAPIURL overrides the default API URL for this Yoti Client
 func (client *Client) OverrideAPIURL(apiURL string) {
 	client.apiURL = apiURL
 }
@@ -88,10 +88,15 @@ func (client *Client) GetUserProfile(token string) (userProfile UserProfile, fir
 }
 
 func (client *Client) getAPIURL() string {
-	if client.apiURL != "" {
-		return client.apiURL
+	if client.apiURL == "" {
+		if os.Getenv("YOTI_API_URL") != "" {
+			return os.Getenv("YOTI_API_URL")
+		} else {
+			return apiDefaultURL
+		}
 	}
-	return apiDefaultURL
+
+	return client.apiURL
 }
 
 // GetSdkID gets the Client SDK ID attached to this client instance
@@ -108,7 +113,6 @@ func (client *Client) GetActivityDetails(token string) (ActivityDetails, []strin
 }
 
 func (client *Client) getActivityDetails(token string) (userProfile UserProfile, activity ActivityDetails, errStrings []string) {
-
 	httpMethod := http.MethodGet
 	key, err := cryptoutil.ParseRSAKey(client.Key)
 	if err != nil {

--- a/yoticlient.go
+++ b/yoticlient.go
@@ -88,15 +88,15 @@ func (client *Client) GetUserProfile(token string) (userProfile UserProfile, fir
 }
 
 func (client *Client) getAPIURL() string {
-	if client.apiURL == "" {
-		if os.Getenv("YOTI_API_URL") != "" {
-			return os.Getenv("YOTI_API_URL")
-		} else {
-			return apiDefaultURL
-		}
+	if client.apiURL != "" {
+		return client.apiURL
 	}
 
-	return client.apiURL
+	if value, exists := os.LookupEnv("YOTI_API_URL"); exists && value != "" {
+		return value
+	}
+
+	return apiDefaultURL
 }
 
 // GetSdkID gets the Client SDK ID attached to this client instance

--- a/yoticlient_test.go
+++ b/yoticlient_test.go
@@ -28,10 +28,20 @@ func TestYotiClient_GetAPIURLUsesEnvVariable(t *testing.T) {
 	assert.Equal(t, "envBaseUrl", result)
 }
 
-func TestYotiClient_GetAPIURLUsesDefaultUrlAsFallback(t *testing.T) {
+func TestYotiClient_GetAPIURLUsesDefaultUrlAsFallbackWithEmptyEnvValue(t *testing.T) {
 	client := Client{}
 
 	os.Setenv("YOTI_API_URL", "")
+
+	result := client.getAPIURL()
+
+	assert.Equal(t, "https://api.yoti.com/api/v1", result)
+}
+
+func TestYotiClient_GetAPIURLUsesDefaultUrlAsFallbackWithNoEnvValue(t *testing.T) {
+	client := Client{}
+
+	os.Unsetenv("YOTI_API_URL")
 
 	result := client.getAPIURL()
 

--- a/yoticlient_test.go
+++ b/yoticlient_test.go
@@ -1,0 +1,39 @@
+package yoti
+
+import (
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestYotiClient_GetAPIURLUsesOverriddenBaseUrlOverEnvVariable(t *testing.T) {
+	client := Client{}
+	client.OverrideAPIURL("overridenBaseUrl")
+
+	os.Setenv("YOTI_API_URL", "envBaseUrl")
+
+	result := client.getAPIURL()
+
+	assert.Equal(t, "overridenBaseUrl", result)
+}
+
+func TestYotiClient_GetAPIURLUsesEnvVariable(t *testing.T) {
+	client := Client{}
+
+	os.Setenv("YOTI_API_URL", "envBaseUrl")
+
+	result := client.getAPIURL()
+
+	assert.Equal(t, "envBaseUrl", result)
+}
+
+func TestYotiClient_GetAPIURLUsesDefaultUrlAsFallback(t *testing.T) {
+	client := Client{}
+
+	os.Setenv("YOTI_API_URL", "")
+
+	result := client.getAPIURL()
+
+	assert.Equal(t, "https://api.yoti.com/api/v1", result)
+}


### PR DESCRIPTION
Branched off https://github.com/getyoti/yoti-go-sdk/pull/116, see changes for this branch here:
https://github.com/getyoti/yoti-go-sdk/compare/SDK-1527-SandboxDocumentation...SDK-1500-UseEnvApiURLForYotiClient

We are already using this .env variable for Sandbox, this is just to update the YotiClient to do the same too. 

I opted to keep the `.OverrideAPIURL` in the sandbox example files (when we could instead just use the .env files), as I think it makes it clearer to the client that the client is not pointing at the same place

### TODO 
* [x] Merge https://github.com/getyoti/yoti-go-sdk/pull/116 into development