### PR TITLE
SDK-1729: Fix profile example

### DIFF
--- a/_examples/profile/main.go
+++ b/_examples/profile/main.go
@@ -42,13 +42,23 @@ func home(w http.ResponseWriter, req *http.Request) {
 	t, err := template.ParseFiles("login.html")
 
 	if err != nil {
-		panic(errParsingTheTemplate + err.Error())
+		errorPage(w, req.WithContext(context.WithValue(
+			req.Context(),
+			contextKey("yotiError"),
+			fmt.Sprintf(errParsingTheTemplate+err.Error()),
+		)))
+		return
 	}
 
 	err = t.Execute(w, templateVars)
 
 	if err != nil {
-		panic(errApplyingTheParsedTemplate + err.Error())
+		errorPage(w, req.WithContext(context.WithValue(
+			req.Context(),
+			contextKey("yotiError"),
+			fmt.Sprintf(errApplyingTheParsedTemplate+err.Error()),
+		)))
+		return
 	}
 }
 
@@ -148,14 +158,25 @@ func pageFromScenario(w http.ResponseWriter, req *http.Request, title string, sc
 		"yotiShareURL":    share.ShareURL,
 	}
 
-	t, err := template.ParseFiles("dynamic-share.html")
+	var t *template.Template
+	t, err = template.ParseFiles("dynamic-share.html")
 	if err != nil {
-		panic("Error parsing template: " + err.Error())
+		errorPage(w, req.WithContext(context.WithValue(
+			req.Context(),
+			contextKey("yotiError"),
+			fmt.Sprintf("error parsing template: "+err.Error()),
+		)))
+		return
 	}
 
 	err = t.Execute(w, templateVars)
 	if err != nil {
-		panic("Error applying the parsed template: " + err.Error())
+		errorPage(w, req.WithContext(context.WithValue(
+			req.Context(),
+			contextKey("yotiError"),
+			fmt.Sprintf("error applying the parsed template: "+err.Error()),
+		)))
+		return
 	}
 }
 
@@ -274,7 +295,12 @@ func profile(w http.ResponseWriter, r *http.Request) {
 	err = t.Execute(w, templateVars)
 
 	if err != nil {
-		panic("Error applying the parsed profile template. Error: " + err.Error())
+		errorPage(w, r.WithContext(context.WithValue(
+			r.Context(),
+			contextKey("yotiError"),
+			fmt.Sprintf("Error applying the parsed profile template. Error: `%s`", err),
+		)))
+		return
 	}
 }
 

--- a/_examples/profile/profile.html
+++ b/_examples/profile/profile.html
@@ -97,9 +97,11 @@
             </div>
         {{ end }}
 
-        <div class="yoti-profile-name">
-            {{ .profile.FullName.Value }}
-        </div>
+        {{ if .profile.FullName  }}
+            <div class="yoti-profile-name">
+                {{ .profile.FullName.Value }}
+            </div>
+        {{ end }}
     </section>
 
     <section class="yoti-attributes-section">


### PR DESCRIPTION
This fix is just to not assume full name is present in the template, and wrap it in an IF statement.

This issue was being hidden by another issue - we were panicking instead of gracefully handling the error. This meant the request was retried with the same token, which had then expired as it had been used once. 

I have updated the panic instances to redirect to the error page with the error information, (where we're not already trying to parse the error page)
