### PR TITLE
SDK-1659: Response Errors

### DIFF
--- a/aml/service.go
+++ b/aml/service.go
@@ -35,10 +35,10 @@ func PerformAmlCheck(httpClient requests.HttpClient, amlProfile AmlProfile, clie
 		return
 	}
 
-	amlErrorMessages := make(map[int]string)
-	amlErrorMessages[-1] = "AML Check was unsuccessful, status code: '%[1]d', content '%[2]s'"
+	httpErrorMessages := make(map[int]string)
+	httpErrorMessages[-1] = "AML Check was unsuccessful"
 
-	response, err := requests.Execute(httpClient, request, amlErrorMessages)
+	response, err := requests.Execute(httpClient, request, httpErrorMessages)
 	if err != nil {
 		return
 	}

--- a/aml/service_test.go
+++ b/aml/service_test.go
@@ -2,13 +2,13 @@ package aml
 
 import (
 	"crypto/rsa"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/getyoti/yoti-go-sdk/v3/test"
-
 	"gotest.tools/v3/assert"
 )
 
@@ -61,18 +61,19 @@ func TestYotiClient_PerformAmlCheck_Success(t *testing.T) {
 
 func TestYotiClient_PerformAmlCheck_Unsuccessful(t *testing.T) {
 	key := getValidKey()
+	responseBody := "SERVICE UNAVAILABLE - Unable to reach the Integrity Service"
 
 	client := &mockHTTPClient{
 		do: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 503,
-				Body:       ioutil.NopCloser(strings.NewReader(`SERVICE UNAVAILABLE - Unable to reach the Integrity Service`)),
+				Body:       ioutil.NopCloser(strings.NewReader(responseBody)),
 			}, nil
 		},
 	}
 
 	_, err := PerformAmlCheck(client, createStandardAmlProfile(), "clientSdkId", "https://apiUrl", key)
