### PR TITLE
SDK-1640: Chip Data

### DIFF
--- a/docscan/sandbox/request/task/document_text_data_extraction_task.go
+++ b/docscan/sandbox/request/task/document_text_data_extraction_task.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"encoding/base64"
+
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/filter"
 )
 
@@ -13,11 +15,18 @@ type DocumentTextDataExtractionTask struct {
 // DocumentTextDataExtractionTaskBuilder builds a DocumentTextDataExtractionTask
 type DocumentTextDataExtractionTaskBuilder struct {
 	documentTaskBuilder
-	documentFields map[string]interface{}
+	documentFields  map[string]interface{}
+	documentIDPhoto *documentIDPhoto
 }
 
 type documentTextDataExtractionTaskResult struct {
-	DocumentFields map[string]interface{} `json:"document_fields,omitempty"`
+	DocumentFields  map[string]interface{} `json:"document_fields,omitempty"`
+	DocumentIDPhoto *documentIDPhoto       `json:"document_id_photo,omitempty"`
+}
+
+type documentIDPhoto struct {
+	ContentType string `json:"content_type"`
+	Data        string `json:"data"`
 }
 
 // NewDocumentTextDataExtractionTaskBuilder creates a new DocumentTextDataExtractionTaskBuilder
@@ -46,12 +55,22 @@ func (b *DocumentTextDataExtractionTaskBuilder) WithDocumentFields(documentField
 	return b
 }
 
+// WithDocumentIDPhoto set the document ID photo
+func (b *DocumentTextDataExtractionTaskBuilder) WithDocumentIDPhoto(contentType string, data []byte) *DocumentTextDataExtractionTaskBuilder {
+	b.documentIDPhoto = &documentIDPhoto{
+		ContentType: contentType,
+		Data:        base64.StdEncoding.EncodeToString(data),
+	}
+	return b
+}
+
 // Build creates a new DocumentTextDataExtractionTask
 func (b *DocumentTextDataExtractionTaskBuilder) Build() (*DocumentTextDataExtractionTask, error) {
 	return &DocumentTextDataExtractionTask{
 		documentTask: b.documentTaskBuilder.build(),
 		Result: documentTextDataExtractionTaskResult{
-			DocumentFields: b.documentFields,
+			DocumentFields:  b.documentFields,
+			DocumentIDPhoto: b.documentIDPhoto,
 		},
 	}, nil
 }

--- a/docscan/sandbox/request/task/document_text_data_extraction_task_test.go
+++ b/docscan/sandbox/request/task/document_text_data_extraction_task_test.go
@@ -14,7 +14,7 @@ func ExampleDocumentTextDataExtractionTaskBuilder() {
 		return
 	}
 
-	check, err := NewDocumentTextDataExtractionTaskBuilder().
+	task, err := NewDocumentTextDataExtractionTaskBuilder().
 		WithDocumentFilter(docFilter).
 		WithDocumentField("some-key", "some-value").
 		WithDocumentField("some-other-key", map[string]string{
@@ -26,7 +26,7 @@ func ExampleDocumentTextDataExtractionTaskBuilder() {
 		return
 	}
 
-	data, _ := json.Marshal(check)
+	data, _ := json.Marshal(task)
 	fmt.Println(string(data))
 	// Output: {"document_filter":{"document_types":[],"country_codes":[]},"result":{"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}}}
 }
@@ -38,7 +38,7 @@ func ExampleDocumentTextDataExtractionTaskBuilder_WithDocumentFields() {
 		return
 	}
 
-	check, err := NewDocumentTextDataExtractionTaskBuilder().
+	task, err := NewDocumentTextDataExtractionTaskBuilder().
 		WithDocumentFilter(docFilter).
 		WithDocumentFields(map[string]interface{}{
 			"some-key": "some-value",
@@ -52,19 +52,33 @@ func ExampleDocumentTextDataExtractionTaskBuilder_WithDocumentFields() {
 		return
 	}
 
-	data, _ := json.Marshal(check)
+	data, _ := json.Marshal(task)
 	fmt.Println(string(data))
 	// Output: {"document_filter":{"document_types":[],"country_codes":[]},"result":{"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}}}
 }
 
-func ExampleDocumentTextDataExtractionTaskBuilder_minimal() {
-	check, err := NewDocumentTextDataExtractionTaskBuilder().Build()
+func ExampleDocumentTextDataExtractionTaskBuilder_WithDocumentIDPhoto() {
+	task, err := NewDocumentTextDataExtractionTaskBuilder().
+		WithDocumentIDPhoto("some-content-type", []byte{0xDE, 0xAD, 0xBE, 0xEF}).
+		Build()
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())
 		return
 	}
 
-	data, _ := json.Marshal(check)
+	data, _ := json.Marshal(task)
+	fmt.Println(string(data))
+	// Output: {"result":{"document_id_photo":{"content_type":"some-content-type","data":"3q2+7w=="}}}
+}
+
+func ExampleDocumentTextDataExtractionTaskBuilder_minimal() {
+	task, err := NewDocumentTextDataExtractionTaskBuilder().Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(task)
 	fmt.Println(string(data))
 	// Output: {"result":{}}
 }


### PR DESCRIPTION
### Added
- Sandbox support for setting document ID photo

Note: SDK already allows chip data to be ignored/desired and parses ID photo in response