### PR TITLE
SDK-1300: Add Doc Scan test coverage

### DIFF
--- a/docscan/client.go
+++ b/docscan/client.go
@@ -200,7 +200,7 @@ func (c *Client) GetMediaContent(sessionID, mediaID string) (media.Media, error)
 	}
 
 	contentTypes := strings.Split(response.Header.Get("Content-type"), ";")
-	if len(contentTypes) < 1 {
+	if len(contentTypes[0]) < 1 {
 		err = errors.New("unable to parse content type from response")
 	}
 

--- a/docscan/client_test.go
+++ b/docscan/client_test.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -62,6 +64,47 @@ func TestClient_CreateSession(t *testing.T) {
 	assert.Equal(t, sessionID, createSessionResult.SessionID)
 }
 
+func TestClient_CreateSession_ShouldReturnJsonMarshalError(t *testing.T) {
+	client := Client{
+		jsonMarshaler: &mockJSONMarshaler{
+			marshal: func(v interface{}) ([]byte, error) {
+				return []byte{}, errors.New("some json error")
+			},
+		},
+	}
+	_, err := client.CreateSession(&create.SessionSpecification{})
+	assert.ErrorContains(t, err, "some json error")
+}
+
+func TestClient_CreateSession_ShouldReturnMissingKeyError(t *testing.T) {
+	client := Client{}
+	_, err := client.CreateSession(&create.SessionSpecification{})
+	assert.ErrorContains(t, err, "missing private key")
+}
+
+func TestClient_CreateSession_ShouldReturnResponseError(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+			}, nil
+		},
+	}
+
+	var sessionSpec *create.SessionSpecification
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+	_, err := client.CreateSession(sessionSpec)
+	assert.ErrorContains(t, err, "400: unknown HTTP error")
+}
+
 func TestClient_GetSession(t *testing.T) {
 	key, _ := rsa.GenerateKey(rand.Reader, 1024)
 
@@ -98,6 +141,57 @@ func TestClient_GetSession(t *testing.T) {
 	assert.Equal(t, state, getSessionResult.State)
 }
 
+func TestClient_GetSession_ShouldReturnMissingKeyError(t *testing.T) {
+	client := Client{}
+	_, err := client.GetSession("some-id")
+	assert.ErrorContains(t, err, "missing private key")
+}
+
+func TestClient_GetSession_ShouldReturnResponseError(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+			}, nil
+		},
+	}
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+
+	_, err := client.GetSession("some-id")
+	assert.ErrorContains(t, err, "400: unknown HTTP error")
+}
+
+func TestClient_GetSession_ShouldReturnJsonError(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(strings.NewReader("some-invalid-json")),
+			}, nil
+		},
+	}
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+
+	_, err := client.GetSession("some-id")
+	assert.ErrorContains(t, err, "invalid character")
+}
+
 func TestClient_DeleteSession(t *testing.T) {
 	key, _ := rsa.GenerateKey(rand.Reader, 1024)
 	HTTPClient := &mockHTTPClient{
@@ -117,6 +211,34 @@ func TestClient_DeleteSession(t *testing.T) {
 
 	err := client.DeleteSession("some-session-id")
 	assert.NilError(t, err)
+}
+
+func TestClient_DeleteSession_ShouldReturnMissingKeyError(t *testing.T) {
+	client := Client{}
+	err := client.DeleteSession("some-id")
+	assert.ErrorContains(t, err, "missing private key")
+}
+
+func TestClient_DeleteSession_ShouldReturnResponseError(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+			}, nil
+		},
+	}
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+
+	err := client.DeleteSession("some-id")
+	assert.ErrorContains(t, err, "400: unknown HTTP error")
 }
 
 func TestClient_GetMediaContent(t *testing.T) {
@@ -147,6 +269,59 @@ func TestClient_GetMediaContent(t *testing.T) {
 	assert.Equal(t, media.ImageTypeJPEG, result.MIME())
 }
 
+func TestClient_GetMediaContent_NoContentType(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	jpegImage := []byte("value")
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(jpegImage)),
+				Header:     map[string][]string{},
+			}, nil
+		},
+	}
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+
+	_, err := client.GetMediaContent("some-sessionID", "some-mediaID")
+	assert.ErrorContains(t, err, "unable to parse content type from response")
+}
+
+func TestClient_GetMediaContent_ShouldReturnMissingKeyError(t *testing.T) {
+	client := Client{}
+	_, err := client.GetMediaContent("some-id", "some-media-id")
+	assert.ErrorContains(t, err, "missing private key")
+}
+
+func TestClient_GetMediaContent_ShouldReturnResponseError(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+			}, nil
+		},
+	}
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+
+	_, err := client.GetMediaContent("some-id", "some-media-id")
+	assert.ErrorContains(t, err, "400: unknown HTTP error")
+}
+
 func TestClient_DeleteMediaContent(t *testing.T) {
 	key, _ := rsa.GenerateKey(rand.Reader, 1024)
 	HTTPClient := &mockHTTPClient{
@@ -166,6 +341,34 @@ func TestClient_DeleteMediaContent(t *testing.T) {
 
 	err := client.DeleteMediaContent("some-session-id", "some-media-id")
 	assert.NilError(t, err)
+}
+
+func TestClient_DeleteMediaContent_ShouldReturnMissingKeyError(t *testing.T) {
+	client := Client{}
+	err := client.DeleteMediaContent("some-id", "some-media-id")
+	assert.ErrorContains(t, err, "missing private key")
+}
+
+func TestClient_DeleteMediaContent_ShouldReturnResponseError(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+			}, nil
+		},
+	}
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+
+	err := client.DeleteMediaContent("some-id", "some-media-id")
+	assert.ErrorContains(t, err, "400: unknown HTTP error")
 }
 
 func TestClient_GetSupportedDocuments(t *testing.T) {
@@ -209,6 +412,34 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 
 	assert.Equal(t, result.SupportedCountries[0].Code, countryCodeUSA)
 	assert.Equal(t, result.SupportedCountries[0].SupportedDocuments[0].Type, documentTypePassport)
+}
+
+func TestClient_GetSupportedDocuments_ShouldReturnMissingKeyError(t *testing.T) {
+	client := Client{}
+	_, err := client.GetSupportedDocuments()
+	assert.ErrorContains(t, err, "missing private key")
+}
+
+func TestClient_GetSupportedDocuments_ShouldReturnResponseError(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+			}, nil
+		},
+	}
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+
+	_, err := client.GetSupportedDocuments()
+	assert.ErrorContains(t, err, "400: unknown HTTP error")
 }
 
 func TestNewClient(t *testing.T) {
@@ -302,4 +533,63 @@ func Test_EmptySdkID(t *testing.T) {
 
 	_, err = client.GetSession("")
 	assert.ErrorContains(t, err, "sessionID cannot be an empty string")
+}
+
+func TestNewClient_KeyLoad_Failure(t *testing.T) {
+	key, _ := ioutil.ReadFile("../test/test-key-invalid-format.pem")
+	_, err := NewClient("sdkID", key)
+
+	assert.ErrorContains(t, err, "invalid key: not PEM-encoded")
+
+	tempError, temporary := err.(interface {
+		Temporary() bool
+	})
+	assert.Check(t, !temporary || !tempError.Temporary())
+}
+
+func TestClient_UsesDefaultApiUrl(t *testing.T) {
+	key, err := ioutil.ReadFile("../test/test-key.pem")
+	assert.NilError(t, err)
+
+	client, err := NewClient("sdkID", key)
+	assert.NilError(t, err)
+
+	assert.Equal(t, "https://api.yoti.com/idverify/v1", client.apiURL)
+}
+
+func TestClient_UsesEnvVariable(t *testing.T) {
+	key, err := ioutil.ReadFile("../test/test-key.pem")
+	assert.NilError(t, err)
+
+	os.Setenv("YOTI_DOC_SCAN_API_URL", "envBaseUrl")
+
+	client, err := NewClient("sdkID", key)
+	assert.NilError(t, err)
+
+	assert.Equal(t, "envBaseUrl", client.apiURL)
+}
+
+func TestClient_UsesOverrideApiUrlOverEnvVariable(t *testing.T) {
+	key, err := ioutil.ReadFile("../test/test-key.pem")
+	assert.NilError(t, err)
+
+	os.Setenv("YOTI_DOC_SCAN_API_URL", "envBaseUrl")
+
+	client, err := NewClient("sdkID", key)
+	assert.NilError(t, err)
+
+	client.OverrideAPIURL("overrideApiURL")
+
+	assert.Equal(t, "overrideApiURL", client.apiURL)
+}
+
+type mockJSONMarshaler struct {
+	marshal func(v interface{}) ([]byte, error)
+}
+
+func (mock *mockJSONMarshaler) Marshal(v interface{}) ([]byte, error) {
+	if mock.marshal != nil {
+		return mock.marshal(v)
+	}
+	return nil, nil
 }

--- a/docscan/session/create/check/face_match_test.go
+++ b/docscan/session/create/check/face_match_test.go
@@ -3,6 +3,9 @@ package check
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 func ExampleRequestedFaceMatchCheckBuilder() {
@@ -17,4 +20,40 @@ func ExampleRequestedFaceMatchCheckBuilder() {
 	data, _ := json.Marshal(check)
 	fmt.Println(string(data))
 	// Output: {"type":"ID_DOCUMENT_FACE_MATCH","config":{"manual_check":"NEVER"}}
+}
+
+func TestRequestedFaceMatchCheckBuilder_WithManualCheckAlways(t *testing.T) {
+	task, err := NewRequestedFaceMatchCheckBuilder().
+		WithManualCheckAlways().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedFaceMatchConfig)
+	assert.Equal(t, "ALWAYS", config.ManualCheck)
+}
+
+func TestRequestedFaceMatchCheckBuilder_WithManualCheckFallback(t *testing.T) {
+	task, err := NewRequestedFaceMatchCheckBuilder().
+		WithManualCheckFallback().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedFaceMatchConfig)
+	assert.Equal(t, "FALLBACK", config.ManualCheck)
+}
+
+func TestRequestedFaceMatchCheckBuilder_WithManualCheckNever(t *testing.T) {
+	task, err := NewRequestedFaceMatchCheckBuilder().
+		WithManualCheckNever().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedFaceMatchConfig)
+	assert.Equal(t, "NEVER", config.ManualCheck)
 }

