### PR TITLE
SDK-1667: Base64 URL token

### DIFF
--- a/attribute/issuancedetails.go
+++ b/attribute/issuancedetails.go
@@ -53,7 +53,7 @@ func ParseIssuanceDetails(thirdPartyAttributeBytes []byte) (*IssuanceDetails, er
 		return nil, errors.New("Issuance Token is invalid")
 	}
 
-	base64EncodedToken := base64.StdEncoding.EncodeToString(issuanceTokenBytes)
+	base64EncodedToken := base64.RawURLEncoding.EncodeToString(issuanceTokenBytes)
 
 	return &IssuanceDetails{
 		token:      base64EncodedToken,

--- a/attribute/issuancedetails_test.go
+++ b/attribute/issuancedetails_test.go
@@ -20,10 +20,19 @@ func TestShouldParseThirdPartyAttributeCorrectly(t *testing.T) {
 
 	assert.Assert(t, is.Nil(err))
 	assert.Equal(t, issuanceDetails.Attributes()[0].Name(), "com.thirdparty.id")
-	assert.Equal(t, issuanceDetails.Token(), "c29tZUlzc3VhbmNlVG9rZW4=")
+	assert.Equal(t, issuanceDetails.Token(), "c29tZUlzc3VhbmNlVG9rZW4")
 	assert.Equal(t,
 		issuanceDetails.ExpiryDate().Format("2006-01-02T15:04:05.000Z"),
 		"2019-10-15T22:04:05.123Z")
+}
+
+func TestToken_ShouldReturnUnpaddedBase64UrlToken(t *testing.T) {
+	var thirdPartyAttributeBytes []byte = test.GetTestFileBytes(t, "testthirdpartyattribute.txt")
+	issuanceDetails, err := ParseIssuanceDetails(thirdPartyAttributeBytes)
+	assert.Assert(t, is.Nil(err))
+
+	decodedToken, _ := base64.RawURLEncoding.DecodeString(issuanceDetails.Token())
+	assert.Equal(t, string(decodedToken), "someIssuanceToken")
 }
 
 func TestShouldLogWarningIfErrorInParsingExpiryDate(t *testing.T) {
@@ -40,7 +49,7 @@ func TestShouldLogWarningIfErrorInParsingExpiryDate(t *testing.T) {
 	assert.Assert(t, is.Nil(err))
 
 	var tokenBytes []byte = []byte(tokenValue)
-	var expectedBase64Token string = base64.StdEncoding.EncodeToString(tokenBytes)
+	var expectedBase64Token string = base64.RawURLEncoding.EncodeToString(tokenBytes)
 
 	result, err := ParseIssuanceDetails(marshalled)
 	assert.Equal(t, expectedBase64Token, result.Token())

--- a/consts/version.go
+++ b/consts/version.go
@@ -2,5 +2,5 @@ package consts
 
 const (
 	SDKIdentifier        = "Go"
-	SDKVersionIdentifier = "2.10.0"
+	SDKVersionIdentifier = "2.10.1"
 )

--- a/share/extradata_test.go
+++ b/share/extradata_test.go
@@ -42,7 +42,7 @@ func TestShouldReturnFirstMatchingThirdPartyAttribute(t *testing.T) {
 	result := parsedExtraData.AttributeIssuanceDetails()
 
 	var tokenBytes = []byte(tokenValue1)
-	var base64EncodedToken = base64.StdEncoding.EncodeToString(tokenBytes)
+	var base64EncodedToken = base64.RawURLEncoding.EncodeToString(tokenBytes)
 
 	assert.Equal(t, result.Token(), base64EncodedToken)
 	assert.Equal(t, result.Attributes()[0].Name(), "attributeName1")
@@ -61,7 +61,7 @@ func TestShouldParseMultipleIssuingAttributes(t *testing.T) {
 
 	result := extraData.AttributeIssuanceDetails()
 
-	assert.Equal(t, result.Token(), "c29tZUlzc3VhbmNlVG9rZW4=")
+	assert.Equal(t, result.Token(), "c29tZUlzc3VhbmNlVG9rZW4")
 	assert.Equal(t,
 		result.ExpiryDate().Format("2006-01-02T15:04:05.000Z"),
 		time.Date(2019, time.October, 15, 22, 04, 05, 123000000, time.UTC).Format("2006-01-02T15:04:05.000Z"))
@@ -103,7 +103,7 @@ func TestShouldHandleNoIssuingAttributes(t *testing.T) {
 	result, err := processThirdPartyAttribute(t, marshalledThirdPartyAttribute)
 
 	assert.Assert(t, is.Nil(err))
-	assert.Equal(t, base64.StdEncoding.EncodeToString(tokenValueBytes), result.Token())
+	assert.Equal(t, base64.RawURLEncoding.EncodeToString(tokenValueBytes), result.Token())
 }
 
 func TestShouldHandleNoIssuingAttributeDefinitions(t *testing.T) {
@@ -123,7 +123,7 @@ func TestShouldHandleNoIssuingAttributeDefinitions(t *testing.T) {
 	result, err := processThirdPartyAttribute(t, marshalledThirdPartyAttribute)
 
 	assert.Assert(t, is.Nil(err))
-	assert.Equal(t, base64.StdEncoding.EncodeToString(tokenValueBytes), result.Token())
+	assert.Equal(t, base64.RawURLEncoding.EncodeToString(tokenValueBytes), result.Token())
 }
 
 func processThirdPartyAttribute(t *testing.T, marshalledThirdPartyAttribute []byte) (*attribute.IssuanceDetails, error) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization = getyoti
 sonar.projectKey = getyoti:go
 sonar.projectName = Go SDK
-sonar.projectVersion = 2.10.0
+sonar.projectVersion = 2.10.1
 sonar.exclusions = **/yotiprotoattr/*.go,**/yotiprotocom/*.go,**/**_test.go
 sonar.links.scm = https://github.com/getyoti/yoti-go-sdk
 sonar.host.url = https://sonarcloud.io


### PR DESCRIPTION
> Version: `2.10.1`

### Fixed
- Attribute Issuance token is now base64 URL encoded