### PR TITLE
SDK-1300: Add json subtype parsing with custom JSON unmarshalling

### DIFF
--- a/docscan/client.go
+++ b/docscan/client.go
@@ -153,7 +153,7 @@ func (c *Client) DeleteSession(sessionID string) error {
 }
 
 // GetMediaContent retrieves media related to a Yoti Doc Scan session based on the supplied media ID
-func (c *Client) GetMediaContent(sessionID, mediaID string) (*media.Media, error) { // TODO: change to media.Value
+func (c *Client) GetMediaContent(sessionID, mediaID string) (*media.Media, error) {
 	request, err := (&requests.SignedRequest{
 		Key:        c.Key,
 		HTTPMethod: http.MethodGet,

--- a/docscan/client.go
+++ b/docscan/client.go
@@ -153,7 +153,7 @@ func (c *Client) DeleteSession(sessionID string) error {
 }
 
 // GetMediaContent retrieves media related to a Yoti Doc Scan session based on the supplied media ID
-func (c *Client) GetMediaContent(sessionID, mediaID string) (*media.Media, error) {
+func (c *Client) GetMediaContent(sessionID, mediaID string) (media.Media, error) {
 	request, err := (&requests.SignedRequest{
 		Key:        c.Key,
 		HTTPMethod: http.MethodGet,
@@ -183,7 +183,8 @@ func (c *Client) GetMediaContent(sessionID, mediaID string) (*media.Media, error
 	}
 
 	media := media.NewMedia(contentTypes[0], responseBytes)
-	return &media, err
+
+	return media, err
 }
 
 // DeleteMediaContent deletes media related to a Yoti Doc Scan session based on the supplied media ID

--- a/docscan/constants/constants.go
+++ b/docscan/constants/constants.go
@@ -5,6 +5,7 @@ const (
 	IDDocumentTextDataCheck      string = "ID_DOCUMENT_TEXT_DATA_CHECK"
 	IDDocumentTextDataExtraction string = "ID_DOCUMENT_TEXT_DATA_EXTRACTION"
 	IDDocumentFaceMatch          string = "ID_DOCUMENT_FACE_MATCH"
+	Liveness                     string = "LIVENESS"
 
 	Camera          string = "CAMERA"
 	CameraAndUpload string = "CAMERA_AND_UPLOAD"

--- a/docscan/session/create/check/constants.go
+++ b/docscan/session/create/check/constants.go
@@ -1,6 +1,5 @@
 package check
 
 const (
-	liveness = "LIVENESS"
-	zoom     = "ZOOM"
+	zoom = "ZOOM"
 )

--- a/docscan/session/create/check/liveness.go
+++ b/docscan/session/create/check/liveness.go
@@ -2,6 +2,8 @@ package check
 
 import (
 	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
 )
 
 // RequestedLivenessCheck requests creation of a Liveness Check
@@ -11,7 +13,7 @@ type RequestedLivenessCheck struct {
 
 // Type is the type of the Requested Check
 func (c RequestedLivenessCheck) Type() string {
-	return liveness
+	return constants.Liveness
 }
 
 // Config is the configuration of the Requested Check

--- a/docscan/session/create/task/text_extraction_test.go
+++ b/docscan/session/create/task/text_extraction_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleRequestedTextExtractionTaskBuilder() {
-	check, err := NewRequestedTextExtractionTaskBuilder().
+	task, err := NewRequestedTextExtractionTaskBuilder().
 		WithManualCheckAlways().
 		WithChipDataIgnore().
 		Build()
@@ -15,7 +15,7 @@ func ExampleRequestedTextExtractionTaskBuilder() {
 		return
 	}
 
-	data, _ := json.Marshal(check)
+	data, _ := json.Marshal(task)
 	fmt.Println(string(data))
 	// Output: {"type":"ID_DOCUMENT_TEXT_DATA_EXTRACTION","config":{"manual_check":"ALWAYS","chip_data":"IGNORE"}}
 }

--- a/docscan/session/retrieve/check_response.go
+++ b/docscan/session/retrieve/check_response.go
@@ -1,6 +1,8 @@
 package retrieve
 
-import "time"
+import (
+	"time"
+)
 
 // CheckResponse represents the attributes of a check, for any given session
 type CheckResponse struct {
@@ -12,4 +14,24 @@ type CheckResponse struct {
 	Report         ReportResponse   `json:"report"`
 	Created        *time.Time       `json:"created"`
 	LastUpdated    *time.Time       `json:"last_updated"`
+}
+
+// AuthenticityCheckResponse represents a Document Authenticity check for a given session
+type AuthenticityCheckResponse struct {
+	*CheckResponse
+}
+
+// FaceMatchCheckResponse represents a FaceMatch Check for a given session
+type FaceMatchCheckResponse struct {
+	*CheckResponse
+}
+
+// LivenessCheckResponse represents a Liveness Check for a given session
+type LivenessCheckResponse struct {
+	*CheckResponse
+}
+
+// TextDataCheckResponse represents a Text Data check for a given session
+type TextDataCheckResponse struct {
+	*CheckResponse
 }

--- a/docscan/session/retrieve/generated_check_response.go
+++ b/docscan/session/retrieve/generated_check_response.go
@@ -5,3 +5,8 @@ type GeneratedCheckResponse struct {
 	ID   string `json:"id"`
 	Type string `json:"type"`
 }
+
+// GeneratedTextDataCheckResponse represents a Text Extraction task response
+type GeneratedTextDataCheckResponse struct {
+	*GeneratedCheckResponse
+}

--- a/docscan/session/retrieve/get_session_result.go
+++ b/docscan/session/retrieve/get_session_result.go
@@ -2,7 +2,6 @@ package retrieve
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
 )
@@ -62,9 +61,6 @@ func (g *GetSessionResult) UnmarshalJSON(data []byte) error {
 
 		case constants.Liveness:
 			g.livenessChecks = append(g.livenessChecks, &LivenessCheckResponse{CheckResponse: check})
-
-		default:
-			fmt.Printf("Unrecognized check type: `%s`", check.Type)
 		}
 	}
 

--- a/docscan/session/retrieve/get_session_result.go
+++ b/docscan/session/retrieve/get_session_result.go
@@ -1,12 +1,72 @@
 package retrieve
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+)
+
 // GetSessionResult contains the information about a created session
 type GetSessionResult struct {
-	ClientSessionTokenTTL int               `json:"client_session_token_ttl"`
-	ClientSessionToken    string            `json:"client_session_token"`
-	SessionID             string            `json:"session_id"`
-	UserTrackingID        string            `json:"user_tracking_id"`
-	State                 string            `json:"state"`
-	Checks                []CheckResponse   `json:"checks"`
-	Resources             ResourceContainer `json:"resources"`
+	ClientSessionTokenTTL int                `json:"client_session_token_ttl"`
+	ClientSessionToken    string             `json:"client_session_token"`
+	SessionID             string             `json:"session_id"`
+	UserTrackingID        string             `json:"user_tracking_id"`
+	State                 string             `json:"state"`
+	Checks                []*CheckResponse   `json:"checks"`
+	Resources             *ResourceContainer `json:"resources"`
+	authenticityChecks    []*AuthenticityCheckResponse
+	faceMatchChecks       []*FaceMatchCheckResponse
+	textDataChecks        []*TextDataCheckResponse
+	livenessChecks        []*LivenessCheckResponse
+}
+
+// AuthenticityChecks filters the checks, returning only document authenticity checks
+func (g *GetSessionResult) AuthenticityChecks() []*AuthenticityCheckResponse {
+	return g.authenticityChecks
+}
+
+// FaceMatchChecks filters the checks, returning only FaceMatch checks
+func (g *GetSessionResult) FaceMatchChecks() []*FaceMatchCheckResponse {
+	return g.faceMatchChecks
+}
+
+// TextDataChecks filters the checks, returning only Text Data checks
+func (g *GetSessionResult) TextDataChecks() []*TextDataCheckResponse {
+	return g.textDataChecks
+}
+
+// LivenessChecks filters the checks, returning only Liveness checks
+func (g *GetSessionResult) LivenessChecks() []*LivenessCheckResponse {
+	return g.livenessChecks
+}
+
+// UnmarshalJSON handles the custom JSON unmarshalling
+func (g *GetSessionResult) UnmarshalJSON(data []byte) error {
+	type result GetSessionResult // declared as "type" to prevent recursive unmarshalling
+	if err := json.Unmarshal(data, (*result)(g)); err != nil {
+		return err
+	}
+
+	for _, check := range g.Checks {
+		switch check.Type {
+		case constants.IDDocumentAuthenticity:
+			g.authenticityChecks = append(g.authenticityChecks, &AuthenticityCheckResponse{CheckResponse: check})
+
+		case constants.IDDocumentFaceMatch:
+			g.faceMatchChecks = append(g.faceMatchChecks, &FaceMatchCheckResponse{CheckResponse: check})
+
+		case constants.IDDocumentTextDataCheck:
+			g.textDataChecks = append(g.textDataChecks, &TextDataCheckResponse{CheckResponse: check})
+
+		case constants.Liveness:
+			g.livenessChecks = append(g.livenessChecks, &LivenessCheckResponse{CheckResponse: check})
+
+		default:
+			fmt.Printf("Unrecognized check type: `%s`", check.Type)
+		}
+	}
+
+	return nil
 }

--- a/docscan/session/retrieve/get_session_result_test.go
+++ b/docscan/session/retrieve/get_session_result_test.go
@@ -1,0 +1,62 @@
+package retrieve
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+	"gotest.tools/v3/assert"
+)
+
+func TestGetSessionResult_UnmarshalJSON(t *testing.T) {
+	authenticityCheckResponse := &CheckResponse{
+		Type:  constants.IDDocumentAuthenticity,
+		State: "DONE",
+	}
+
+	testDate := time.Date(2020, 01, 01, 1, 2, 3, 4, time.UTC)
+	faceMatchCheckResponse := &CheckResponse{
+		Type:    constants.IDDocumentFaceMatch,
+		Created: &testDate,
+	}
+
+	textDataCheckResponse := &CheckResponse{
+		Type:   constants.IDDocumentTextDataCheck,
+		Report: ReportResponse{},
+	}
+
+	livenessCheckResponse := &CheckResponse{
+		Type:        constants.Liveness,
+		LastUpdated: &testDate,
+	}
+
+	var checks []*CheckResponse
+	checks = append(checks, &CheckResponse{Type: "OTHER_TYPE", ID: "id"})
+	checks = append(checks, authenticityCheckResponse)
+	checks = append(checks, faceMatchCheckResponse)
+	checks = append(checks, textDataCheckResponse)
+	checks = append(checks, livenessCheckResponse)
+
+	getSessionResult := GetSessionResult{
+		Checks: checks,
+	}
+	marshalled, err := json.Marshal(&getSessionResult)
+	assert.NilError(t, err)
+
+	var result GetSessionResult
+	err = json.Unmarshal(marshalled, &result)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 1, len(result.AuthenticityChecks()))
+	assert.Equal(t, "DONE", result.AuthenticityChecks()[0].State)
+
+	assert.Equal(t, 1, len(result.FaceMatchChecks()))
+	assert.Check(t, result.FaceMatchChecks()[0].Created.Equal(testDate))
+
+	assert.Equal(t, 1, len(result.TextDataChecks()))
+	assert.DeepEqual(t, ReportResponse{}, result.TextDataChecks()[0].Report)
+
+	assert.Equal(t, 1, len(result.LivenessChecks()))
+	assert.Check(t, result.LivenessChecks()[0].LastUpdated.Equal(testDate))
+}

--- a/docscan/session/retrieve/id_document_resource_response.go
+++ b/docscan/session/retrieve/id_document_resource_response.go
@@ -1,9 +1,5 @@
 package retrieve
 
-import (
-	"github.com/getyoti/yoti-go-sdk/v3/util"
-)
-
 // IDDocumentResourceResponse represents an Identity Document resource for a given session
 type IDDocumentResourceResponse struct {
 	ResourceResponse
@@ -16,14 +12,4 @@ type IDDocumentResourceResponse struct {
 	// DocumentFields are the associated document fields of a document
 	DocumentFields  DocumentFieldsResponse  `json:"document_fields"`
 	DocumentIDPhoto DocumentIDPhotoResponse `json:"document_id_photo"`
-}
-
-// GetTextExtractionTasks returns a slice of text extraction tasks associated with the ID document
-func (id IDDocumentResourceResponse) GetTextExtractionTasks() []TextExtractionTaskResponse {
-	filteredTasks := util.Filter(id.Tasks, func(val interface{}) bool {
-		_, isTextExtractionTaskResponse := val.(TextExtractionTaskResponse)
-		return isTextExtractionTaskResponse
-	})
-
-	return filteredTasks.([]TextExtractionTaskResponse)
 }

--- a/docscan/session/retrieve/resource_container.go
+++ b/docscan/session/retrieve/resource_container.go
@@ -1,19 +1,7 @@
 package retrieve
 
-import "github.com/getyoti/yoti-go-sdk/v3/util"
-
 // ResourceContainer contains different resources that are part of the Yoti Doc Scan session
 type ResourceContainer struct {
 	IDDocuments     []IDDocumentResourceResponse `json:"id_documents"`
 	LivenessCapture []LivenessResourceResponse   `json:"liveness_capture"`
-}
-
-// GetZoomLivenessResources returns a filtered slice of Zoom liveness capture resources
-func (rc ResourceContainer) GetZoomLivenessResources() []ZoomLivenessResourceResponse {
-	filteredResources := util.Filter(rc.LivenessCapture, func(val interface{}) bool {
-		_, isZoomLivenessResource := val.(TextExtractionTaskResponse)
-		return isZoomLivenessResource
-	})
-
-	return filteredResources.([]ZoomLivenessResourceResponse)
 }

--- a/docscan/session/retrieve/task_response.go
+++ b/docscan/session/retrieve/task_response.go
@@ -1,16 +1,46 @@
 package retrieve
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
 )
 
 // TaskResponse represents the attributes of a task, for any given session
 type TaskResponse struct {
-	ID              string                   `json:"id"`
-	Type            string                   `json:"type"`
-	State           string                   `json:"state"`
-	Created         *time.Time               `json:"created"`
-	LastUpdated     *time.Time               `json:"last_updated"`
-	GeneratedChecks []GeneratedCheckResponse `json:"generated_checks"`
-	GeneratedMedia  []GeneratedMedia         `json:"generated_media"`
+	ID                      string                    `json:"id"`
+	Type                    string                    `json:"type"`
+	State                   string                    `json:"state"`
+	Created                 *time.Time                `json:"created"`
+	LastUpdated             *time.Time                `json:"last_updated"`
+	GeneratedChecks         []*GeneratedCheckResponse `json:"generated_checks"`
+	GeneratedMedia          []*GeneratedMedia         `json:"generated_media"`
+	generatedTextDataChecks []*GeneratedTextDataCheckResponse
+}
+
+// GeneratedTextDataChecks  filters the checks, returning only text data checks
+func (t *TaskResponse) GeneratedTextDataChecks() []*GeneratedTextDataCheckResponse {
+	return t.generatedTextDataChecks
+}
+
+// UnmarshalJSON handles the custom JSON unmarshalling
+func (t *TaskResponse) UnmarshalJSON(data []byte) error {
+	type result TaskResponse // declared as "type" to prevent recursive unmarshalling
+	if err := json.Unmarshal(data, (*result)(t)); err != nil {
+		return err
+	}
+
+	for _, check := range t.GeneratedChecks {
+		switch check.Type {
+		case constants.IDDocumentTextDataCheck:
+			t.generatedTextDataChecks = append(t.generatedTextDataChecks, &GeneratedTextDataCheckResponse{GeneratedCheckResponse: check})
+
+		default:
+			fmt.Printf("Unrecognized check type: `%s`", check.Type)
+		}
+	}
+
+	return nil
 }

--- a/docscan/session/retrieve/task_response.go
+++ b/docscan/session/retrieve/task_response.go
@@ -2,7 +2,6 @@ package retrieve
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
@@ -20,7 +19,7 @@ type TaskResponse struct {
 	generatedTextDataChecks []*GeneratedTextDataCheckResponse
 }
 
-// GeneratedTextDataChecks  filters the checks, returning only text data checks
+// GeneratedTextDataChecks filters the checks, returning only text data checks
 func (t *TaskResponse) GeneratedTextDataChecks() []*GeneratedTextDataCheckResponse {
 	return t.generatedTextDataChecks
 }
@@ -36,9 +35,6 @@ func (t *TaskResponse) UnmarshalJSON(data []byte) error {
 		switch check.Type {
 		case constants.IDDocumentTextDataCheck:
 			t.generatedTextDataChecks = append(t.generatedTextDataChecks, &GeneratedTextDataCheckResponse{GeneratedCheckResponse: check})
-
-		default:
-			fmt.Printf("Unrecognized check type: `%s`", check.Type)
 		}
 	}
 

--- a/docscan/session/retrieve/task_response_test.go
+++ b/docscan/session/retrieve/task_response_test.go
@@ -1,0 +1,33 @@
+package retrieve
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+	"gotest.tools/v3/assert"
+)
+
+func TestTaskResponse_UnmarshalJSON(t *testing.T) {
+	generatedTextDataCheck := GeneratedCheckResponse{
+		Type: constants.IDDocumentTextDataCheck,
+		ID:   "some-id",
+	}
+
+	var checks []*GeneratedCheckResponse
+	checks = append(checks, &GeneratedCheckResponse{Type: "OTHER_TYPE", ID: "other-id"})
+	checks = append(checks, &generatedTextDataCheck)
+
+	taskResponse := TaskResponse{
+		GeneratedChecks: checks,
+	}
+	marshalled, err := json.Marshal(&taskResponse)
+	assert.NilError(t, err)
+
+	var result TaskResponse
+	err = json.Unmarshal(marshalled, &result)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 1, len(result.GeneratedTextDataChecks()))
+	assert.Equal(t, "some-id", result.GeneratedTextDataChecks()[0].ID)
+}

--- a/docscan/session/retrieve/text_extraction_task_response.go
+++ b/docscan/session/retrieve/text_extraction_task_response.go
@@ -1,6 +1,0 @@
-package retrieve
-
-// TextExtractionTaskResponse represents a Text Extraction task response
-type TextExtractionTaskResponse struct {
-	TaskResponse
-}


### PR DESCRIPTION
This is a proposed solution for dealing with the handling of various subtypes when parsing the GetSession response.

CheckResponses can be (based on the value of the `type` field):
- CheckResponse
  - AuthenticityCheckResponse
  - FaceMatchCheckResponse
  - LivenessCheckResponse
  - TextDataCheckResponse
  - may be others in future

Likewise, a GeneratedChecks can be:
- GeneratedCheck 
  - GeneratedTextDataCheckResponse
  - may be others in future

So we want to add convenience methods to _filter_:
- `GetSessionResult.Checks` to return the the above subsets listed, and
- `TaskResponse.GeneratedChecks` to only return the `GeneratedTextDataCheckResponses`

There are two other "subtypes" which will need filtering too, but thought I'd check this was the right approach before applying to those as well.

At first I had:
```go
type TaskResponse struct {
	GeneratedChecks         []*GeneratedCheckResponse `json:"generated_checks"`
	GeneratedTextDataChecks []*GeneratedTextDataCheckResponse
}
```
instead of what I currently have:
```go
type TaskResponse struct {
	GeneratedChecks         []*GeneratedCheckResponse `json:"generated_checks"`
	generatedTextDataChecks []*GeneratedTextDataCheckResponse
}

// GeneratedTextDataChecks  filters the checks, returning only text data checks
func (t *TaskResponse) GeneratedTextDataChecks() []*GeneratedTextDataCheckResponse {
	return t.generatedTextDataChecks
}
```

But I thought this 2nd approach makes it a bit clearer that they aren't two distinct slices, and `GeneratedChecks` also includes the items in `generatedTextDataChecks`

Another approach could be to have `GetSessionResult.Checks` and `TaskResponse.GeneratedChecks` return a slice of interfaces, with the subtypes each implementing the values on the interface, but I thought the approach in this PR was neater.