### PR TITLE
SDK-1618: Wanted Attribute

### DIFF
--- a/dynamic/policy_builder.go
+++ b/dynamic/policy_builder.go
@@ -35,10 +35,10 @@ func (b *PolicyBuilder) WithWantedAttribute(attribute WantedAttribute) *PolicyBu
 		b.wantedAttributes = make(map[string]WantedAttribute)
 	}
 	var key string
-	if attribute.Derivation != "" {
-		key = attribute.Derivation
+	if attribute.derivation != "" {
+		key = attribute.derivation
 	} else {
-		key = attribute.Name
+		key = attribute.name
 	}
 	b.wantedAttributes[key] = attribute
 	return b

--- a/dynamic/policy_builder_test.go
+++ b/dynamic/policy_builder_test.go
@@ -1,7 +1,6 @@
 package dynamic
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -18,7 +17,7 @@ func ExamplePolicyBuilder_WithFamilyName() {
 		return
 	}
 
-	data, _ := json.Marshal(policy.attributes[0])
+	data, _ := policy.attributes[0].MarshalJSON()
 	fmt.Println(string(data))
 	// Output: {"name":"family_name","accept_self_asserted":false}
 }
@@ -28,7 +27,7 @@ func ExamplePolicyBuilder_WithDocumentDetails() {
 	if err != nil {
 		return
 	}
-	data, _ := json.Marshal(policy.attributes[0])
+	data, _ := policy.attributes[0].MarshalJSON()
 	fmt.Println(string(data))
 	// Output: {"name":"document_details","accept_self_asserted":false}
 }
@@ -40,7 +39,7 @@ func ExamplePolicyBuilder_WithDocumentImages() {
 		return
 	}
 
-	data, _ := json.Marshal(policy.attributes[0])
+	data, _ := policy.attributes[0].MarshalJSON()
 	fmt.Println(string(data))
 	// Output: {"name":"document_images","accept_self_asserted":false}
 }
@@ -52,7 +51,7 @@ func ExamplePolicyBuilder_WithSelfie() {
 		return
 	}
 
-	data, _ := json.Marshal(policy.attributes[0])
+	data, _ := policy.attributes[0].MarshalJSON()
 	fmt.Println(string(data))
 	// Output: {"name":"selfie","accept_self_asserted":false}
 }
@@ -70,7 +69,7 @@ func ExamplePolicyBuilder_WithAgeOver() {
 		return
 	}
 
-	data, _ := json.Marshal(policy.attributes[0])
+	data, _ := policy.attributes[0].MarshalJSON()
 	fmt.Println(string(data))
 	// Output: {"name":"date_of_birth","derivation":"age_over:18","constraints":[{"type":"SOURCE","preferred_sources":{"anchors":[{"name":"DRIVING_LICENCE","sub_type":""}],"soft_preference":false}}],"accept_self_asserted":false}
 }