--- a/docscan/session/create/filter/document_restriction_test.go
+++ b/docscan/session/create/filter/document_restriction_test.go
@@ -1,0 +1,49 @@
+package filter
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func ExampleRequestedDocumentRestriction() {
+	docRestriction, err := NewRequestedDocumentRestrictionBuilder().
+		WithDocumentTypes([]string{"PASSPORT"}).
+		WithCountryCodes([]string{"GBR"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(docRestriction)
+	fmt.Println(string(data))
+	// Output: {"document_types":["PASSPORT"],"country_codes":["GBR"]}
+}
+
+func ExampleRequestedDocumentRestrictionBuilder_WithDocumentTypes() {
+	docRestriction, err := NewRequestedDocumentRestrictionBuilder().
+		WithDocumentTypes([]string{"PASSPORT"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(docRestriction)
+	fmt.Println(string(data))
+	// Output: {"document_types":["PASSPORT"]}
+}
+
+func ExampleRequestedDocumentRestrictionBuilder_WithCountryCodes() {
+	docRestriction, err := NewRequestedDocumentRestrictionBuilder().
+		WithCountryCodes([]string{"GBR"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(docRestriction)
+	fmt.Println(string(data))
+	// Output: {"country_codes":["GBR"]}
+}

--- a/docscan/session/create/filter/document_restrictions_filter_test.go
+++ b/docscan/session/create/filter/document_restrictions_filter_test.go
@@ -1,0 +1,54 @@
+package filter
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func ExampleRequestedDocumentRestrictionsFilterBuilder_ForIncludeList() {
+	docRestriction, err := NewRequestedDocumentRestrictionBuilder().
+		WithDocumentTypes([]string{"PASSPORT"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	var docFilter *RequestedDocumentRestrictionsFilter
+	docFilter, err = NewRequestedDocumentRestrictionsFilterBuilder().
+		ForIncludeList().
+		WithDocumentRestriction(docRestriction).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(docFilter)
+	fmt.Println(string(data))
+	// Output: {"type":"DOCUMENT_RESTRICTIONS","inclusion":"WHITELIST","documents":[{"document_types":["PASSPORT"]}]}
+}
+
+func ExampleRequestedDocumentRestrictionsFilterBuilder_ForExcludeList() {
+	docRestriction, err := NewRequestedDocumentRestrictionBuilder().
+		WithDocumentTypes([]string{"PASSPORT"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	var docFilter *RequestedDocumentRestrictionsFilter
+	docFilter, err = NewRequestedDocumentRestrictionsFilterBuilder().
+		ForExcludeList().
+		WithDocumentRestriction(docRestriction).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(docFilter)
+	fmt.Println(string(data))
+	// Output: {"type":"DOCUMENT_RESTRICTIONS","inclusion":"BLACKLIST","documents":[{"document_types":["PASSPORT"]}]}
+}

--- a/docscan/session/create/sdk_config_test.go
+++ b/docscan/session/create/sdk_config_test.go
@@ -26,3 +26,18 @@ func ExampleSdkConfigBuilder_Build() {
 	fmt.Println(string(data))
 	// Output: {"allowed_capture_methods":"CAMERA","primary_colour":"#aa1111","secondary_colour":"#bb2222","font_colour":"#ff0000","locale":"fr_FR","preset_issuing_country":"USA","success_url":"https://successurl.com","error_url":"https://errorurl.com"}
 }
+
+func ExampleSdkConfigBuilder_WithAllowsCameraAndUpload() {
+	sdkConfig, err := NewSdkConfigBuilder().
+		WithAllowsCameraAndUpload().
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(sdkConfig)
+	fmt.Println(string(data))
+	// Output: {"allowed_capture_methods":"CAMERA_AND_UPLOAD"}
+}

--- a/docscan/session/create/session_spec_test.go
+++ b/docscan/session/create/session_spec_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/check"
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/filter"
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/task"
 )
 
@@ -59,6 +60,13 @@ func ExampleSessionSpecificationBuilder_Build() {
 		return
 	}
 
+	requiredIDDocument, err := filter.NewRequiredIDDocumentBuilder().
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	sessionSpecification, err := NewSessionSpecificationBuilder().
 		WithClientSessionTokenTTL(789).
 		WithResourcesTTL(456).
@@ -69,6 +77,7 @@ func ExampleSessionSpecificationBuilder_Build() {
 		WithRequestedCheck(livenessCheck).
 		WithRequestedTask(textExtractionTask).
 		WithSDKConfig(sdkConfig).
+		WithRequiredDocument(requiredIDDocument).
 		Build()
 
 	if err != nil {
@@ -78,5 +87,5 @@ func ExampleSessionSpecificationBuilder_Build() {
 
 	data, _ := json.Marshal(sessionSpecification)
 	fmt.Println(string(data))
-	// Output: {"client_session_token_ttl":789,"resources_ttl":456,"user_tracking_id":"some-tracking-id","notifications":{"topics":["some-topic"]},"requested_checks":[{"type":"ID_DOCUMENT_FACE_MATCH","config":{"manual_check":"NEVER"}},{"type":"ID_DOCUMENT_AUTHENTICITY","config":{}},{"type":"LIVENESS","config":{"max_retries":5,"liveness_type":"LIVENESSTYPE"}}],"requested_tasks":[{"type":"ID_DOCUMENT_TEXT_DATA_EXTRACTION","config":{"manual_check":"FALLBACK"}}],"sdk_config":{"allowed_capture_methods":"CAMERA"}}
+	// Output: {"client_session_token_ttl":789,"resources_ttl":456,"user_tracking_id":"some-tracking-id","notifications":{"topics":["some-topic"]},"requested_checks":[{"type":"ID_DOCUMENT_FACE_MATCH","config":{"manual_check":"NEVER"}},{"type":"ID_DOCUMENT_AUTHENTICITY","config":{}},{"type":"LIVENESS","config":{"max_retries":5,"liveness_type":"LIVENESSTYPE"}}],"requested_tasks":[{"type":"ID_DOCUMENT_TEXT_DATA_EXTRACTION","config":{"manual_check":"FALLBACK"}}],"sdk_config":{"allowed_capture_methods":"CAMERA"},"required_documents":[{"type":"ID_DOCUMENT"}]}
 }

--- a/docscan/session/create/task/text_extraction_test.go
+++ b/docscan/session/create/task/text_extraction_test.go
@@ -36,3 +36,63 @@ func TestRequestedTextExtractionTaskBuilder_Build_UsesLastManualCheck(t *testing
 	config := task.Config().(RequestedTextExtractionTaskConfig)
 	assert.Equal(t, "FALLBACK", config.ManualCheck)
 }
+
+func TestRequestedTextExtractionTaskBuilder_WithManualCheckAlways(t *testing.T) {
+	task, err := NewRequestedTextExtractionTaskBuilder().
+		WithManualCheckAlways().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedTextExtractionTaskConfig)
+	assert.Equal(t, "ALWAYS", config.ManualCheck)
+}
+
+func TestRequestedTextExtractionTaskBuilder_WithManualCheckFallback(t *testing.T) {
+	task, err := NewRequestedTextExtractionTaskBuilder().
+		WithManualCheckFallback().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedTextExtractionTaskConfig)
+	assert.Equal(t, "FALLBACK", config.ManualCheck)
+}
+
+func TestRequestedTextExtractionTaskBuilder_WithManualCheckNever(t *testing.T) {
+	task, err := NewRequestedTextExtractionTaskBuilder().
+		WithManualCheckNever().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedTextExtractionTaskConfig)
+	assert.Equal(t, "NEVER", config.ManualCheck)
+}
+
+func TestRequestedTextExtractionTaskBuilder_WithChipDataDesired(t *testing.T) {
+	task, err := NewRequestedTextExtractionTaskBuilder().
+		WithChipDataDesired().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedTextExtractionTaskConfig)
+	assert.Equal(t, "DESIRED", config.ChipData)
+}
+
+func TestRequestedTextExtractionTaskBuilder_WithChipDataIgnore(t *testing.T) {
+	task, err := NewRequestedTextExtractionTaskBuilder().
+		WithChipDataIgnore().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedTextExtractionTaskConfig)
+	assert.Equal(t, "IGNORE", config.ChipData)
+}

--- a/docscan/session/retrieve/get_session_result_test.go
+++ b/docscan/session/retrieve/get_session_result_test.go
@@ -60,3 +60,9 @@ func TestGetSessionResult_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, 1, len(result.LivenessChecks()))
 	assert.Check(t, result.LivenessChecks()[0].LastUpdated.Equal(testDate))
 }
+
+func TestGetSessionResult_UnmarshalJSON_Invalid(t *testing.T) {
+	var result GetSessionResult
+	err := result.UnmarshalJSON([]byte("some-invalid-json"))
+	assert.ErrorContains(t, err, "invalid character")
+}

--- a/docscan/session/retrieve/id_document_resource_response_test.go
+++ b/docscan/session/retrieve/id_document_resource_response_test.go
@@ -36,3 +36,9 @@ func TestIDDocumentResourceResponse_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, 1, len(result.TextExtractionTasks()))
 	assert.Equal(t, "some-id", result.TextExtractionTasks()[0].ID)
 }
+
+func TestIDDocumentResourceResponse_UnmarshalJSON_Invalid(t *testing.T) {
+	var result IDDocumentResourceResponse
+	err := result.UnmarshalJSON([]byte("some-invalid-json"))
+	assert.ErrorContains(t, err, "invalid character")
+}

--- a/docscan/session/retrieve/resource_container_test.go
+++ b/docscan/session/retrieve/resource_container_test.go
@@ -23,3 +23,9 @@ func TestLivenessResourceResponse_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, "IMAGE", result.ZoomLivenessResources()[0].Frames[0].Media.Type)
 	assert.Equal(t, "BINARY", result.ZoomLivenessResources()[0].FaceMap.Media.Type)
 }
+
+func TestLivenessResourceResponse_UnmarshalJSON_Invalid(t *testing.T) {
+	var result ResourceContainer
+	err := result.UnmarshalJSON([]byte("some-invalid-json"))
+	assert.ErrorContains(t, err, "invalid character")
+}

--- a/docscan/session/retrieve/task_response_test.go
+++ b/docscan/session/retrieve/task_response_test.go
@@ -31,3 +31,9 @@ func TestTaskResponse_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, 1, len(result.GeneratedTextDataChecks()))
 	assert.Equal(t, "some-id", result.GeneratedTextDataChecks()[0].ID)
 }
+
+func TestTaskResponse_UnmarshalJSON_Invalid(t *testing.T) {
+	var result TaskResponse
+	err := result.UnmarshalJSON([]byte("some-invalid-json"))
+	assert.ErrorContains(t, err, "invalid character")
+}


### PR DESCRIPTION
### Added
- Added Doc Scan test coverage

### Fixed
- `client.GetMediaContent()` content type validation - now returns error when content type is not available.