-	assert.ErrorContains(t, err, "AML Check was unsuccessful")
+	assert.ErrorContains(t, err, fmt.Sprintf("%d: AML Check was unsuccessful: %s", 503, responseBody))
 
 	tempError, temporary := err.(interface {
 		Temporary() bool

--- a/aml/service_test.go
+++ b/aml/service_test.go
@@ -61,7 +61,7 @@ func TestYotiClient_PerformAmlCheck_Success(t *testing.T) {
 
 func TestYotiClient_PerformAmlCheck_Unsuccessful(t *testing.T) {
 	key := getValidKey()
-	responseBody := "SERVICE UNAVAILABLE - Unable to reach the Integrity Service"
+	responseBody := "some service unavailable response"
 
 	client := &mockHTTPClient{
 		do: func(*http.Request) (*http.Response, error) {
@@ -73,7 +73,7 @@ func TestYotiClient_PerformAmlCheck_Unsuccessful(t *testing.T) {
 	}
 
 	_, err := PerformAmlCheck(client, createStandardAmlProfile(), "clientSdkId", "https://apiUrl", key)
-	assert.ErrorContains(t, err, fmt.Sprintf("%d: AML Check was unsuccessful: %s", 503, responseBody))
+	assert.ErrorContains(t, err, fmt.Sprintf("%d: AML Check was unsuccessful - %s", 503, responseBody))
 
 	tempError, temporary := err.(interface {
 		Temporary() bool

--- a/dynamic/service_test.go
+++ b/dynamic/service_test.go
@@ -5,8 +5,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"testing"
 
 	"github.com/getyoti/yoti-go-sdk/v3/test"
+	"gotest.tools/v3/assert"
 )
 
 type mockHTTPClient struct {
@@ -48,4 +50,61 @@ func ExampleCreateShareURL() {
 	}
 	fmt.Printf("QR code: %s", result.ShareURL)
 	// Output: QR code: https://code.yoti.com/CAEaJDQzNzllZDc0LTU0YjItNDkxMy04OTE4LTExYzM2ZDU2OTU3ZDAC
+}
+
+func TestCreateShareURL_Unsuccessful_503(t *testing.T) {
+	_, err := createShareUrlWithErrorResponse(503, "SERVICE UNAVAILABLE")
+
+	assert.ErrorContains(t, err, "503: Unknown HTTP Error: SERVICE UNAVAILABLE")
+
+	tempError, temporary := err.(interface {
+		Temporary() bool
+	})
+	assert.Check(t, temporary && tempError.Temporary())
+}
+
+func TestCreateShareURL_Unsuccessful_404(t *testing.T) {
+	_, err := createShareUrlWithErrorResponse(404, "NOT FOUND")
+
+	assert.ErrorContains(t, err, "404: Application was not found: NOT FOUND")
+
+	tempError, temporary := err.(interface {
+		Temporary() bool
+	})
+	assert.Check(t, !temporary || !tempError.Temporary())
+}
+
+func TestCreateShareURL_Unsuccessful_400(t *testing.T) {
+	_, err := createShareUrlWithErrorResponse(400, "INVALID JSON")
+
+	assert.ErrorContains(t, err, "400: JSON is incorrect, contains invalid data: INVALID JSON")
+
+	tempError, temporary := err.(interface {
+		Temporary() bool
+	})
+	assert.Check(t, !temporary || !tempError.Temporary())
+}
+
+func createShareUrlWithErrorResponse(statusCode int, responseBody string) (share ShareURL, err error) {
+	key := test.GetValidKey("../test/test-key.pem")
+
+	client := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       ioutil.NopCloser(strings.NewReader(responseBody)),
+			}, nil
+		},
+	}
+
+	policy, err := (&DynamicPolicyBuilder{}).WithFullName().WithWantedRememberMe().Build()
+	if err != nil {
+		return
+	}
+	scenario, err := (&DynamicScenarioBuilder{}).WithPolicy(policy).Build()
+	if err != nil {
+		return
+	}
+
+	return CreateShareURL(client, &scenario, "sdkId", "https://apiurl", key)
 }

--- a/dynamic/service_test.go
+++ b/dynamic/service_test.go
@@ -55,7 +55,7 @@ func ExampleCreateShareURL() {
 func TestCreateShareURL_Unsuccessful_503(t *testing.T) {
 	_, err := createShareUrlWithErrorResponse(503, "SERVICE UNAVAILABLE")
 
-	assert.ErrorContains(t, err, "503: Unknown HTTP Error: SERVICE UNAVAILABLE")
+	assert.ErrorContains(t, err, "503: unknown HTTP error: SERVICE UNAVAILABLE")
 
 	tempError, temporary := err.(interface {
 		Temporary() bool

--- a/dynamic/service_test.go
+++ b/dynamic/service_test.go
@@ -53,9 +53,9 @@ func ExampleCreateShareURL() {
 }
 
 func TestCreateShareURL_Unsuccessful_503(t *testing.T) {
-	_, err := createShareUrlWithErrorResponse(503, "SERVICE UNAVAILABLE")
+	_, err := createShareUrlWithErrorResponse(503, "some service unavailable response")
 
-	assert.ErrorContains(t, err, "503: unknown HTTP error: SERVICE UNAVAILABLE")
+	assert.ErrorContains(t, err, "503: unknown HTTP error - some service unavailable response")
 
 	tempError, temporary := err.(interface {
 		Temporary() bool
@@ -64,9 +64,9 @@ func TestCreateShareURL_Unsuccessful_503(t *testing.T) {
 }
 
 func TestCreateShareURL_Unsuccessful_404(t *testing.T) {
-	_, err := createShareUrlWithErrorResponse(404, "NOT FOUND")
+	_, err := createShareUrlWithErrorResponse(404, "some not found response")
 
-	assert.ErrorContains(t, err, "404: Application was not found: NOT FOUND")
+	assert.ErrorContains(t, err, "404: Application was not found - some not found response")
 
 	tempError, temporary := err.(interface {
 		Temporary() bool
@@ -75,9 +75,9 @@ func TestCreateShareURL_Unsuccessful_404(t *testing.T) {
 }
 
 func TestCreateShareURL_Unsuccessful_400(t *testing.T) {
-	_, err := createShareUrlWithErrorResponse(400, "INVALID JSON")
+	_, err := createShareUrlWithErrorResponse(400, "some invalid JSON response")
 
-	assert.ErrorContains(t, err, "400: JSON is incorrect, contains invalid data: INVALID JSON")
+	assert.ErrorContains(t, err, "400: JSON is incorrect, contains invalid data - some invalid JSON response")
 
 	tempError, temporary := err.(interface {
 		Temporary() bool

--- a/dynamic/share_url.go
+++ b/dynamic/share_url.go
@@ -4,8 +4,8 @@ var (
 	// ShareURLHTTPErrorMessages specifies the HTTP error status codes used
 	// by the Share URL API
 	ShareURLHTTPErrorMessages = map[int]string{
-		400: "JSON is incorrect, contains invalid data: %[2]s",
-		404: "Application was not found: %[2]s",
+		400: "JSON is incorrect, contains invalid data",
+		404: "Application was not found",
 	}
 )
 

--- a/profile/service.go
+++ b/profile/service.go
@@ -48,7 +48,7 @@ func GetActivityDetails(httpClient requests.HttpClient, token, clientSdkId, apiU
 		return
 	}
 
-	response, err := requests.Execute(httpClient, request, map[int]string{404: "Profile Not Found"}, requests.DefaultHTTPErrorMessages)
+	response, err := requests.Execute(httpClient, request, map[int]string{404: "Profile not found"}, requests.DefaultHTTPErrorMessages)
 	if err != nil {
 		return
 	}

--- a/profile/service.go
+++ b/profile/service.go
@@ -48,7 +48,7 @@ func GetActivityDetails(httpClient requests.HttpClient, token, clientSdkId, apiU
 		return
 	}
 
-	response, err := requests.Execute(httpClient, request, map[int]string{404: "%[1]d: Profile Not Found"}, requests.DefaultHTTPErrorMessages)
+	response, err := requests.Execute(httpClient, request, map[int]string{404: "Profile Not Found"}, requests.DefaultHTTPErrorMessages)
 	if err != nil {
 		return
 	}

--- a/profile/service_test.go
+++ b/profile/service_test.go
@@ -192,7 +192,7 @@ func TestProfileService_TokenDecodedSuccessfully(t *testing.T) {
 	}
 
 	_, err := GetActivityDetails(client, test.EncryptedToken, "sdkId", "https://apiurl", key)
-	assert.ErrorContains(t, err, "Unknown HTTP Error")
+	assert.ErrorContains(t, err, "unknown HTTP error")
 
 	tempError, temporary := err.(interface {
 		Temporary() bool

--- a/profile/service_test.go
+++ b/profile/service_test.go
@@ -76,7 +76,7 @@ func TestProfileService_RequestErrIsReturned(t *testing.T) {
 	}
 	_, err := GetActivityDetails(client, test.EncryptedToken, "clientSdkId", "https://apiUrl", getValidKey())
 
-	assert.ErrorContains(t, err, "404: Profile Not Found")
+	assert.ErrorContains(t, err, "404: Profile not found")
 }
 
 func TestProfileService_InvalidToken(t *testing.T) {

--- a/requests/client.go
+++ b/requests/client.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	defaultUnknownErrorMessageConst = "Unknown HTTP Error"
+	defaultUnknownErrorMessageConst = "unknown HTTP error"
 
 	// DefaultHTTPErrorMessages maps HTTP error status codes to format strings
 	// to create useful error messages. -1 is used to specify a default message

--- a/requests/client.go
+++ b/requests/client.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	defaultUnknownErrorMessageConst = "Unknown HTTP Error: %[1]d: %[2]s"
+	defaultUnknownErrorMessageConst = "Unknown HTTP Error"
 
 	// DefaultHTTPErrorMessages maps HTTP error status codes to format strings
 	// to create useful error messages. -1 is used to specify a default message

--- a/requests/request.go
+++ b/requests/request.go
@@ -47,7 +47,7 @@ func formatHTTPError(message string, statusCode int, body []byte) error {
 	if len(body) == 0 {
 		return fmt.Errorf("%d: %s", statusCode, message)
 	}
-	return fmt.Errorf("%d: %s: %s", statusCode, message, body)
+	return fmt.Errorf("%d: %s - %s", statusCode, message, body)
 }
 
 func handleHTTPError(response *http.Response, errorMessages ...map[int]string) error {

--- a/yoti_client_test.go
+++ b/yoti_client_test.go
@@ -51,14 +51,14 @@ func TestYotiClient_HttpFailure_ReturnsFailure(t *testing.T) {
 	_, err := client.GetActivityDetails(test.EncryptedToken)
 
 	assert.Check(t, err != nil)
-	assert.ErrorContains(t, err, "Unknown HTTP Error")
+	assert.ErrorContains(t, err, "unknown HTTP error")
 	tempError, temporary := err.(interface {
 		Temporary() bool
 		Unwrap() error
 	})
 	assert.Check(t, temporary)
 	assert.Check(t, tempError.Temporary())
-	assert.ErrorContains(t, tempError.Unwrap(), "Unknown HTTP Error")
+	assert.ErrorContains(t, tempError.Unwrap(), "unknown HTTP error")
 }
 
 func TestYotiClient_HttpFailure_ReturnsProfileNotFound(t *testing.T) {

--- a/yoti_client_test.go
+++ b/yoti_client_test.go
@@ -77,7 +77,7 @@ func TestYotiClient_HttpFailure_ReturnsProfileNotFound(t *testing.T) {
 
 	_, err := client.GetActivityDetails(test.EncryptedToken)
 
-	assert.ErrorContains(t, err, "Profile Not Found")
+	assert.ErrorContains(t, err, "Profile not found")
 	tempError, temporary := err.(interface {
 		Temporary() bool
 	})


### PR DESCRIPTION
Following #137 

### Fixed
- Response body is now only appended when available (no trailing `:`)
- Reset the response body after reading so that the response can be used by callers

### Changed
- `defaultUnknownErrorMessageConst` is now the message string, rather than a format - status code is now always prefixed, e.g. `404: Profile not found`