@@ -240,8 +239,8 @@ func TestDynamicPolicyBuilder_WithWantedAttributeByName_WithSourceConstraint(t *
 	policy, err := builder.Build()
 	assert.NilError(t, err)
 	assert.Equal(t, len(policy.attributes), 1)
-	assert.Equal(t, policy.attributes[0].Name, attributeName)
-	assert.Equal(t, len(policy.attributes[0].Constraints), 1)
+	assert.Equal(t, policy.attributes[0].name, attributeName)
+	assert.Equal(t, len(policy.attributes[0].constraints), 1)
 }
 
 func TestDynamicPolicyBuilder_WithWantedAttributeByName_InvalidOptionsShouldPanic(t *testing.T) {
@@ -288,8 +287,8 @@ func TestDynamicPolicyBuilder_WithAgeDerivedAttribute_WithSourceConstraint(t *te
 	policy, err := builder.Build()
 	assert.NilError(t, err)
 	assert.Equal(t, len(policy.attributes), 1)
-	assert.Equal(t, policy.attributes[0].Name, consts.AttrDateOfBirth)
-	assert.Equal(t, len(policy.attributes[0].Constraints), 1)
+	assert.Equal(t, policy.attributes[0].name, consts.AttrDateOfBirth)
+	assert.Equal(t, len(policy.attributes[0].constraints), 1)
 }
 
 func TestDynamicPolicyBuilder_WithAgeDerivedAttribute_WithConstraintInterface(t *testing.T) {
@@ -307,8 +306,8 @@ func TestDynamicPolicyBuilder_WithAgeDerivedAttribute_WithConstraintInterface(t 
 	policy, err := builder.Build()
 	assert.NilError(t, err)
 	assert.Equal(t, len(policy.attributes), 1)
-	assert.Equal(t, policy.attributes[0].Name, consts.AttrDateOfBirth)
-	assert.Equal(t, len(policy.attributes[0].Constraints), 1)
+	assert.Equal(t, policy.attributes[0].name, consts.AttrDateOfBirth)
+	assert.Equal(t, len(policy.attributes[0].constraints), 1)
 }
 
 func TestDynamicPolicyBuilder_WithAgeDerivedAttribute_InvalidOptionsShouldPanic(t *testing.T) {

--- a/dynamic/wanted_attribute_builder.go
+++ b/dynamic/wanted_attribute_builder.go
@@ -1,6 +1,7 @@
 package dynamic
 
 import (
+	"encoding/json"
 	"errors"
 )
 
@@ -17,46 +18,61 @@ type WantedAttributeBuilder struct {
 
 // WantedAttribute represents a wanted attribute in a dynamic sharing policy
 type WantedAttribute struct {
-	Name               string                `json:"name"`
-	Derivation         string                `json:"derivation,omitempty"`
-	Constraints        []constraintInterface `json:"constraints,omitempty"`
-	AcceptSelfAsserted bool                  `json:"accept_self_asserted"`
+	name               string
+	derivation         string
+	constraints        []constraintInterface
+	acceptSelfAsserted bool
 }
 
 // WithName sets the name of the wanted attribute
 func (builder *WantedAttributeBuilder) WithName(name string) *WantedAttributeBuilder {
-	builder.attr.Name = name
+	builder.attr.name = name
 	return builder
 }
 
 // WithDerivation sets the derivation
 func (builder *WantedAttributeBuilder) WithDerivation(derivation string) *WantedAttributeBuilder {
-	builder.attr.Derivation = derivation
+	builder.attr.derivation = derivation
 	return builder
 }
 
 // WithConstraint adds a constraint to a wanted attribute
 func (builder *WantedAttributeBuilder) WithConstraint(constraint constraintInterface) *WantedAttributeBuilder {
-	builder.attr.Constraints = append(builder.attr.Constraints, constraint)
+	builder.attr.constraints = append(builder.attr.constraints, constraint)
 	return builder
 }
 
 // WithAcceptSelfAsserted allows self-asserted user details, such as those from Aadhar
 func (builder *WantedAttributeBuilder) WithAcceptSelfAsserted(accept bool) *WantedAttributeBuilder {
-	builder.attr.AcceptSelfAsserted = accept
+	builder.attr.acceptSelfAsserted = accept
 	return builder
 }
 
 // Build generates the wanted attribute's specification
 func (builder *WantedAttributeBuilder) Build() (WantedAttribute, error) {
-	if builder.attr.Constraints == nil {
-		builder.attr.Constraints = make([]constraintInterface, 0)
+	if builder.attr.constraints == nil {
+		builder.attr.constraints = make([]constraintInterface, 0)
 	}
 
 	var err error
-	if len(builder.attr.Name) == 0 {
+	if len(builder.attr.name) == 0 {
 		err = errors.New("Wanted attribute names must not be empty")
 	}
 
 	return builder.attr, err
+}
+
+// MarshalJSON returns the JSON encoding
+func (attr *WantedAttribute) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Name               string                `json:"name"`
+		Derivation         string                `json:"derivation,omitempty"`
+		Constraints        []constraintInterface `json:"constraints,omitempty"`
+		AcceptSelfAsserted bool                  `json:"accept_self_asserted"`
+	}{
+		Name:               attr.name,
+		Derivation:         attr.derivation,
+		Constraints:        attr.constraints,
+		AcceptSelfAsserted: attr.acceptSelfAsserted,
+	})
 }

--- a/dynamic/wanted_attribute_test.go
+++ b/dynamic/wanted_attribute_test.go
@@ -1,7 +1,6 @@
 package dynamic
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -13,7 +12,7 @@ func ExampleWantedAttributeBuilder_WithName() {
 		return
 	}
 
-	fmt.Println(attribute.Name)
+	fmt.Println(attribute.name)
 	// Output: TEST NAME
 }
 
@@ -27,7 +26,7 @@ func ExampleWantedAttributeBuilder_WithDerivation() {
 		return
 	}
 
-	fmt.Println(attribute.Derivation)
+	fmt.Println(attribute.derivation)
 	// Output: TEST DERIVATION
 }
 
@@ -48,7 +47,7 @@ func ExampleWantedAttributeBuilder_WithConstraint() {
 		return
 	}
 
-	json, _ := json.Marshal(attribute)
+	json, _ := attribute.MarshalJSON()
 	fmt.Println(string(json))
 	// Output: {"name":"TEST NAME","constraints":[{"type":"SOURCE","preferred_sources":{"anchors":[],"soft_preference":false}}],"accept_self_asserted":false}
 }
@@ -63,7 +62,7 @@ func ExampleWantedAttributeBuilder_WithAcceptSelfAsserted() {
 		return
 	}
 
-	json, _ := json.Marshal(attribute)
+	json, _ := attribute.MarshalJSON()
 	fmt.Println(string(json))
 	// Output: {"name":"TEST NAME","accept_self_asserted":true}
 }
@@ -78,7 +77,7 @@ func ExampleWantedAttributeBuilder_WithAcceptSelfAsserted_false() {
 		return
 	}
 
-	json, _ := json.Marshal(attribute)
+	json, _ := attribute.MarshalJSON()
 	fmt.Println(string(json))
 	// Output: {"name":"TEST NAME","accept_self_asserted":false}
 }


### PR DESCRIPTION
Amendment to #174 - reinstates custom `MarshalJSON()`

### Changed
- Keeps wanted attribute fields private inline with other dynamic scenario request structs