### PR TITLE
SDK-1618: Dynamic Scenario Extensions

### DIFF
--- a/extension/location_constraint_extension.go
+++ b/extension/location_constraint_extension.go
@@ -39,8 +39,8 @@ func (builder *LocationConstraintExtensionBuilder) WithRadius(radius float64) *L
 	return builder
 }
 
-// WithUncertainty sets the max uncertainty allowed by the location constraint extension
-func (builder *LocationConstraintExtensionBuilder) WithUncertainty(uncertainty float64) *LocationConstraintExtensionBuilder {
+// WithMaxUncertainty sets the max uncertainty allowed by the location constraint extension
+func (builder *LocationConstraintExtensionBuilder) WithMaxUncertainty(uncertainty float64) *LocationConstraintExtensionBuilder {
 	builder.extension.uncertainty = uncertainty
 	return builder
 }

--- a/extension/location_constraint_extension_test.go
+++ b/extension/location_constraint_extension_test.go
@@ -9,7 +9,7 @@ func ExampleLocationConstraintExtension() {
 		WithLatitude(51.511831).
 		WithLongitude(-0.081446).
 		WithRadius(0.001).
-		WithUncertainty(0.001).
+		WithMaxUncertainty(0.001).
 		Build()
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())

--- a/extension/third_party_attribute_extension.go
+++ b/extension/third_party_attribute_extension.go
@@ -41,8 +41,8 @@ func (builder *ThirdPartyAttributeExtensionBuilder) WithDefinitions(definitions 
 }
 
 // Build creates a ThirdPartyAttributeExtension using the supplied values
-func (builder *ThirdPartyAttributeExtensionBuilder) Build() ThirdPartyAttributeExtension {
-	return builder.extension
+func (builder *ThirdPartyAttributeExtensionBuilder) Build() (ThirdPartyAttributeExtension, error) {
+	return builder.extension, nil
 }
 
 // MarshalJSON returns the JSON encoding

--- a/extension/third_party_attribute_extension_test.go
+++ b/extension/third_party_attribute_extension_test.go
@@ -23,10 +23,15 @@ func ExampleThirdPartyAttributeExtension() {
 		return
 	}
 
-	extension := (&ThirdPartyAttributeExtensionBuilder{}).
+	extension, err := (&ThirdPartyAttributeExtensionBuilder{}).
 		WithExpiryDate(&datetime).
 		WithDefinition(attributeDefinition).
 		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
 
 	data, _ := extension.MarshalJSON()
 	fmt.Println(string(data))
@@ -44,12 +49,13 @@ func TestWithDefinitionShouldAddToList(t *testing.T) {
 
 	someOtherDefinition := createDefinitionByName("wanted_definition")
 
-	extension := (&ThirdPartyAttributeExtensionBuilder{}).
+	extension, err := (&ThirdPartyAttributeExtensionBuilder{}).
 		WithExpiryDate(&datetime).
 		WithDefinitions(definitionList).
 		WithDefinition(someOtherDefinition).
 		Build()
 
+	assert.NilError(t, err)
 	assert.Equal(t, len(extension.definitions), 3)
 	assert.Equal(t, extension.definitions[0].Name(), "some_attribute")
 	assert.Equal(t, extension.definitions[1].Name(), "some_other_attribute")
@@ -67,12 +73,13 @@ func TestWithDefinitionsShouldOverwriteList(t *testing.T) {
 
 	someOtherDefinition := createDefinitionByName("wanted_definition")
 
-	extension := (&ThirdPartyAttributeExtensionBuilder{}).
+	extension, err := (&ThirdPartyAttributeExtensionBuilder{}).
 		WithExpiryDate(&datetime).
 		WithDefinition(someOtherDefinition).
 		WithDefinitions(definitionList).
 		Build()
 
+	assert.NilError(t, err)
 	assert.Equal(t, len(extension.definitions), 2)
 	assert.Equal(t, extension.definitions[0].Name(), "some_attribute")
 	assert.Equal(t, extension.definitions[1].Name(), "some_other_attribute")
@@ -100,10 +107,12 @@ func TestExpiryDatesAreFormattedCorrectly(t *testing.T) {
 	attributeDefinition := attribute.NewAttributeDefinition("some_value")
 
 	for _, date := range expiryDates {
-		extension := (&ThirdPartyAttributeExtensionBuilder{}).
+		extension, err := (&ThirdPartyAttributeExtensionBuilder{}).
 			WithExpiryDate(&date.in).
 			WithDefinition(attributeDefinition).
 			Build()
+
+		assert.NilError(t, err)
 
 		marshalledJson, _ := extension.MarshalJSON()
 


### PR DESCRIPTION
### Changed
- `LocationConstraintExtensionBuilder.WithUncertainty()` renamed to `LocationConstraintExtensionBuilder.WithMaxUncertainty()`
- `ThirdPartyAttributeExtensionBuilder.Build()` now returns an error