### PR TITLE
SDK-1661: Tidying up before major release

### DIFF
--- a/_examples/aml/main.go
+++ b/_examples/aml/main.go
@@ -27,7 +27,7 @@ func main() {
 		return
 	}
 
-	client, err := yoti.NewClient(sdkID, key)
+	client, err = yoti.NewClient(sdkID, key)
 	if err != nil {
 		log.Printf("Problem initialising client: Error: `%s`", err)
 		return
@@ -44,7 +44,8 @@ func main() {
 		FamilyName: familyName,
 		Address:    amlAddress}
 
-	result, err := client.PerformAmlCheck(amlProfile)
+	var result aml.Result
+	result, err = client.PerformAmlCheck(amlProfile)
 
 	if err != nil {
 		log.Printf(

--- a/dynamic/policy_builder.go
+++ b/dynamic/policy_builder.go
@@ -215,8 +215,8 @@ func (b *PolicyBuilder) attributesAsList() []WantedAttribute {
 
 func (b *PolicyBuilder) authTypesAsList() []int {
 	authTypeList := make([]int, 0)
-	for auth, b := range b.wantedAuthTypes {
-		if b {
+	for auth, boolValue := range b.wantedAuthTypes {
+		if boolValue {
 			authTypeList = append(authTypeList, auth)
 		}
 	}

--- a/dynamic/scenario_builder_test.go
+++ b/dynamic/scenario_builder_test.go
@@ -36,14 +36,14 @@ func ExampleScenarioBuilder_WithExtension() {
 	if err != nil {
 		return
 	}
-	extension, err := (&extension.TransactionalFlowExtensionBuilder{}).
+	builtExtension, err := (&extension.TransactionalFlowExtensionBuilder{}).
 		WithContent("Transactional Flow Extension").
 		Build()
 	if err != nil {
 		return
 	}
 
-	scenario, err := (&ScenarioBuilder{}).WithExtension(extension).WithPolicy(policy).Build()
+	scenario, err := (&ScenarioBuilder{}).WithExtension(builtExtension).WithPolicy(policy).Build()
 	if err != nil {
 		return
 	}

--- a/profile/application_profile.go
+++ b/profile/application_profile.go
@@ -19,8 +19,7 @@ type ApplicationProfile struct {
 	baseProfile
 }
 
-// Creates a new Profile struct
-func NewApplicationProfile(attributes *yotiprotoattr.AttributeList) ApplicationProfile {
+func newApplicationProfile(attributes *yotiprotoattr.AttributeList) ApplicationProfile {
 	return ApplicationProfile{
 		baseProfile{
 			attributeSlice: createAttributeSlice(attributes),

--- a/profile/attribute/anchor/anchor_parser_test.go
+++ b/profile/attribute/anchor/anchor_parser_test.go
@@ -130,7 +130,7 @@ func TestAnchorParser_YotiAdmin(t *testing.T) {
 }
 
 func TestAnchors_None(t *testing.T) {
-	anchorSlice := []*Anchor{}
+	var anchorSlice []*Anchor
 
 	sources := GetSources(anchorSlice)
 	assert.Equal(t, len(sources), 0, "GetSources should not return anything with empty anchors")

--- a/profile/attribute/definition_test.go
+++ b/profile/attribute/definition_test.go
@@ -7,7 +7,7 @@ import (
 
 func ExampleDefinition_MarshalJSON() {
 	exampleDefinition := NewAttributeDefinition("exampleDefinition")
-	json, _ := json.Marshal(exampleDefinition)
-	fmt.Println(string(json))
+	marshalledJSON, _ := json.Marshal(exampleDefinition)
+	fmt.Println(string(marshalledJSON))
 	// Output: {"name":"exampleDefinition"}
 }

--- a/profile/attribute/document_details_attribute_test.go
+++ b/profile/attribute/document_details_attribute_test.go
@@ -73,7 +73,7 @@ func TestDocumentDetailsShouldParseRedactedAadhar(t *testing.T) {
 }
 
 func TestDocumentDetailsShouldParseSpecialCharacters(t *testing.T) {
-	test_data := [][]string{
+	testData := [][]string{
 		{"type country **** - authority", "****"},
 		{"type country ~!@#$%^&*()-_=+[]{}|;':,./<>? - authority", "~!@#$%^&*()-_=+[]{}|;':,./<>?"},
 		{"type country \"\" - authority", "\"\""},
@@ -82,7 +82,7 @@ func TestDocumentDetailsShouldParseSpecialCharacters(t *testing.T) {
 		{"type country '' - authority", "''"},
 		{"type country ' - authority", "'"},
 	}
-	for _, row := range test_data {
+	for _, row := range testData {
 		details := DocumentDetails{}
 		err := details.Parse(row[0])
 		if err != nil {

--- a/profile/attribute/parser.go
+++ b/profile/attribute/parser.go
@@ -37,9 +37,9 @@ func parseValue(contentType yotiprotoattr.ContentType, byteValue []byte) (interf
 
 	case yotiprotoattr.ContentType_INT:
 		var stringValue = string(byteValue)
-		int, err := strconv.Atoi(stringValue)
+		intValue, err := strconv.Atoi(stringValue)
 		if err == nil {
-			return int, nil
+			return intValue, nil
 		}
 
 		return nil, fmt.Errorf("unable to parse INT value: %q. Error: %q", string(byteValue), err)

--- a/profile/base_profile.go
+++ b/profile/base_profile.go
@@ -33,10 +33,10 @@ func (p baseProfile) GetStringAttribute(attributeName string) *attribute.StringA
 func (p baseProfile) GetImageAttribute(attributeName string) *attribute.ImageAttribute {
 	for _, a := range p.attributeSlice {
 		if a.Name == attributeName {
-			attribute, err := attribute.NewImage(a)
+			imageAttribute, err := attribute.NewImage(a)
 
 			if err == nil {
-				return attribute
+				return imageAttribute
 			}
 		}
 	}

--- a/profile/sandbox/anchor.go
+++ b/profile/sandbox/anchor.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// Initialises an anchor where the type is "SOURCE",
+// SourceAnchor initialises an anchor where the type is "SOURCE",
 // which has information about how the anchor was sourced.
 func SourceAnchor(subtype string, timestamp time.Time, value string) Anchor {
 	return Anchor{
@@ -16,7 +16,7 @@ func SourceAnchor(subtype string, timestamp time.Time, value string) Anchor {
 	}
 }
 
-// Initialises an anchor where the type is "VERIFIER",
+// VerifierAnchor initialises an anchor where the type is "VERIFIER",
 // which has information about how the anchor was verified.
 func VerifierAnchor(subtype string, timestamp time.Time, value string) Anchor {
 	return Anchor{

--- a/profile/sandbox/attribute.go
+++ b/profile/sandbox/attribute.go
@@ -22,7 +22,7 @@ func (attr Attribute) WithName(name string) Attribute {
 	return attr
 }
 
-// WithAnchor sets the value of a Sandbox Attribute
+// WithValue sets the value of a Sandbox Attribute
 func (attr Attribute) WithValue(value string) Attribute {
 	attr.Value = value
 	return attr

--- a/profile/sandbox/document_images.go
+++ b/profile/sandbox/document_images.go
@@ -6,7 +6,7 @@ import (
 	"github.com/getyoti/yoti-go-sdk/v3/profile/attribute"
 )
 
-// Attribute describes an attribute on a sandbox profile
+// DocumentImages describes a Document Images attribute on a sandbox profile
 type DocumentImages struct {
 	Images []attribute.Image
 }
@@ -33,7 +33,7 @@ func (d DocumentImages) WithPngImage(imageContent []byte) DocumentImages {
 	return d
 }
 
-// WithPngImage adds a JPEG image to the slice of document images
+// WithJpegImage adds a JPEG image to the slice of document images
 func (d DocumentImages) WithJpegImage(imageContent []byte) DocumentImages {
 	jpegImage := attribute.Image{
 		Type: attribute.ImageTypeJpeg,

--- a/profile/service.go
+++ b/profile/service.go
@@ -81,7 +81,7 @@ func handleSuccessfulResponse(responseBytes []byte, key *rsa.PrivateKey) (activi
 		id := parsedResponse.Receipt.RememberMeID
 
 		userProfile := newUserProfile(userAttributeList)
-		applicationProfile := NewApplicationProfile(applicationAttributeList)
+		applicationProfile := newApplicationProfile(applicationAttributeList)
 
 		var extraData *extra.Data
 		extraData, err = parseExtraData(&parsedResponse.Receipt, key, err)

--- a/profile/service_test.go
+++ b/profile/service_test.go
@@ -266,7 +266,6 @@ func TestProfileService_ShouldParseAndDecryptExtraDataContent(t *testing.T) {
 	pemBytes, err := ioutil.ReadFile("../test/test-key.pem")
 	assert.NilError(t, err)
 
-	attributeName := "attributeName"
 	dataEntries := make([]*yotiprotoshare.DataEntry, 0)
 	expiryDate := time.Now().UTC().AddDate(0, 0, 1)
 	thirdPartyAttributeDataEntry := test.CreateThirdPartyAttributeDataEntry(t, &expiryDate, []string{attributeName}, "tokenValue")
@@ -300,7 +299,6 @@ func TestProfileService_ShouldParseAndDecryptExtraDataContent(t *testing.T) {
 }
 
 func TestProfileService_ShouldCarryOnProcessingIfIssuanceTokenIsNotPresent(t *testing.T) {
-	var attributeName = "attributeName"
 	dataEntries := make([]*yotiprotoshare.DataEntry, 0)
 	expiryDate := time.Now().UTC().AddDate(0, 0, 1)
 	thirdPartyAttributeDataEntry := test.CreateThirdPartyAttributeDataEntry(t, &expiryDate, []string{attributeName}, "")

--- a/profile/service_test.go
+++ b/profile/service_test.go
@@ -276,7 +276,7 @@ func TestProfileService_ShouldParseAndDecryptExtraDataContent(t *testing.T) {
 		List: dataEntries,
 	}
 
-	extraDataContent := createExtraDataContent(t, pemBytes, protoExtraData, test.WrappedReceiptKey)
+	extraDataContent := createExtraDataContent(t, protoExtraData)
 
 	client := &mockHTTPClient{
 		do: func(*http.Request) (*http.Response, error) {
@@ -313,7 +313,7 @@ func TestProfileService_ShouldCarryOnProcessingIfIssuanceTokenIsNotPresent(t *te
 	pemBytes, err := ioutil.ReadFile("../test/test-key.pem")
 	assert.NilError(t, err)
 
-	extraDataContent := createExtraDataContent(t, pemBytes, protoExtraData, test.WrappedReceiptKey)
+	extraDataContent := createExtraDataContent(t, protoExtraData)
 
 	otherPartyProfileContent := "ChCZAib1TBm9Q5GYfFrS1ep9EnAwQB5shpAPWLBgZgFgt6bCG3S5qmZHhrqUbQr3yL6yeLIDwbM7x4nuT/MYp+LDXgmFTLQNYbDTzrEzqNuO2ZPn9Kpg+xpbm9XtP7ZLw3Ep2BCmSqtnll/OdxAqLb4DTN4/wWdrjnFC+L/oQEECu646"
 
@@ -368,7 +368,7 @@ func getValidKey() *rsa.PrivateKey {
 	return test.GetValidKey("../test/test-key.pem")
 }
 
-func createExtraDataContent(t *testing.T, pemBytes []byte, protoExtraData *yotiprotoshare.ExtraData, wrappedReceiptKey string) string {
+func createExtraDataContent(t *testing.T, protoExtraData *yotiprotoshare.ExtraData) string {
 	outBytes, err := proto.Marshal(protoExtraData)
 	assert.NilError(t, err)
 

--- a/profile/user_profile.go
+++ b/profile/user_profile.go
@@ -8,7 +8,7 @@ import (
 	"github.com/getyoti/yoti-go-sdk/v3/yotiprotoattr"
 )
 
-// Profile represents the details retrieved for a particular user. Consists of
+// UserProfile represents the details retrieved for a particular user. Consists of
 // Yoti attributes: a small piece of information about a Yoti user such as a
 // photo of the user or the user's date of birth.
 type UserProfile struct {

--- a/profile/user_profile.go
+++ b/profile/user_profile.go
@@ -149,14 +149,3 @@ func (p UserProfile) AgeVerifications() (out []attribute.AgeVerification, err er
 	}
 	return out, err
 }
-
-// GetProtobufAnchors gets the anchors associated with an attribute
-func GetProtobufAnchors(profile UserProfile, attributeName string) []*yotiprotoattr.Anchor {
-	for _, v := range profile.attributeSlice {
-		if v.Name == attributeName {
-			return v.Anchors
-		}
-	}
-
-	return nil
-}

--- a/profile/user_profile_test.go
+++ b/profile/user_profile_test.go
@@ -114,8 +114,8 @@ func TestProfile_GetApplicationAttribute(t *testing.T) {
 	}
 
 	appProfile := createProfileWithSingleAttribute(attr)
-	attribute := appProfile.GetAttribute(attributeName)
-	assert.Equal(t, attribute.Name(), attributeName)
+	applicationAttribute := appProfile.GetAttribute(attributeName)
+	assert.Equal(t, applicationAttribute.Name(), attributeName)
 }
 
 func TestProfile_GetApplicationName(t *testing.T) {
@@ -352,24 +352,24 @@ func TestProfile_GetAttribute_Undefined(t *testing.T) {
 }
 
 func TestProfile_GetAttribute_ReturnsNil(t *testing.T) {
-	result := UserProfile{
+	userProfile := UserProfile{
 		baseProfile{
 			attributeSlice: []*yotiprotoattr.Attribute{},
 		},
 	}
 
-	attribute := result.GetAttribute("attributeName")
+	result := userProfile.GetAttribute("attributeName")
 
-	assert.Assert(t, is.Nil(attribute))
+	assert.Assert(t, is.Nil(result))
 }
 
 func TestProfile_StringAttribute(t *testing.T) {
-	attributeName := consts.AttrNationality
+	nationalityName := consts.AttrNationality
 	attributeValueString := "value"
 	attributeValueBytes := []byte(attributeValueString)
 
 	var as = &yotiprotoattr.Attribute{
-		Name:        attributeName,
+		Name:        nationalityName,
 		Value:       attributeValueBytes,
 		ContentType: yotiprotoattr.ContentType_STRING,
 		Anchors:     []*yotiprotoattr.Anchor{},
@@ -383,11 +383,11 @@ func TestProfile_StringAttribute(t *testing.T) {
 }
 
 func TestProfile_AttributeProperty_RetrievesAttribute(t *testing.T) {
-	attributeName := consts.AttrSelfie
+	selfieName := consts.AttrSelfie
 	attributeValue := []byte("value")
 
 	var attributeImage = &yotiprotoattr.Attribute{
-		Name:        attributeName,
+		Name:        selfieName,
 		Value:       attributeValue,
 		ContentType: yotiprotoattr.ContentType_PNG,
 		Anchors:     []*yotiprotoattr.Anchor{},
@@ -396,23 +396,23 @@ func TestProfile_AttributeProperty_RetrievesAttribute(t *testing.T) {
 	result := createProfileWithSingleAttribute(attributeImage)
 	selfie := result.Selfie()
 
-	assert.Equal(t, selfie.Name(), attributeName)
+	assert.Equal(t, selfie.Name(), selfieName)
 	assert.DeepEqual(t, attributeValue, selfie.Value().Data)
 	assert.Equal(t, selfie.ContentType(), yotiprotoattr.ContentType_PNG.String())
 }
 
 func TestProfile_DocumentDetails_RetrievesAttribute(t *testing.T) {
-	attributeName := consts.AttrDocumentDetails
+	documentDetailsName := consts.AttrDocumentDetails
 	attributeValue := []byte("PASSPORT GBR 1234567")
 
-	var proto = &yotiprotoattr.Attribute{
-		Name:        attributeName,
+	var protoAttribute = &yotiprotoattr.Attribute{
+		Name:        documentDetailsName,
 		Value:       attributeValue,
 		ContentType: yotiprotoattr.ContentType_STRING,
 		Anchors:     make([]*yotiprotoattr.Anchor, 0),
 	}
 
-	result := createProfileWithSingleAttribute(proto)
+	result := createProfileWithSingleAttribute(protoAttribute)
 	documentDetails, err := result.DocumentDetails()
 	assert.NilError(t, err)
 
@@ -420,18 +420,18 @@ func TestProfile_DocumentDetails_RetrievesAttribute(t *testing.T) {
 }
 
 func TestProfile_DocumentImages_RetrievesAttribute(t *testing.T) {
-	attributeName := consts.AttrDocumentImages
+	documentImagesName := consts.AttrDocumentImages
 	attributeValue, err := proto.Marshal(&yotiprotoattr.MultiValue{})
 	assert.NilError(t, err)
 
-	proto := &yotiprotoattr.Attribute{
-		Name:        attributeName,
+	protoAttribute := &yotiprotoattr.Attribute{
+		Name:        documentImagesName,
 		Value:       attributeValue,
 		ContentType: yotiprotoattr.ContentType_MULTI_VALUE,
 		Anchors:     make([]*yotiprotoattr.Anchor, 0),
 	}
 
-	result := createProfileWithSingleAttribute(proto)
+	result := createProfileWithSingleAttribute(protoAttribute)
 	documentImages, err := result.DocumentImages()
 	assert.NilError(t, err)
 
@@ -439,18 +439,18 @@ func TestProfile_DocumentImages_RetrievesAttribute(t *testing.T) {
 }
 
 func TestProfile_AttributesReturnsNilWhenNotPresent(t *testing.T) {
-	attributeName := consts.AttrDocumentImages
+	documentImagesName := consts.AttrDocumentImages
 	attributeValue, err := proto.Marshal(&yotiprotoattr.MultiValue{})
 	assert.NilError(t, err)
 
-	proto := &yotiprotoattr.Attribute{
-		Name:        attributeName,
+	protoAttribute := &yotiprotoattr.Attribute{
+		Name:        documentImagesName,
 		Value:       attributeValue,
 		ContentType: yotiprotoattr.ContentType_MULTI_VALUE,
 		Anchors:     make([]*yotiprotoattr.Anchor, 0),
 	}
 
-	result := createProfileWithSingleAttribute(proto)
+	result := createProfileWithSingleAttribute(protoAttribute)
 
 	DoB, err := result.DateOfBirth()
 	assert.Check(t, DoB == nil)
@@ -491,11 +491,11 @@ func TestMissingPostalAddress_UsesFormattedAddress(t *testing.T) {
 }
 
 func TestAttributeImage_Image_Png(t *testing.T) {
-	attributeName := consts.AttrSelfie
+	selfieName := consts.AttrSelfie
 	byteValue := []byte("value")
 
 	var attributeImage = &yotiprotoattr.Attribute{
-		Name:        attributeName,
+		Name:        selfieName,
 		Value:       byteValue,
 		ContentType: yotiprotoattr.ContentType_PNG,
 		Anchors:     []*yotiprotoattr.Anchor{},
@@ -508,11 +508,11 @@ func TestAttributeImage_Image_Png(t *testing.T) {
 }
 
 func TestAttributeImage_Image_Jpeg(t *testing.T) {
-	attributeName := consts.AttrSelfie
+	selfieName := consts.AttrSelfie
 	byteValue := []byte("value")
 
 	var attributeImage = &yotiprotoattr.Attribute{
-		Name:        attributeName,
+		Name:        selfieName,
 		Value:       byteValue,
 		ContentType: yotiprotoattr.ContentType_JPEG,
 		Anchors:     []*yotiprotoattr.Anchor{},
@@ -525,11 +525,11 @@ func TestAttributeImage_Image_Jpeg(t *testing.T) {
 }
 
 func TestAttributeImage_Image_Default(t *testing.T) {
-	attributeName := consts.AttrSelfie
+	selfieName := consts.AttrSelfie
 	byteValue := []byte("value")
 
 	var attributeImage = &yotiprotoattr.Attribute{
-		Name:        attributeName,
+		Name:        selfieName,
 		Value:       byteValue,
 		ContentType: yotiprotoattr.ContentType_PNG,
 		Anchors:     []*yotiprotoattr.Anchor{},
@@ -540,11 +540,11 @@ func TestAttributeImage_Image_Default(t *testing.T) {
 	assert.DeepEqual(t, selfie.Value().Data, byteValue)
 }
 func TestAttributeImage_Base64Selfie_Png(t *testing.T) {
-	attributeName := consts.AttrSelfie
+	selfieName := consts.AttrSelfie
 	imageBytes := []byte("value")
 
 	var attributeImage = &yotiprotoattr.Attribute{
-		Name:        attributeName,
+		Name:        selfieName,
 		Value:       imageBytes,
 		ContentType: yotiprotoattr.ContentType_PNG,
 		Anchors:     []*yotiprotoattr.Anchor{},
@@ -562,11 +562,11 @@ func TestAttributeImage_Base64Selfie_Png(t *testing.T) {
 }
 
 func TestAttributeImage_Base64URL_Jpeg(t *testing.T) {
-	attributeName := consts.AttrSelfie
+	selfieName := consts.AttrSelfie
 	imageBytes := []byte("value")
 
 	var attributeImage = &yotiprotoattr.Attribute{
-		Name:        attributeName,
+		Name:        selfieName,
 		Value:       imageBytes,
 		ContentType: yotiprotoattr.ContentType_JPEG,
 		Anchors:     []*yotiprotoattr.Anchor{},

--- a/requests/signed_message.go
+++ b/requests/signed_message.go
@@ -101,7 +101,7 @@ func (msg SignedRequest) WithPemFile(in []byte) SignedRequest {
 	return msg
 }
 
-func (msg *SignedRequest) addParametersToEndpoint() (endpoint string, err error) {
+func (msg *SignedRequest) addParametersToEndpoint() (string, error) {
 	if msg.Params == nil {
 		msg.Params = make(map[string]string)
 	}
@@ -117,7 +117,7 @@ func (msg *SignedRequest) addParametersToEndpoint() (endpoint string, err error)
 		msg.Params["timestamp"] = getTimestamp()
 	}
 
-	endpoint = msg.Endpoint
+	endpoint := msg.Endpoint
 	if !strings.Contains(endpoint, "?") {
 		endpoint = endpoint + "?"
 	} else {
@@ -133,7 +133,8 @@ func (msg *SignedRequest) addParametersToEndpoint() (endpoint string, err error)
 		endpoint = fmt.Sprintf(formatString, endpoint, param, value)
 		firstParam = false
 	}
-	return
+
+	return endpoint, nil
 }
 
 func (msg *SignedRequest) generateDigest(endpoint string) (digest string) {

--- a/util/conversion.go
+++ b/util/conversion.go
@@ -12,7 +12,7 @@ func Base64ToBytes(base64Str string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(base64Str)
 }
 
-// UrlSafe Base64 uses '-' and '_' instead of '+' and '/' respectively so it can be passed
+// UrlSafeBase64ToBytes UrlSafe Base64 uses '-' and '_', instead of '+' and '/' respectively, so it can be passed
 // as a url parameter without extra encoding.
 func UrlSafeBase64ToBytes(urlSafeBase64 string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(urlSafeBase64)


### PR DESCRIPTION
- Correct godoc string prefixes (or make unexported if not necessary)
- Rename variable names so they don't shadow other names, or packages
- Remove unused functions/variables, change empty slice initialisation (https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices)