### PR TITLE
SDK-1690: Test Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ env:
     - GO111MODULE=on
 
 jobs:
-  allow_failures:
-    - go: master
   include:
     - &test
       stage: Test
@@ -35,8 +33,6 @@ jobs:
       go: "1.14.x"
     - <<: *test
       go: "1.x"
-    - <<: *test
-      go: "master"
 
     - stage: Analysis
       name: Sonarcloud

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Build Status](https://travis-ci.com/getyoti/yoti-go-sdk.svg?branch=master)](https://travis-ci.com/getyoti/yoti-go-sdk)
 [![GoDoc](https://godoc.org/github.com/getyoti/yoti-go-sdk?status.svg)](https://godoc.org/github.com/getyoti/yoti-go-sdk)
 [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://github.com/getyoti/yoti-go-sdk/blob/master/LICENSE.md)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=getyoti%3Ago&metric=coverage)](https://sonarcloud.io/dashboard?id=getyoti%3Ago)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=getyoti%3Ago&metric=bugs)](https://sonarcloud.io/dashboard?id=getyoti%3Ago)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=getyoti%3Ago&metric=code_smells)](https://sonarcloud.io/dashboard?id=getyoti%3Ago)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=getyoti%3Ago&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=getyoti%3Ago)
 
 Welcome to the Yoti Go SDK. This repo contains the tools and step by step instructions you need to quickly integrate your Go back-end with Yoti so that your users can share their identity details with your application in a secure and trusted way.
 

--- a/aml/service_test.go
+++ b/aml/service_test.go
@@ -2,6 +2,7 @@ package aml
 
 import (
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -21,6 +22,25 @@ func (mock *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
 		return mock.do(request)
 	}
 	return nil, nil
+}
+
+type mockReadCloser struct {
+	read  func(p []byte) (n int, err error)
+	close func() error
+}
+
+func (mock *mockReadCloser) Read(p []byte) (n int, err error) {
+	if mock.read != nil {
+		return mock.read(p)
+	}
+	return 0, nil
+}
+
+func (mock *mockReadCloser) Close() error {
+	if mock.close != nil {
+		return mock.close()
+	}
+	return nil
 }
 
 func TestPerformCheck_WithInvalidJSON(t *testing.T) {
@@ -79,6 +99,43 @@ func TestPerformCheck_Unsuccessful(t *testing.T) {
 		Temporary() bool
 	})
 	assert.Check(t, temporary && tempError.Temporary())
+}
+
+func TestPerformCheck_ShouldReturnMissingBaseURLError(t *testing.T) {
+	key := getValidKey()
+
+	client := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+			}, nil
+		},
+	}
+
+	_, err := PerformCheck(client, createStandardProfile(), "clientSdkId", "", key)
+	assert.ErrorContains(t, err, "missing BaseURL")
+}
+
+func TestPerformCheck_ShouldReturnBodyError(t *testing.T) {
+	key := getValidKey()
+
+	body := &mockReadCloser{
+		read: func(p []byte) (n int, err error) {
+			return 0, errors.New("some read error")
+		},
+	}
+
+	client := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       body,
+			}, nil
+		},
+	}
+
+	_, err := PerformCheck(client, createStandardProfile(), "clientSdkId", "https://apiUrl", key)
+	assert.ErrorContains(t, err, "some read error")
 }
 
 func getValidKey() *rsa.PrivateKey {

--- a/cryptoutil/crypto_utils_test.go
+++ b/cryptoutil/crypto_utils_test.go
@@ -21,6 +21,7 @@ import (
 const (
 	wrappedKey       = "kyHPjq2+Y48cx+9yS/XzmW09jVUylSdhbP+3Q9Tc9p6bCEnyfa8vj38AIu744RzzE+Dc4qkSF21VfzQKtJVILfOXu5xRc7MYa5k3zWhjiesg/gsrv7J4wDyyBpHIJB8TWXnubYMbSYQJjlsfwyxE9kGe0YI08pRo2Tiht0bfR5Z/YrhAk4UBvjp84D+oyug/1mtGhKphA4vgPhQ9/y2wcInYxju7Q6yzOsXGaRUXR38Tn2YmY9OBgjxiTnhoYJFP1X9YJkHeWMW0vxF1RHxgIVrpf7oRzdY1nq28qzRg5+wC7cjRpS2i/CKUAo0oVG4pbpXsaFhaTewStVC7UFtA77JHb3EnF4HcSWMnK5FM7GGkL9MMXQenh11NZHKPWXpux0nLZ6/vwffXZfsiyTIcFL/NajGN8C/hnNBljoQ+B3fzWbjcq5ueUOPwARZ1y38W83UwMynzkud/iEdHLaZIu4qUCRkfSxJg7Dc+O9/BdiffkOn2GyFmNjVeq754DCUypxzMkjYxokedN84nK13OU4afVyC7t5DDxAK/MqAc69NCBRLqMi5f8BMeOZfMcSWPGC9a2Qu8VgG125TuZT4+wIykUhGyj3Bb2/fdPsxwuKFR+E0uqs0ZKvcv1tkNRRtKYBqTacgGK9Yoehg12cyLrITLdjU1fmIDn4/vrhztN5w="
 	b64EncryptedData = "ChCZAib1TBm9Q5GYfFrS1ep9EnAwQB5shpAPWLBgZgFgt6bCG3S5qmZHhrqUbQr3yL6yeLIDwbM7x4nuT/MYp+LDXgmFTLQNYbDTzrEzqNuO2ZPn9Kpg+xpbm9XtP7ZLw3Ep2BCmSqtnll/OdxAqLb4DTN4/wWdrjnFC+L/oQEECu646"
+	encryptedToken   = "b6H19bUCJhwh6WqQX_sEHWX9RP-A_ANr1fkApwA4Dp2nJQFAjrF9e6YCXhNBpAIhfHnN0iXubyXxXZMNwNMSQ5VOxkqiytrvPykfKQWHC6ypSbfy0ex8ihndaAXG5FUF-qcU8QaFPMy6iF3x0cxnY0Ij0kZj0Ng2t6oiNafb7AhT-VGXxbFbtZu1QF744PpWMuH0LVyBsAa5N5GJw2AyBrnOh67fWMFDKTJRziP5qCW2k4h5vJfiYr_EOiWKCB1d_zINmUm94ZffGXxcDAkq-KxhN1ZuNhGlJ2fKcFh7KxV0BqlUWPsIEiwS0r9CJ2o1VLbEs2U_hCEXaqseEV7L29EnNIinEPVbL4WR7vkF6zQCbK_cehlk2Qwda-VIATqupRO5grKZN78R9lBitvgilDaoE7JB_VFcPoljGQ48kX0wje1mviX4oJHhuO8GdFITS5LTbojGVQWT7LUNgAUe0W0j-FLHYYck3v84OhWTqads5_jmnnLkp9bdJSRuJF0e8pNdePnn2lgF-GIcyW_0kyGVqeXZrIoxnObLpF-YeUteRBKTkSGFcy7a_V_DLiJMPmH8UXDLOyv8TVt3ppzqpyUrLN2JVMbL5wZ4oriL2INEQKvw_boDJjZDGeRlu5m1y7vGDNBRDo64-uQM9fRUULPw-YkABNwC0DeShswzT00="
 )
 
 func TestCryptoUtil_ParseRSAKey(t *testing.T) {
@@ -137,18 +138,12 @@ func TestCryptoutil_pkcs7Unpad_CiphertextPaddingIncorrect(t *testing.T) {
 }
 
 func TestCryptoutil_DecryptToken(t *testing.T) {
-	_, err := DecryptToken(
-		"b6H19bUCJhwh6WqQX_sEHWX9RP-A_ANr1fkApwA4Dp2nJQFAjrF9e6YCXhNBpAIhfHnN0iXubyXxXZMNwNMSQ5VOxkqiytrvPykfKQWHC6ypSbfy0ex8ihndaAXG5FUF-qcU8QaFPMy6iF3x0cxnY0Ij0kZj0Ng2t6oiNafb7AhT-VGXxbFbtZu1QF744PpWMuH0LVyBsAa5N5GJw2AyBrnOh67fWMFDKTJRziP5qCW2k4h5vJfiYr_EOiWKCB1d_zINmUm94ZffGXxcDAkq-KxhN1ZuNhGlJ2fKcFh7KxV0BqlUWPsIEiwS0r9CJ2o1VLbEs2U_hCEXaqseEV7L29EnNIinEPVbL4WR7vkF6zQCbK_cehlk2Qwda-VIATqupRO5grKZN78R9lBitvgilDaoE7JB_VFcPoljGQ48kX0wje1mviX4oJHhuO8GdFITS5LTbojGVQWT7LUNgAUe0W0j-FLHYYck3v84OhWTqads5_jmnnLkp9bdJSRuJF0e8pNdePnn2lgF-GIcyW_0kyGVqeXZrIoxnObLpF-YeUteRBKTkSGFcy7a_V_DLiJMPmH8UXDLOyv8TVt3ppzqpyUrLN2JVMbL5wZ4oriL2INEQKvw_boDJjZDGeRlu5m1y7vGDNBRDo64-uQM9fRUULPw-YkABNwC0DeShswzT00=",
-		getKey(),
-	)
+	_, err := DecryptToken(encryptedToken, getKey())
 	assert.NilError(t, err)
 }
 
 func TestCryptoutil_DecryptToken_InvalidToken(t *testing.T) {
-	_, err := DecryptToken(
-		"c29tZS10b2tlbg==",
-		getKey(),
-	)
+	_, err := DecryptToken("c29tZS10b2tlbg==", getKey())
 	assert.Error(t, err, "crypto/rsa: decryption error")
 }
 

--- a/cryptoutil/crypto_utils_test.go
+++ b/cryptoutil/crypto_utils_test.go
@@ -6,11 +6,21 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/getyoti/yoti-go-sdk/v3/file"
+	"github.com/getyoti/yoti-go-sdk/v3/util"
+	"github.com/getyoti/yoti-go-sdk/v3/yotiprotocom"
+	"github.com/golang/protobuf/proto"
 	"gotest.tools/v3/assert"
+)
+
+const (
+	wrappedKey       = "kyHPjq2+Y48cx+9yS/XzmW09jVUylSdhbP+3Q9Tc9p6bCEnyfa8vj38AIu744RzzE+Dc4qkSF21VfzQKtJVILfOXu5xRc7MYa5k3zWhjiesg/gsrv7J4wDyyBpHIJB8TWXnubYMbSYQJjlsfwyxE9kGe0YI08pRo2Tiht0bfR5Z/YrhAk4UBvjp84D+oyug/1mtGhKphA4vgPhQ9/y2wcInYxju7Q6yzOsXGaRUXR38Tn2YmY9OBgjxiTnhoYJFP1X9YJkHeWMW0vxF1RHxgIVrpf7oRzdY1nq28qzRg5+wC7cjRpS2i/CKUAo0oVG4pbpXsaFhaTewStVC7UFtA77JHb3EnF4HcSWMnK5FM7GGkL9MMXQenh11NZHKPWXpux0nLZ6/vwffXZfsiyTIcFL/NajGN8C/hnNBljoQ+B3fzWbjcq5ueUOPwARZ1y38W83UwMynzkud/iEdHLaZIu4qUCRkfSxJg7Dc+O9/BdiffkOn2GyFmNjVeq754DCUypxzMkjYxokedN84nK13OU4afVyC7t5DDxAK/MqAc69NCBRLqMi5f8BMeOZfMcSWPGC9a2Qu8VgG125TuZT4+wIykUhGyj3Bb2/fdPsxwuKFR+E0uqs0ZKvcv1tkNRRtKYBqTacgGK9Yoehg12cyLrITLdjU1fmIDn4/vrhztN5w="
+	b64EncryptedData = "ChCZAib1TBm9Q5GYfFrS1ep9EnAwQB5shpAPWLBgZgFgt6bCG3S5qmZHhrqUbQr3yL6yeLIDwbM7x4nuT/MYp+LDXgmFTLQNYbDTzrEzqNuO2ZPn9Kpg+xpbm9XtP7ZLw3Ep2BCmSqtnll/OdxAqLb4DTN4/wWdrjnFC+L/oQEECu646"
 )
 
 func TestCryptoUtil_ParseRSAKey(t *testing.T) {
@@ -59,12 +69,40 @@ VGVzdCBTdHJpbmc=
 	assert.Error(t, err, "invalid Key: bad RSA private key")
 }
 
-func TestCryptoutil_decipherAes_EmptyCiphertextShouldError(t *testing.T) {
+func TestCryptoutil_ParseRSAKey_InvalidShouldFail(t *testing.T) {
+	testPEM := []byte{}
+
+	_, err := ParseRSAKey(testPEM)
+
+	assert.Error(t, err, "invalid Key: not PEM-encoded")
+}
+
+func TestCryptoutil_DecipherAes(t *testing.T) {
+	unwrappedKey, err := UnwrapKey(wrappedKey, getKey())
+	if err != nil {
+		return
+	}
+
+	encryptedBytes, err := util.Base64ToBytes(b64EncryptedData)
+	if err != nil || len(encryptedBytes) == 0 {
+		assert.NilError(t, err)
+	}
+	encryptedData := &yotiprotocom.EncryptedData{}
+	err = proto.Unmarshal(encryptedBytes, encryptedData)
+	assert.NilError(t, err)
+
+	bytes, err := DecipherAes(unwrappedKey, encryptedData.Iv, encryptedData.CipherText)
+	assert.NilError(t, err)
+	assert.Check(t, bytes != nil)
+	fmt.Println(string(bytes))
+}
+
+func TestCryptoutil_DecipherAes_EmptyCiphertextShouldError(t *testing.T) {
 	_, err := DecipherAes([]byte{}, []byte{}, []byte{})
 	assert.Check(t, err != nil)
 }
 
-func TestCryptoutil_decipherAes_CiphertextNotMatchingBlocksizeShouldError(t *testing.T) {
+func TestCryptoutil_DecipherAes_CiphertextNotMatchingBlocksizeShouldError(t *testing.T) {
 	_, err := DecipherAes(
 		make([]byte, 16),
 		[]byte{},
@@ -98,12 +136,49 @@ func TestCryptoutil_pkcs7Unpad_CiphertextPaddingIncorrect(t *testing.T) {
 	assert.Error(t, err, "ciphertext is not padded with PKCS#7 padding")
 }
 
-func TestCryptoutil_decryptToken_InvalidBase64ShouldError(t *testing.T) {
+func TestCryptoutil_DecryptToken(t *testing.T) {
+	_, err := DecryptToken(
+		"b6H19bUCJhwh6WqQX_sEHWX9RP-A_ANr1fkApwA4Dp2nJQFAjrF9e6YCXhNBpAIhfHnN0iXubyXxXZMNwNMSQ5VOxkqiytrvPykfKQWHC6ypSbfy0ex8ihndaAXG5FUF-qcU8QaFPMy6iF3x0cxnY0Ij0kZj0Ng2t6oiNafb7AhT-VGXxbFbtZu1QF744PpWMuH0LVyBsAa5N5GJw2AyBrnOh67fWMFDKTJRziP5qCW2k4h5vJfiYr_EOiWKCB1d_zINmUm94ZffGXxcDAkq-KxhN1ZuNhGlJ2fKcFh7KxV0BqlUWPsIEiwS0r9CJ2o1VLbEs2U_hCEXaqseEV7L29EnNIinEPVbL4WR7vkF6zQCbK_cehlk2Qwda-VIATqupRO5grKZN78R9lBitvgilDaoE7JB_VFcPoljGQ48kX0wje1mviX4oJHhuO8GdFITS5LTbojGVQWT7LUNgAUe0W0j-FLHYYck3v84OhWTqads5_jmnnLkp9bdJSRuJF0e8pNdePnn2lgF-GIcyW_0kyGVqeXZrIoxnObLpF-YeUteRBKTkSGFcy7a_V_DLiJMPmH8UXDLOyv8TVt3ppzqpyUrLN2JVMbL5wZ4oriL2INEQKvw_boDJjZDGeRlu5m1y7vGDNBRDo64-uQM9fRUULPw-YkABNwC0DeShswzT00=",
+		getKey(),
+	)
+	assert.NilError(t, err)
+}
+
+func TestCryptoutil_DecryptToken_InvalidToken(t *testing.T) {
+	_, err := DecryptToken(
+		"c29tZS10b2tlbg==",
+		getKey(),
+	)
+	assert.Error(t, err, "crypto/rsa: decryption error")
+}
+
+func TestCryptoutil_DecryptToken_InvalidBase64ShouldError(t *testing.T) {
 	_, err := DecryptToken("Not a Token", nil)
 	assert.Check(t, err != nil)
 }
 
-func TestCryptoutil_unwrapKey_InvalidBase64ShouldError(t *testing.T) {
+func TestCryptoutil_UnwrapKey(t *testing.T) {
+	unwrappedKey, err := UnwrapKey(wrappedKey, getKey())
+
+	assert.NilError(t, err)
+	assert.Check(t, unwrappedKey != nil)
+}
+
+func TestCryptoutil_UnwrapKey_InvalidBase64ShouldError(t *testing.T) {
 	_, err := UnwrapKey("Not b64 encoded", nil)
 	assert.Check(t, err != nil)
+}
+
+func getKey() (key *rsa.PrivateKey) {
+	keyBytes, err := ioutil.ReadFile("../test/test-key.pem")
+	if err != nil {
+		panic("Error reading the test key: " + err.Error())
+	}
+
+	key, err = ParseRSAKey(keyBytes)
+	if err != nil {
+		panic("Error parsing the test key: " + err.Error())
+	}
+
+	return key
 }

--- a/dynamic/policy_builder_test.go
+++ b/dynamic/policy_builder_test.go
@@ -20,6 +20,26 @@ func ExamplePolicyBuilder_WithFamilyName() {
 	// Output: {"name":"family_name"}
 }
 
+func ExamplePolicyBuilder_WithDocumentDetails() {
+	policy, err := (&PolicyBuilder{}).WithDocumentDetails().Build()
+	if err != nil {
+		return
+	}
+	data, _ := policy.attributes[0].MarshalJSON()
+	fmt.Println(string(data))
+	// Output: {"name":"document_details"}
+}
+
+func ExamplePolicyBuilder_WithDocumentImages() {
+	policy, err := (&PolicyBuilder{}).WithDocumentImages().Build()
+	if err != nil {
+		return
+	}
+	data, _ := policy.attributes[0].MarshalJSON()
+	fmt.Println(string(data))
+	// Output: {"name":"document_images"}
+}
+
 func ExamplePolicyBuilder_WithSelfie() {
 	policy, err := (&PolicyBuilder{}).WithSelfie().Build()
 	if err != nil {

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -6,6 +6,11 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestFile_ReadFile(t *testing.T) {
+	_, err := ReadFile("../test/test-key.pem")
+	assert.NilError(t, err)
+}
+
 func TestFile_ReadFile_ShouldFailForFileNotFound(t *testing.T) {
 	MissingFileName := "/tmp/file_not_found"
 	_, err := ReadFile(MissingFileName)

--- a/profile/attribute/age_verifications.go
+++ b/profile/attribute/age_verifications.go
@@ -16,19 +16,19 @@ type AgeVerification struct {
 	Attribute *yotiprotoattr.Attribute
 }
 
-// New constructs an AgeVerification from a protobuffer
-func (AgeVerification) New(attr *yotiprotoattr.Attribute) (value AgeVerification, err error) {
+// NewAgeVerification constructs an AgeVerification from a protobuffer
+func NewAgeVerification(attr *yotiprotoattr.Attribute) (verification AgeVerification, err error) {
 	split := strings.Split(attr.Name, ":")
-	value.Age, err = strconv.Atoi(split[1])
-	value.CheckType = split[0]
+	verification.Age, err = strconv.Atoi(split[1])
+	verification.CheckType = split[0]
 
 	if string(attr.Value) == "true" {
-		value.Result = true
+		verification.Result = true
 	} else {
-		value.Result = false
+		verification.Result = false
 	}
 
-	value.Attribute = attr
+	verification.Attribute = attr
 
 	return
 }

--- a/profile/attribute/age_verifications_test.go
+++ b/profile/attribute/age_verifications_test.go
@@ -1,0 +1,42 @@
+package attribute
+
+import (
+	"testing"
+
+	"github.com/getyoti/yoti-go-sdk/v3/yotiprotoattr"
+	"gotest.tools/v3/assert"
+)
+
+func TestNewAgeVerification_ValueTrue(t *testing.T) {
+	attribute := &yotiprotoattr.Attribute{
+		Name:        "age_over:18",
+		Value:       []byte("true"),
+		ContentType: yotiprotoattr.ContentType_STRING,
+		Anchors:     []*yotiprotoattr.Anchor{},
+	}
+
+	ageVerification, err := NewAgeVerification(attribute)
+
+	assert.NilError(t, err)
+
+	assert.Equal(t, ageVerification.Age, 18)
+	assert.Equal(t, ageVerification.CheckType, "age_over")
+	assert.Equal(t, ageVerification.Result, true)
+}
+
+func TestNewAgeVerification_ValueFalse(t *testing.T) {
+	attribute := &yotiprotoattr.Attribute{
+		Name:        "age_under:30",
+		Value:       []byte("false"),
+		ContentType: yotiprotoattr.ContentType_STRING,
+		Anchors:     []*yotiprotoattr.Anchor{},
+	}
+
+	ageVerification, err := NewAgeVerification(attribute)
+
+	assert.NilError(t, err)
+
+	assert.Equal(t, ageVerification.Age, 30)
+	assert.Equal(t, ageVerification.CheckType, "age_under")
+	assert.Equal(t, ageVerification.Result, false)
+}

--- a/profile/receipt_parser.go
+++ b/profile/receipt_parser.go
@@ -11,28 +11,9 @@ import (
 )
 
 func parseApplicationProfile(receipt *receiptDO, key *rsa.PrivateKey) (result *yotiprotoattr.AttributeList, err error) {
-	var unwrappedKey []byte
-	if unwrappedKey, err = cryptoutil.UnwrapKey(receipt.WrappedReceiptKey, key); err != nil {
+	decipheredBytes, err := parseEncryptedProto(receipt, receipt.ProfileContent, key)
+	if err != nil {
 		return
-	}
-
-	if receipt.ProfileContent == "" {
-		return
-	}
-
-	var profileContentBytes []byte
-	if profileContentBytes, err = util.Base64ToBytes(receipt.ProfileContent); err != nil {
-		return
-	}
-
-	encryptedData := &yotiprotocom.EncryptedData{}
-	if err = proto.Unmarshal(profileContentBytes, encryptedData); err != nil {
-		return nil, err
-	}
-
-	var decipheredBytes []byte
-	if decipheredBytes, err = cryptoutil.DecipherAes(unwrappedKey, encryptedData.Iv, encryptedData.CipherText); err != nil {
-		return nil, err
 	}
 
 	attributeList := &yotiprotoattr.AttributeList{}

--- a/profile/sandbox/tokenrequest_test.go
+++ b/profile/sandbox/tokenrequest_test.go
@@ -1,7 +1,9 @@
 package sandbox
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 )
 
@@ -10,6 +12,14 @@ func AnchorList() []Anchor {
 		SourceAnchor("", time.Unix(1234567890, 0), ""),
 		VerifierAnchor("", time.Unix(1234567890, 0), ""),
 	}
+}
+
+func ExampleTokenRequest_WithRememberMeID() {
+	time.Local = time.UTC
+	tokenRequest := TokenRequest{}.WithRememberMeID("some-remember-me-id")
+
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"some-remember-me-id","profile_attributes":null}
 }
 
 func ExampleTokenRequest_WithAttribute() {
@@ -23,8 +33,8 @@ func ExampleTokenRequest_WithAttribute() {
 		"Value",
 		nil,
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{AttributeName1 Value   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]} {AttributeName2 Value   []}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"AttributeName1","value":"Value","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]},{"name":"AttributeName2","value":"Value","derivation":"","optional":"","anchors":[]}]}
 }
 
 func ExampleTokenRequest_WithAttributeStruct() {
@@ -36,8 +46,8 @@ func ExampleTokenRequest_WithAttributeStruct() {
 
 	time.Local = time.UTC
 	tokenRequest := TokenRequest{}.WithAttributeStruct(attribute)
-	fmt.Println(tokenRequest)
-	// Output: { [{AttributeName3 Value3   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"AttributeName3","value":"Value3","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithGivenNames() {
@@ -46,8 +56,8 @@ func ExampleTokenRequest_WithGivenNames() {
 		"Value",
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{given_names Value   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"given_names","value":"Value","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithFamilyName() {
@@ -56,8 +66,8 @@ func ExampleTokenRequest_WithFamilyName() {
 		"Value",
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{family_name Value   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"family_name","value":"Value","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithFullName() {
@@ -66,15 +76,15 @@ func ExampleTokenRequest_WithFullName() {
 		"Value",
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{full_name Value   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"full_name","value":"Value","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithDateOfBirth() {
 	time.Local = time.UTC
 	tokenRequest := TokenRequest{}.WithDateOfBirth(time.Unix(1234567890, 0), AnchorList())
-	fmt.Println(tokenRequest)
-	// Output: { [{date_of_birth 2009-02-13   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"date_of_birth","value":"2009-02-13","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithAgeVerification() {
@@ -84,36 +94,36 @@ func ExampleTokenRequest_WithAgeVerification() {
 		Derivation{}.AgeOver(18),
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{date_of_birth 2009-02-13 age_over:18  [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"date_of_birth","value":"2009-02-13","derivation":"age_over:18","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithGender() {
 	time.Local = time.UTC
 	tokenRequest := TokenRequest{}.WithGender("male", AnchorList())
-	fmt.Println(tokenRequest)
-	// Output: { [{gender male   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"gender","value":"male","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithPhoneNumber() {
 	time.Local = time.UTC
 	tokenRequest := TokenRequest{}.WithPhoneNumber("00005550000", AnchorList())
-	fmt.Println(tokenRequest)
-	// Output: { [{phone_number 00005550000   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"phone_number","value":"00005550000","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithNationality() {
 	time.Local = time.UTC
 	tokenRequest := TokenRequest{}.WithNationality("Value", AnchorList())
-	fmt.Println(tokenRequest)
-	// Output: { [{nationality Value   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"nationality","value":"Value","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithPostalAddress() {
 	time.Local = time.UTC
 	tokenRequest := TokenRequest{}.WithPostalAddress("Value", AnchorList())
-	fmt.Println(tokenRequest)
-	// Output: { [{postal_address Value   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"postal_address","value":"Value","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithStructuredPostalAddress() {
@@ -124,8 +134,8 @@ func ExampleTokenRequest_WithStructuredPostalAddress() {
 		},
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{structured_postal_address {"FormattedAddressLine":"Value"}   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"structured_postal_address","value":"{\"FormattedAddressLine\":\"Value\"}","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithSelfie() {
@@ -134,8 +144,8 @@ func ExampleTokenRequest_WithSelfie() {
 		[]byte{0xDE, 0xAD, 0xBE, 0xEF},
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{selfie 3q2+7w==   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"selfie","value":"3q2+7w==","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithBase64Selfie() {
@@ -144,15 +154,15 @@ func ExampleTokenRequest_WithBase64Selfie() {
 		"3q2+7w==",
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{selfie 3q2+7w==   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"selfie","value":"3q2+7w==","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithEmailAddress() {
 	time.Local = time.UTC
 	tokenRequest := TokenRequest{}.WithEmailAddress("user@example.com", AnchorList())
-	fmt.Println(tokenRequest)
-	// Output: { [{email_address user@example.com   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"email_address","value":"user@example.com","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithDocumentDetails() {
@@ -161,8 +171,8 @@ func ExampleTokenRequest_WithDocumentDetails() {
 		"DRIVING_LICENCE - abc1234",
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{document_details DRIVING_LICENCE - abc1234   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"document_details","value":"DRIVING_LICENCE - abc1234","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
 }
 
 func ExampleTokenRequest_WithDocumentImages() {
@@ -174,6 +184,16 @@ func ExampleTokenRequest_WithDocumentImages() {
 		documentImages,
 		AnchorList(),
 	)
-	fmt.Println(tokenRequest)
-	// Output: { [{document_images data:image/png;base64,3q2+7w==&data:image/jpeg;base64,3q2+7w==   [{SOURCE   2009-02-13 23:31:30 +0000 UTC} {VERIFIER   2009-02-13 23:31:30 +0000 UTC}]}]}
+	printJson(tokenRequest)
+	// Output: {"remember_me_id":"","profile_attributes":[{"name":"document_images","value":"data:image/png;base64,3q2+7w==\u0026data:image/jpeg;base64,3q2+7w==","derivation":"","optional":"","anchors":[{"type":"SOURCE","value":"","sub_type":"","timestamp":1234567890000},{"type":"VERIFIER","value":"","sub_type":"","timestamp":1234567890000}]}]}
+}
+
+func printJson(value interface{}) {
+	marshalledJSON, err := json.Marshal(value)
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(marshalledJSON))
 }

--- a/profile/sandbox/tokenrequest_test.go
+++ b/profile/sandbox/tokenrequest_test.go
@@ -3,7 +3,6 @@ package sandbox
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 )
 
@@ -191,7 +190,7 @@ func ExampleTokenRequest_WithDocumentImages() {
 func printJson(value interface{}) {
 	marshalledJSON, err := json.Marshal(value)
 	if err != nil {
-		fmt.Fprintf(os.Stdout, "error: %s", err.Error())
+		fmt.Printf("error: %s", err.Error())
 		return
 	}
 

--- a/profile/user_profile.go
+++ b/profile/user_profile.go
@@ -140,7 +140,7 @@ func (p UserProfile) AgeVerifications() (out []attribute.AgeVerification, err er
 	for _, a := range p.attributeSlice {
 		if strings.HasPrefix(a.Name, ageUnderString) ||
 			strings.HasPrefix(a.Name, ageOverString) {
-			verification, err := attribute.AgeVerification{}.New(a)
+			verification, err := attribute.NewAgeVerification(a)
 			if err != nil {
 				return nil, err
 			}

--- a/requests/request_test.go
+++ b/requests/request_test.go
@@ -1,6 +1,7 @@
 package requests
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -8,13 +9,78 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestYotiClient_NilHTTPClientShouldUse10sTimeout(t *testing.T) {
+type mockHTTPClient struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (mock *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	if mock.do != nil {
+		return mock.do(request)
+	}
+	return nil, nil
+}
+
+func TestExecute_Success(t *testing.T) {
+	client := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+			}, nil
+		},
+	}
+
+	request := &http.Request{
+		Method: http.MethodGet,
+	}
+
+	response, err := Execute(client, request)
+
+	assert.NilError(t, err)
+	assert.Equal(t, response.StatusCode, 200)
+}
+
+func TestExecute_Failure(t *testing.T) {
+	client := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 400,
+			}, nil
+		},
+	}
+
+	request := &http.Request{
+		Method: http.MethodGet,
+	}
+
+	response, err := Execute(client, request)
+
+	assert.ErrorContains(t, err, "400: unknown HTTP error")
+	assert.Equal(t, response.StatusCode, 400)
+}
+
+func TestExecute_ClientError(t *testing.T) {
+	client := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("some error")
+		},
+	}
+
+	request := &http.Request{
+		Method: http.MethodGet,
+	}
+
+	_, err := Execute(client, request)
+
+	assert.ErrorContains(t, err, "some error")
+}
+
+func TestEnsureHttpClientTimeout_NilHTTPClientShouldUse10sTimeout(t *testing.T) {
 	result := ensureHttpClientTimeout(nil).(*http.Client)
 
 	assert.Equal(t, 10*time.Second, result.Timeout)
 }
 
-func TestYotiClient_ShouldSetHTTPClientTimeout(t *testing.T) {
+func TestEnsureHttpClientTimeout(t *testing.T) {
 	httpClient := &http.Client{
 		Timeout: time.Minute * 12,
 	}

--- a/yoti_client_test.go
+++ b/yoti_client_test.go
@@ -99,7 +99,7 @@ func TestYotiClient_CreateShareURL(t *testing.T) {
 
 	result, err := client.CreateShareURL(&scenario)
 	assert.NilError(t, err)
-	assert.Check(t, result.ShareURL == "https://code.yoti.com/some-qr")
+	assert.Equal(t, result.ShareURL, "https://code.yoti.com/some-qr")
 }
 
 func TestYotiClient_HttpFailure_ReturnsFailure(t *testing.T) {

--- a/yoti_client_test.go
+++ b/yoti_client_test.go
@@ -5,8 +5,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/getyoti/yoti-go-sdk/v3/aml"
+	"github.com/getyoti/yoti-go-sdk/v3/dynamic"
 	"github.com/getyoti/yoti-go-sdk/v3/test"
 	"gotest.tools/v3/assert"
 )
@@ -22,7 +25,15 @@ func (mock *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
 	return nil, nil
 }
 
-func TestYotiClient_KeyLoad_Failure(t *testing.T) {
+func TestNewClient(t *testing.T) {
+	key, readErr := ioutil.ReadFile("./test/test-key.pem")
+	assert.NilError(t, readErr)
+
+	_, err := NewClient("some-sdk-id", key)
+	assert.NilError(t, err)
+}
+
+func TestNewClient_KeyLoad_Failure(t *testing.T) {
 	key, _ := ioutil.ReadFile("test/test-key-invalid-format.pem")
 	_, err := NewClient("", key)
 
@@ -32,6 +43,63 @@ func TestYotiClient_KeyLoad_Failure(t *testing.T) {
 		Temporary() bool
 	})
 	assert.Check(t, !temporary || !tempError.Temporary())
+}
+
+func TestYotiClient_PerformAmlCheck(t *testing.T) {
+	key, readErr := ioutil.ReadFile("./test/test-key.pem")
+	assert.NilError(t, readErr)
+
+	client, clientErr := NewClient("some-sdk-id", key)
+	assert.NilError(t, clientErr)
+
+	client.HTTPClient = &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader(`{"on_fraud_list":true}`)),
+			}, nil
+		},
+	}
+
+	var amlAddress = aml.Address{
+		Country: "GBR"}
+
+	var amlProfile = aml.Profile{
+		GivenNames: "Edward Richard George",
+		FamilyName: "Heath",
+		Address:    amlAddress}
+
+	result, err := client.PerformAmlCheck(amlProfile)
+	assert.NilError(t, err)
+
+	assert.Check(t, result.OnFraudList)
+}
+
+func TestYotiClient_CreateShareURL(t *testing.T) {
+	key, readErr := ioutil.ReadFile("./test/test-key.pem")
+	assert.NilError(t, readErr)
+
+	client, clientErr := NewClient("some-sdk-id", key)
+	assert.NilError(t, clientErr)
+
+	client.HTTPClient = &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 201,
+				Body:       ioutil.NopCloser(strings.NewReader(`{"qrcode":"https://code.yoti.com/some-qr","ref_id":"0"}`)),
+			}, nil
+		},
+	}
+
+	policy, policyErr := (&dynamic.PolicyBuilder{}).WithFullName().WithWantedRememberMe().Build()
+	assert.NilError(t, policyErr)
+
+	scenario, scenarioErr := (&dynamic.ScenarioBuilder{}).WithPolicy(policy).Build()
+	assert.NilError(t, scenarioErr)
+
+	result, err := client.CreateShareURL(&scenario)
+	assert.NilError(t, err)
+	assert.Check(t, result.ShareURL == "https://code.yoti.com/some-qr")
 }
 
 func TestYotiClient_HttpFailure_ReturnsFailure(t *testing.T) {


### PR DESCRIPTION
### Added
- Additional test coverage
- SonarCloud badges to README

### Changed
- `AgeVerification{}.New()` changed to `NewAgeVerification()`
- Reusing `parseEncryptedProto()` for application profile

### Removed
- Go master from Travis (we already allowed failures for this and it was taking 4 times longer than stable releases)