### PR TITLE
SDK-1491: Use json.number decoder for JSON values

### DIFF
--- a/attribute/json_attribute.go
+++ b/attribute/json_attribute.go
@@ -1,6 +1,7 @@
 package attribute
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -17,7 +18,10 @@ type JSONAttribute struct {
 
 // NewJSON creates a new JSON attribute
 func NewJSON(a *yotiprotoattr.Attribute) (*JSONAttribute, error) {
-	interfaceValue, err := UnmarshallJSON(a.Value)
+	var interfaceValue map[string]interface{}
+	decoder := json.NewDecoder(bytes.NewReader(a.Value))
+	decoder.UseNumber()
+	err := decoder.Decode(&interfaceValue)
 	if err != nil {
 		err = fmt.Errorf("Unable to parse JSON value: %q. Error: %q", a.Value, err)
 		return nil, err


### PR DESCRIPTION
- Use `decoder.UseNumber()` option in decoder for JSON values is so int values are parsed as `json.number` rather than float64
- Integration tests updated in a separate PR
- See https://eager.io/blog/go-and-json/ for more information:
> your numbers will always be of typefloat64, and will need to be casted to int, for example. If you have a particular need to get ints directly, you can use the UseNumber method. Which gives you an object which can be converted to either a float64 or an int at your discretion.