### PR TITLE
SDK-1733: Add manual fallback option to Doc Auth check

### DIFF
--- a/docscan/session/create/check/document_authenticity.go
+++ b/docscan/session/create/check/document_authenticity.go
@@ -36,6 +36,7 @@ func (c *RequestedDocumentAuthenticityCheck) MarshalJSON() ([]byte, error) {
 
 // RequestedDocumentAuthenticityConfig is the configuration applied when creating a Document Authenticity Check
 type RequestedDocumentAuthenticityConfig struct {
+	ManualCheck string `json:"manual_check,omitempty"`
 }
 
 // RequestedDocumentAuthenticityCheckBuilder builds a RequestedDocumentAuthenticityCheck
@@ -46,6 +47,24 @@ type RequestedDocumentAuthenticityCheckBuilder struct {
 // NewRequestedDocumentAuthenticityCheckBuilder creates a new DocumentAuthenticityCheckBuilder
 func NewRequestedDocumentAuthenticityCheckBuilder() *RequestedDocumentAuthenticityCheckBuilder {
 	return &RequestedDocumentAuthenticityCheckBuilder{}
+}
+
+// WithManualCheckAlways requires that a manual follow-up check is always performed
+func (b *RequestedDocumentAuthenticityCheckBuilder) WithManualCheckAlways() *RequestedDocumentAuthenticityCheckBuilder {
+	b.config.ManualCheck = constants.Always
+	return b
+}
+
+// WithManualCheckFallback requires that a manual follow-up check is performed only on failed Checks, and those with a low level of confidence
+func (b *RequestedDocumentAuthenticityCheckBuilder) WithManualCheckFallback() *RequestedDocumentAuthenticityCheckBuilder {
+	b.config.ManualCheck = constants.Fallback
+	return b
+}
+
+// WithManualCheckNever requires that only an automated Check is performed.  No manual follow-up Check will ever be initiated
+func (b *RequestedDocumentAuthenticityCheckBuilder) WithManualCheckNever() *RequestedDocumentAuthenticityCheckBuilder {
+	b.config.ManualCheck = constants.Never
+	return b
 }
 
 // Build builds the RequestedDocumentAuthenticityCheck

--- a/docscan/session/create/check/document_authenticity_test.go
+++ b/docscan/session/create/check/document_authenticity_test.go
@@ -21,6 +21,19 @@ func ExampleRequestedDocumentAuthenticityCheckBuilder() {
 	// Output: {"type":"ID_DOCUMENT_AUTHENTICITY","config":{"manual_check":"FALLBACK"}}
 }
 
+func ExampleRequestedDocumentAuthenticityCheckBuilder_Build() {
+	docAuthCheck, err := NewRequestedDocumentAuthenticityCheckBuilder().Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(docAuthCheck)
+	fmt.Println(string(data))
+	// Output: {"type":"ID_DOCUMENT_AUTHENTICITY","config":{}}
+}
+
 func TestRequestedDocumentAuthenticityCheckBuilder_WithManualCheckAlways(t *testing.T) {
 	docAuthCheck, err := NewRequestedDocumentAuthenticityCheckBuilder().
 		WithManualCheckAlways().

--- a/docscan/session/create/check/document_authenticity_test.go
+++ b/docscan/session/create/check/document_authenticity_test.go
@@ -3,17 +3,77 @@ package check
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 func ExampleRequestedDocumentAuthenticityCheckBuilder() {
-	check, err := NewRequestedDocumentAuthenticityCheckBuilder().Build()
+	docAuthCheck, err := NewRequestedDocumentAuthenticityCheckBuilder().WithManualCheckFallback().Build()
 
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())
 		return
 	}
 
-	data, _ := json.Marshal(check)
+	data, _ := json.Marshal(docAuthCheck)
 	fmt.Println(string(data))
-	// Output: {"type":"ID_DOCUMENT_AUTHENTICITY","config":{}}
+	// Output: {"type":"ID_DOCUMENT_AUTHENTICITY","config":{"manual_check":"FALLBACK"}}
+}
+
+func TestRequestedDocumentAuthenticityCheckBuilder_WithManualCheckAlways(t *testing.T) {
+	docAuthCheck, err := NewRequestedDocumentAuthenticityCheckBuilder().
+		WithManualCheckAlways().
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	result := docAuthCheck.Config().(RequestedDocumentAuthenticityConfig)
+	assert.Equal(t, "ALWAYS", result.ManualCheck)
+}
+
+func TestRequestedDocumentAuthenticityCheckBuilder_WithManualCheckFallback(t *testing.T) {
+	docAuthCheck, err := NewRequestedDocumentAuthenticityCheckBuilder().
+		WithManualCheckFallback().
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	result := docAuthCheck.Config().(RequestedDocumentAuthenticityConfig)
+	assert.Equal(t, "FALLBACK", result.ManualCheck)
+}
+
+func TestRequestedDocumentAuthenticityCheckBuilder_WithManualCheckNever(t *testing.T) {
+	docAuthCheck, err := NewRequestedDocumentAuthenticityCheckBuilder().
+		WithManualCheckNever().
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	result := docAuthCheck.Config().(RequestedDocumentAuthenticityConfig)
+	assert.Equal(t, "NEVER", result.ManualCheck)
+}
+
+func TestRequestedDocumentAuthenticityCheckBuilder_UsesLastValue(t *testing.T) {
+	docAuthCheck, err := NewRequestedDocumentAuthenticityCheckBuilder().
+		WithManualCheckFallback().
+		WithManualCheckNever().
+		WithManualCheckAlways().
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+	result := docAuthCheck.Config().(RequestedDocumentAuthenticityConfig)
+	assert.Equal(t, "ALWAYS", result.ManualCheck)
 }


### PR DESCRIPTION
### Added
- Ability to configure manual fallback value on Document Authenticity Check