### PR TITLE
NA: Correct "X-Yoti-SDK-Version" request header

### DIFF
--- a/requests/signed_message.go
+++ b/requests/signed_message.go
@@ -200,7 +200,7 @@ func (msg SignedRequest) Request() (request *http.Request, err error) {
 	}
 	request.Header.Add("X-Yoti-Auth-Digest", signedDigest)
 	request.Header.Add("X-Yoti-SDK", consts.SDKIdentifier)
-	request.Header.Add("X-Yoti-SDK-Verson", consts.SDKVersionIdentifier)
+	request.Header.Add("X-Yoti-SDK-Version", consts.SDKVersionIdentifier)
 
 	for key, values := range msg.Headers {
 		for _, value := range values {


### PR DESCRIPTION
This would explain why our metrics are a bit off for Go versions...