### PR TITLE
SDK-1723: Remove logging from SDK

### DIFF
--- a/aml/aml.go
+++ b/aml/aml.go
@@ -2,7 +2,6 @@ package aml
 
 import (
 	"encoding/json"
-	"log"
 )
 
 // Address Address for Anti Money Laundering (AML) purposes
@@ -32,8 +31,6 @@ func GetResult(response []byte) (Result, error) {
 	err := json.Unmarshal(response, &result)
 
 	if err != nil {
-		log.Printf(
-			"Unable to get AML result from response. Error: %s", err)
 		return result, err
 	}
 

--- a/cryptoutil/crypto_utils_test.go
+++ b/cryptoutil/crypto_utils_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -95,7 +94,6 @@ func TestCryptoutil_DecipherAes(t *testing.T) {
 	bytes, err := DecipherAes(unwrappedKey, encryptedData.Iv, encryptedData.CipherText)
 	assert.NilError(t, err)
 	assert.Check(t, bytes != nil)
-	fmt.Println(string(bytes))
 }
 
 func TestCryptoutil_DecipherAes_EmptyCiphertextShouldError(t *testing.T) {

--- a/extension/third_party_attribute_extension_test.go
+++ b/extension/third_party_attribute_extension_test.go
@@ -3,7 +3,6 @@ package extension
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
@@ -36,9 +35,7 @@ func ExampleThirdPartyAttributeExtension() {
 
 func TestWithDefinitionShouldAddToList(t *testing.T) {
 	datetime, err := time.Parse("2006-01-02T15:04:05.000Z", "2019-10-30T12:10:09.458Z")
-	if err != nil {
-		log.Printf("Error parsing date, %v", err)
-	}
+	assert.NilError(t, err)
 
 	definitionList := []attribute.Definition{
 		createDefinitionByName("some_attribute"),
@@ -61,9 +58,7 @@ func TestWithDefinitionShouldAddToList(t *testing.T) {
 
 func TestWithDefinitionsShouldOverwriteList(t *testing.T) {
 	datetime, err := time.Parse("2006-01-02T15:04:05.000Z", "2019-10-30T12:10:09.458Z")
-	if err != nil {
-		log.Printf("Error parsing date, %v", err)
-	}
+	assert.NilError(t, err)
 
 	definitionList := []attribute.Definition{
 		createDefinitionByName("some_attribute"),

--- a/profile/attribute/anchor/anchor_parser.go
+++ b/profile/attribute/anchor/anchor_parser.go
@@ -6,7 +6,6 @@ import (
 	"encoding/asn1"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/getyoti/yoti-go-sdk/v3/yotiprotoattr"
 	"github.com/getyoti/yoti-go-sdk/v3/yotiprotocom"
@@ -49,7 +48,6 @@ func getAnchorValuesFromCertificate(parsedCerts []*x509.Certificate) (anchorType
 			)
 			parsedAnchorType, value, err := parseExtension(ext)
 			if err != nil {
-				log.Printf("error parsing anchor extension, %v", err)
 				continue
 			} else if parsedAnchorType == TypeUnknown {
 				continue

--- a/profile/attribute/anchor/anchor_parser_test.go
+++ b/profile/attribute/anchor/anchor_parser_test.go
@@ -2,8 +2,6 @@ package anchor
 
 import (
 	"crypto/x509/pkix"
-	"io/ioutil"
-	"log"
 	"math/big"
 	"testing"
 	"time"
@@ -46,8 +44,6 @@ func TestAnchorParser_parseExtension_ShouldErrorForInvalidExtension(t *testing.T
 }
 
 func TestAnchorParser_Passport(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-
 	anchorSlice := createAnchorSliceFromTestFile(t, "../../../test/fixtures/test_anchor_passport.txt")
 
 	parsedAnchors := ParseAnchors(anchorSlice)

--- a/profile/attribute/date_attribute.go
+++ b/profile/attribute/date_attribute.go
@@ -1,7 +1,6 @@
 package attribute
 
 import (
-	"log"
 	"time"
 
 	"github.com/getyoti/yoti-go-sdk/v3/profile/attribute/anchor"
@@ -18,7 +17,6 @@ type DateAttribute struct {
 func NewDate(a *yotiprotoattr.Attribute) (*DateAttribute, error) {
 	parsedTime, err := time.Parse("2006-01-02", string(a.Value))
 	if err != nil {
-		log.Printf("Unable to parse time value of: %q. Error: %q", a.Value, err)
 		return nil, err
 	}
 

--- a/profile/attribute/generic_attribute.go
+++ b/profile/attribute/generic_attribute.go
@@ -1,8 +1,6 @@
 package attribute
 
 import (
-	"log"
-
 	"github.com/getyoti/yoti-go-sdk/v3/profile/attribute/anchor"
 	"github.com/getyoti/yoti-go-sdk/v3/yotiprotoattr"
 )
@@ -18,7 +16,6 @@ func NewGeneric(a *yotiprotoattr.Attribute) *GenericAttribute {
 	value, err := parseValue(a.ContentType, a.Value)
 
 	if err != nil {
-		log.Printf("Error creating new generic attribute: `%s`", err)
 		return nil
 	}
 

--- a/profile/attribute/issuance_details.go
+++ b/profile/attribute/issuance_details.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/getyoti/yoti-go-sdk/v3/yotiprotoshare"
@@ -80,7 +79,6 @@ func parseExpiryDate(expiryDateString string) (*time.Time, error) {
 
 	parsedTime, err := time.Parse(time.RFC3339Nano, expiryDateString)
 	if err != nil {
-		log.Printf("Unable to parse time value of: %q. Error: %q", expiryDateString, err)
 		return nil, err
 	}
 

--- a/profile/attribute/parser.go
+++ b/profile/attribute/parser.go
@@ -2,7 +2,6 @@ package attribute
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"time"
 
@@ -49,11 +48,9 @@ func parseValue(contentType yotiprotoattr.ContentType, byteValue []byte) (interf
 		return parseImageValue(contentType, byteValue)
 
 	case yotiprotoattr.ContentType_UNDEFINED:
-		log.Print("Content Type Undefined, attempting to parse it as a string")
 		return string(byteValue), nil
 
 	default:
-		log.Printf("Unknown type '%s', attempting to parse it as a String", contentType)
 		return string(byteValue), nil
 	}
 }

--- a/profile/user_profile_test.go
+++ b/profile/user_profile_test.go
@@ -2,8 +2,6 @@ package profile
 
 import (
 	"encoding/base64"
-	"io/ioutil"
-	"log"
 	"strconv"
 	"strings"
 	"testing"
@@ -206,7 +204,6 @@ func TestProfile_GetAttribute_InvalidInt_ReturnsNil(t *testing.T) {
 
 	result := createProfileWithSingleAttribute(attr)
 
-	log.SetOutput(ioutil.Discard)
 	att := result.GetAttribute(attributeName)
 
 	assert.Assert(t, is.Nil(att))


### PR DESCRIPTION
Integrators could be using std err and std out for their own logging. Enough information should be able to be gleamed from the error and the stack trace