### PR TITLE
SDK-1715: Supplementary Documents

### DIFF
--- a/_examples/docscan/templates/check.html
+++ b/_examples/docscan/templates/check.html
@@ -103,11 +103,11 @@
                         <tbody>
                         <tr>
                             <td>ID</td>
-                            <td><a href="/media?mediaId={{ .media.ID }}">{{ .media.ID }}</a></td>
+                            <td><a href="/media?mediaId={{ $media.ID }}">{{ $media.ID }}</a></td>
                         </tr>
                         <tr>
                             <td>Type</td>
-                            <td>{{ .media.Type }}</td>
+                            <td>{{ $media.Type }}</td>
                         </tr>
                         </tbody>
                     </table>

--- a/_examples/docscan/templates/success.html
+++ b/_examples/docscan/templates/success.html
@@ -73,20 +73,20 @@
                             </div>
                         </div>
                     {{ end }}
-                    {{ if .getSessionResult.TextDataChecks }}
+                    {{ if .getSessionResult.IDDocumentTextDataChecks }}
                         <div class="card">
                             <div class="card-header" id="text-data-checks">
                                 <h3 class="mb-0">
                                     <button class="btn btn-link" type="button" data-toggle="collapse"
                                             data-target="#collapse-text-data-checks" aria-expanded="true"
                                             aria-controls="collapse-text-data-checks">
-                                        Text Data Checks
+                                        ID Document Text Data Checks
                                     </button>
                                 </h3>
                             </div>
                             <div id="collapse-text-data-checks" class="collapse" aria-labelledby="text-data-checks">
                                 <div class="card-body">
-                                    {{ range $check :=  .getSessionResult.TextDataChecks }}
+                                    {{ range $check :=  .getSessionResult.IDDocumentTextDataChecks }}
                                         {{ template "check.html" $check }}
                                     {{ end }}
                                 </div>
@@ -154,10 +154,33 @@
                         </div>
                     </div>
                     {{ end }}
+
+                    {{ if .getSessionResult.SupplementaryDocumentTextDataChecks }}
+                    <div class="card">
+                        <div class="card-header" id="sup-doc-text-data-checks">
+                            <h3 class="mb-0">
+                                <button class="btn btn-link" type="button" data-toggle="collapse"
+                                        data-target="#collapse-sup-doc-text-data-checks" aria-expanded="true"
+                                        aria-controls="collapse-sup-doc-text-data-checks">
+                                    Supplementary Document Text Data Checks
+                                </button>
+                            </h3>
+                        </div>
+                        <div id="collapse-sup-doc-text-data-checks" class="collapse" aria-labelledby="sup-doc-text-data-checks">
+                            <div class="card-body">
+                                {{ range $check :=  .getSessionResult.SupplementaryDocumentTextDataChecks }}
+                                    {{ template "check.html" $check }}
+                                {{ end }}
+                            </div>
+                        </div>
+                    </div>
+                    {{ end }}
+
                 </div>
             </div>
         </div>
     {{ end }}
+
     {{ if .getSessionResult.Resources.IDDocuments }}
         <div class="row pt-4">
             <div class="col">
@@ -309,6 +332,186 @@
                             </div>
                             <div id="collapse-document-pages-{{ $key }}-{{ $pageNum }}" class="collapse"
                                  aria-labelledby="document-pages-{{ $key }}-{{ $pageNum }}">
+
+                                <div class="card-group">
+                                    {{ if $page.Media }}
+                                        <div class="card" style="width: 18rem;">
+                                            <img class="card-img-top"
+                                                    src="/media?mediaId={{ $page.Media.ID }}"/>
+                                            <div class="card-body">
+                                                <p>Method: {{ $page.CaptureMethod }}</p>
+                                            </div>
+                                        </div>
+                                    {{ end }}
+                                </div>
+
+                                {{ if $page.Frames}}
+                                <div class="card-group">
+                                    {{ range $frame := $page.Frames }}
+                                        {{ if $frame.Media }}
+                                            <div class="card">
+                                                <img class="card-img-top"
+                                                    src="/media?mediaId={{ $frame.Media.ID }}"/>
+                                                <div class="card-body">
+                                                    <h5 class="card-title">Frame</h5>
+                                                </div>
+                                            </div>
+                                        {{ end }}
+                                    {{ end }}
+                                </div>
+                                {{ end }}
+
+                            </div>
+                        </div>
+                    {{ end }}
+                    {{ end }}
+                </div>
+            </div>
+        </div>
+    {{ end }}
+
+
+    {{ if .getSessionResult.Resources.SupplementaryDocuments }}
+        <div class="row pt-4">
+            <div class="col">
+                <h2>Supplementary Documents</h2>
+            </div>
+        </div>
+    {{ end }}
+
+    {{ range $key, $doc := .getSessionResult.Resources.SupplementaryDocuments }}
+        <div class="row pt-4">
+            <div class="col">
+
+                <h3>
+                    {{ $doc.DocumentType }} <span
+                            class="badge badge-primary">{{ $doc.IssuingCountry }}</span>
+                </h3>
+
+                <div class="accordion mt-3">
+                    {{ if $doc.DocumentFields }}
+                        <div class="card">
+                            <div class="card-header" id="sup-doc-fields-{{ $key }}">
+                                <h4 class="mb-0">
+                                    <button class="btn btn-link" type="button" data-toggle="collapse"
+                                            data-target="#collapse-sup-doc-fields-{{ $key }}"
+                                            aria-expanded="true"
+                                            aria-controls="collapse-sup-doc-fields-{{ $key }}">
+                                        Document Fields
+                                    </button>
+                                </h4>
+                            </div>
+                            <div id="collapse-sup-doc-fields-{{ $key }}" class="collapse"
+                                 aria-labelledby="sup-doc-fields-{{ $key }}">
+                                <div class="card-body">
+                                    {{ if $doc.DocumentFields.Media }}
+                                        <h5>Media</h5>
+                                        <table class="table table-striped table-light">
+                                            <tbody>
+                                            <tr>
+                                                <td>ID</td>
+                                                <td>
+                                                    <a href="/media?mediaId={{ $doc.DocumentFields.Media.ID }}">
+                                                        {{ $doc.DocumentFields.Media.ID }}
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    {{ end }}
+                                </div>
+                            </div>
+                        </div>
+                    {{ end }}
+
+                    {{ if $doc.DocumentFile }}
+                    <div class="card">
+                        <div class="card-header" id="sup-doc-id-photo-{{ $key }}">
+                            <h4 class="mb-0">
+                            {{ if $doc.DocumentFile.Media }}
+                            <a class="btn btn-link" type="button" href="/media?mediaId={{ $doc.DocumentFile.Media.ID }}">
+                                Download File
+                            </a>
+                            {{ end }}
+                            </h4>
+                        </div>
+                    </div>
+                    {{ end }}
+
+                    {{ if $doc.TextExtractionTasks }}
+                        <div class="card">
+                            <div class="card-header" id="sup-doc-text-extraction-tasks-{{ $key }}">
+                                <h4 class="mb-0">
+                                    <button class="btn btn-link" type="button" data-toggle="collapse"
+                                            data-target="#collapse-sup-doc-text-extraction-tasks-{{ $key }}"
+                                            aria-expanded="true"
+                                            aria-controls="collapse-sup-doc-text-extraction-tasks-{{ $key }}">
+                                        Text Extraction Tasks
+                                    </button>
+                                </h4>
+                            </div>
+                            <div id="collapse-sup-doc-text-extraction-tasks-{{ $key }}" class="collapse"
+                                 aria-labelledby="sup-doc-text-extraction-tasks-{{ $key }}">
+                                <div class="card-body">
+                                    {{ range $task := $doc.TextExtractionTasks }}
+                                        {{ template "task.html" $task }}
+
+                                        {{ if $task.GeneratedTextDataChecks}}
+                                            <h5>Generated Text Data Checks</h5>
+
+                                            {{ range $generatedCheck := $task.GeneratedTextDataChecks }}
+                                                <table class="table table-striped">
+                                                    <tbody>
+                                                    <tr>
+                                                        <td>ID</td>
+                                                        <td>{{ $generatedCheck.ID }}</td>
+                                                    </tr>
+                                                    </tbody>
+                                                </table>
+                                            {{ end }}
+                                        {{ end }}
+
+                                        {{ if $task.GeneratedMedia}}
+                                            <h5>Generated Media</h5>
+
+                                            {{ range $generatedMedia := $task.GeneratedMedia }}
+                                                <table class="table table-striped">
+                                                    <tbody>
+                                                    <tr>
+                                                        <td>ID</td>
+                                                        <td>
+                                                            <a href="/media?mediaId={{ $generatedMedia.ID }}">{{ $generatedMedia.ID }}</a>
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>Type</td>
+                                                        <td>{{ $generatedMedia.Type }}</td>
+                                                    </tr>
+                                                    </tbody>
+                                                </table>
+                                            {{ end }}
+                                        {{ end }}
+                                    {{ end }}
+                                </div>
+                            </div>
+                        </div>
+                    {{ end }}
+
+                    {{ if $doc.Pages }}
+                    {{ range $pageNum, $page := $doc.Pages }}
+                        <div class="card">
+                            <div class="card-header" id="sup-doc-pages-{{ $key }}-{{ $pageNum }}">
+                                <h4 class="mb-0">
+                                    <button class="btn btn-link" type="button" data-toggle="collapse"
+                                            data-target="#collapse-sup-doc-pages-{{ $key }}-{{ $pageNum }}"
+                                            aria-expanded="true"
+                                            aria-controls="collapse-sup-doc-pages-{{ $key }}-{{ $pageNum }}">
+                                        Page {{call $.add $pageNum 1}}
+                                    </button>
+                                </h4>
+                            </div>
+                            <div id="collapse-sup-doc-pages-{{ $key }}-{{ $pageNum }}" class="collapse"
+                                 aria-labelledby="sup-doc-pages-{{ $key }}-{{ $pageNum }}">
 
                                 <div class="card-group">
                                     {{ if $page.Media }}

--- a/docscan/constants/constants.go
+++ b/docscan/constants/constants.go
@@ -1,13 +1,15 @@
 package constants
 
 const (
-	IDDocumentAuthenticity       string = "ID_DOCUMENT_AUTHENTICITY"
-	IDDocumentComparison         string = "ID_DOCUMENT_COMPARISON"
-	IDDocumentTextDataCheck      string = "ID_DOCUMENT_TEXT_DATA_CHECK"
-	IDDocumentTextDataExtraction string = "ID_DOCUMENT_TEXT_DATA_EXTRACTION"
-	IDDocumentFaceMatch          string = "ID_DOCUMENT_FACE_MATCH"
-	Liveness                     string = "LIVENESS"
-	Zoom                         string = "ZOOM"
+	IDDocumentAuthenticity                  string = "ID_DOCUMENT_AUTHENTICITY"
+	IDDocumentComparison                    string = "ID_DOCUMENT_COMPARISON"
+	IDDocumentTextDataCheck                 string = "ID_DOCUMENT_TEXT_DATA_CHECK"
+	IDDocumentTextDataExtraction            string = "ID_DOCUMENT_TEXT_DATA_EXTRACTION"
+	IDDocumentFaceMatch                     string = "ID_DOCUMENT_FACE_MATCH"
+	SupplementaryDocumentTextDataCheck      string = "SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK"
+	SupplementaryDocumentTextDataExtraction string = "SUPPLEMENTARY_DOCUMENT_TEXT_DATA_EXTRACTION"
+	Liveness                                string = "LIVENESS"
+	Zoom                                    string = "ZOOM"
 
 	Camera          string = "CAMERA"
 	CameraAndUpload string = "CAMERA_AND_UPLOAD"
@@ -20,4 +22,6 @@ const (
 	Always   string = "ALWAYS"
 	Fallback string = "FALLBACK"
 	Never    string = "NEVER"
+
+	ProofOfAddress string = "PROOF_OF_ADDRESS"
 )

--- a/docscan/sandbox/request/check/document_text_data_check.go
+++ b/docscan/sandbox/request/check/document_text_data_check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/filter"
 )
 
-// DocumentTextDataCheck Represents a document text data check
+// DocumentTextDataCheck represents a document text data check
 type DocumentTextDataCheck struct {
 	Result DocumentTextDataCheckResult `json:"result"`
 	*documentCheck

--- a/docscan/sandbox/request/check/supplementary_document_text_data_check.go
+++ b/docscan/sandbox/request/check/supplementary_document_text_data_check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/filter"
 )
 
-// DocumentTextDataCheck Represents a document text data check
+// SupplementaryDocumentTextDataCheck represents a supplementary document text data check
 type SupplementaryDocumentTextDataCheck struct {
 	Result SupplementaryDocumentTextDataCheckResult `json:"result"`
 	*documentCheck
@@ -17,7 +17,7 @@ type SupplementaryDocumentTextDataCheckBuilder struct {
 	documentFields map[string]interface{}
 }
 
-// SupplementaryDocumentTextDataCheckResult represent a document text data check result
+// SupplementaryDocumentTextDataCheckResult represents a document text data check result
 type SupplementaryDocumentTextDataCheckResult struct {
 	checkResult
 	DocumentFields map[string]interface{} `json:"document_fields,omitempty"`

--- a/docscan/sandbox/request/check/supplementary_document_text_data_check.go
+++ b/docscan/sandbox/request/check/supplementary_document_text_data_check.go
@@ -1,0 +1,75 @@
+package check
+
+import (
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/check/report"
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/filter"
+)
+
+// DocumentTextDataCheck Represents a document text data check
+type SupplementaryDocumentTextDataCheck struct {
+	Result SupplementaryDocumentTextDataCheckResult `json:"result"`
+	*documentCheck
+}
+
+// SupplementaryDocumentTextDataCheckBuilder builds a SupplementaryDocumentTextDataCheck
+type SupplementaryDocumentTextDataCheckBuilder struct {
+	documentCheckBuilder
+	documentFields map[string]interface{}
+}
+
+// SupplementaryDocumentTextDataCheckResult represent a document text data check result
+type SupplementaryDocumentTextDataCheckResult struct {
+	checkResult
+	DocumentFields map[string]interface{} `json:"document_fields,omitempty"`
+}
+
+// NewSupplementaryDocumentTextDataCheckBuilder builds a new SupplementaryDocumentTextDataCheckResult
+func NewSupplementaryDocumentTextDataCheckBuilder() *SupplementaryDocumentTextDataCheckBuilder {
+	return &SupplementaryDocumentTextDataCheckBuilder{}
+}
+
+// WithRecommendation sets the recommendation on the check
+func (b *SupplementaryDocumentTextDataCheckBuilder) WithRecommendation(recommendation *report.Recommendation) *SupplementaryDocumentTextDataCheckBuilder {
+	b.documentCheckBuilder.withRecommendation(recommendation)
+	return b
+}
+
+// WithBreakdown adds a breakdown item to the check
+func (b *SupplementaryDocumentTextDataCheckBuilder) WithBreakdown(breakdown *report.Breakdown) *SupplementaryDocumentTextDataCheckBuilder {
+	b.documentCheckBuilder.withBreakdown(breakdown)
+	return b
+}
+
+// WithDocumentFilter adds a document filter to the check
+func (b *SupplementaryDocumentTextDataCheckBuilder) WithDocumentFilter(filter *filter.DocumentFilter) *SupplementaryDocumentTextDataCheckBuilder {
+	b.documentCheckBuilder.withDocumentFilter(filter)
+	return b
+}
+
+// WithDocumentField adds a document field to the text data check
+func (b *SupplementaryDocumentTextDataCheckBuilder) WithDocumentField(key string, value interface{}) *SupplementaryDocumentTextDataCheckBuilder {
+	if b.documentFields == nil {
+		b.documentFields = make(map[string]interface{})
+	}
+	b.documentFields[key] = value
+	return b
+}
+
+// WithDocumentFields sets document fields
+func (b *SupplementaryDocumentTextDataCheckBuilder) WithDocumentFields(documentFields map[string]interface{}) *SupplementaryDocumentTextDataCheckBuilder {
+	b.documentFields = documentFields
+	return b
+}
+
+// Build creates a new SupplementaryDocumentTextDataCheck
+func (b *SupplementaryDocumentTextDataCheckBuilder) Build() (*SupplementaryDocumentTextDataCheck, error) {
+	docCheck := b.documentCheckBuilder.build()
+
+	return &SupplementaryDocumentTextDataCheck{
+		documentCheck: docCheck,
+		Result: SupplementaryDocumentTextDataCheckResult{
+			checkResult:    docCheck.Result,
+			DocumentFields: b.documentFields,
+		},
+	}, nil
+}

--- a/docscan/sandbox/request/check/supplementary_document_text_data_check_test.go
+++ b/docscan/sandbox/request/check/supplementary_document_text_data_check_test.go
@@ -46,7 +46,12 @@ func ExampleSupplementaryDocumentTextDataCheckBuilder() {
 		return
 	}
 
-	data, _ := json.Marshal(check)
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]},"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}},"document_filter":{"document_types":[],"country_codes":[]}}
 }
@@ -65,7 +70,12 @@ func ExampleSupplementaryDocumentTextDataCheckBuilder_WithDocumentFields() {
 		return
 	}
 
-	data, _ := json.Marshal(check)
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{},"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}}}
 }
@@ -77,7 +87,12 @@ func ExampleSupplementaryDocumentTextDataCheckBuilder_minimal() {
 		return
 	}
 
-	data, _ := json.Marshal(check)
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{}}}
 }

--- a/docscan/sandbox/request/check/supplementary_document_text_data_check_test.go
+++ b/docscan/sandbox/request/check/supplementary_document_text_data_check_test.go
@@ -1,0 +1,83 @@
+package check
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/check/report"
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/filter"
+)
+
+func ExampleSupplementaryDocumentTextDataCheckBuilder() {
+	breakdown, err := report.NewBreakdownBuilder().
+		WithResult("some_result").
+		WithSubCheck("some_check").
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	recommendation, err := report.NewRecommendationBuilder().
+		WithValue("some_value").
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	docFilter, err := filter.NewDocumentFilterBuilder().Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	check, err := NewSupplementaryDocumentTextDataCheckBuilder().
+		WithBreakdown(breakdown).
+		WithRecommendation(recommendation).
+		WithDocumentFilter(docFilter).
+		WithDocumentField("some-key", "some-value").
+		WithDocumentField("some-other-key", map[string]string{
+			"some-nested-key": "some-nested-value",
+		}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(check)
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]},"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}},"document_filter":{"document_types":[],"country_codes":[]}}
+}
+
+func ExampleSupplementaryDocumentTextDataCheckBuilder_WithDocumentFields() {
+	check, err := NewSupplementaryDocumentTextDataCheckBuilder().
+		WithDocumentFields(map[string]interface{}{
+			"some-key": "some-value",
+			"some-other-key": map[string]string{
+				"some-nested-key": "some-nested-value",
+			},
+		}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(check)
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{},"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}}}
+}
+
+func ExampleSupplementaryDocumentTextDataCheckBuilder_minimal() {
+	check, err := NewSupplementaryDocumentTextDataCheckBuilder().Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(check)
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}}}
+}

--- a/docscan/sandbox/request/check_reports.go
+++ b/docscan/sandbox/request/check_reports.go
@@ -50,7 +50,7 @@ func (b *CheckReportsBuilder) WithDocumentTextDataCheck(documentTextDataCheck *c
 	return b
 }
 
-// WithDocumentTextDataCheck adds an supplementary document text data check
+// WithDocumentTextDataCheck adds a supplementary document text data check
 func (b *CheckReportsBuilder) WithSupplementaryDocumentTextDataCheck(supplementaryDocumentTextDataCheck *check.SupplementaryDocumentTextDataCheck) *CheckReportsBuilder {
 	b.supplementaryDocumentTextDataChecks = append(
 		b.supplementaryDocumentTextDataChecks,

--- a/docscan/sandbox/request/check_reports.go
+++ b/docscan/sandbox/request/check_reports.go
@@ -6,32 +6,35 @@ import (
 
 // CheckReports represents check reports
 type CheckReports struct {
-	DocumentAuthenticityChecks []*check.DocumentAuthenticityCheck `json:"ID_DOCUMENT_AUTHENTICITY"`
-	DocumentTextDataChecks     []*check.DocumentTextDataCheck     `json:"ID_DOCUMENT_TEXT_DATA_CHECK"`
-	DocumentFaceMatchChecks    []*check.DocumentFaceMatchCheck    `json:"ID_DOCUMENT_FACE_MATCH"`
-	LivenessChecks             []*check.LivenessCheck             `json:"LIVENESS"`
-	IDDocumentComparisonChecks []*check.IDDocumentComparisonCheck `json:"ID_DOCUMENT_COMPARISON"`
-	AsyncReportDelay           uint32                             `json:"async_report_delay,omitempty"`
+	DocumentAuthenticityChecks          []*check.DocumentAuthenticityCheck          `json:"ID_DOCUMENT_AUTHENTICITY"`
+	DocumentTextDataChecks              []*check.DocumentTextDataCheck              `json:"ID_DOCUMENT_TEXT_DATA_CHECK"`
+	DocumentFaceMatchChecks             []*check.DocumentFaceMatchCheck             `json:"ID_DOCUMENT_FACE_MATCH"`
+	LivenessChecks                      []*check.LivenessCheck                      `json:"LIVENESS"`
+	IDDocumentComparisonChecks          []*check.IDDocumentComparisonCheck          `json:"ID_DOCUMENT_COMPARISON"`
+	SupplementaryDocumentTextDataChecks []*check.SupplementaryDocumentTextDataCheck `json:"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK"`
+	AsyncReportDelay                    uint32                                      `json:"async_report_delay,omitempty"`
 }
 
 // CheckReportsBuilder builds CheckReports
 type CheckReportsBuilder struct {
-	documentAuthenticityChecks []*check.DocumentAuthenticityCheck
-	documentTextDataChecks     []*check.DocumentTextDataCheck
-	documentFaceMatchChecks    []*check.DocumentFaceMatchCheck
-	livenessChecks             []*check.LivenessCheck
-	idDocumentComparisonChecks []*check.IDDocumentComparisonCheck
-	asyncReportDelay           uint32
+	documentAuthenticityChecks          []*check.DocumentAuthenticityCheck
+	documentTextDataChecks              []*check.DocumentTextDataCheck
+	documentFaceMatchChecks             []*check.DocumentFaceMatchCheck
+	livenessChecks                      []*check.LivenessCheck
+	idDocumentComparisonChecks          []*check.IDDocumentComparisonCheck
+	supplementaryDocumentTextDataChecks []*check.SupplementaryDocumentTextDataCheck
+	asyncReportDelay                    uint32
 }
 
 // NewCheckReportsBuilder creates a new CheckReportsBuilder
 func NewCheckReportsBuilder() *CheckReportsBuilder {
 	return &CheckReportsBuilder{
-		documentAuthenticityChecks: []*check.DocumentAuthenticityCheck{},
-		documentTextDataChecks:     []*check.DocumentTextDataCheck{},
-		documentFaceMatchChecks:    []*check.DocumentFaceMatchCheck{},
-		livenessChecks:             []*check.LivenessCheck{},
-		idDocumentComparisonChecks: []*check.IDDocumentComparisonCheck{},
+		documentAuthenticityChecks:          []*check.DocumentAuthenticityCheck{},
+		documentTextDataChecks:              []*check.DocumentTextDataCheck{},
+		documentFaceMatchChecks:             []*check.DocumentFaceMatchCheck{},
+		livenessChecks:                      []*check.LivenessCheck{},
+		idDocumentComparisonChecks:          []*check.IDDocumentComparisonCheck{},
+		supplementaryDocumentTextDataChecks: []*check.SupplementaryDocumentTextDataCheck{},
 	}
 }
 
@@ -44,6 +47,15 @@ func (b *CheckReportsBuilder) WithDocumentAuthenticityCheck(documentAuthenticity
 // WithDocumentTextDataCheck adds a document text data check
 func (b *CheckReportsBuilder) WithDocumentTextDataCheck(documentTextDataCheck *check.DocumentTextDataCheck) *CheckReportsBuilder {
 	b.documentTextDataChecks = append(b.documentTextDataChecks, documentTextDataCheck)
+	return b
+}
+
+// WithDocumentTextDataCheck adds an supplementary document text data check
+func (b *CheckReportsBuilder) WithSupplementaryDocumentTextDataCheck(supplementaryDocumentTextDataCheck *check.SupplementaryDocumentTextDataCheck) *CheckReportsBuilder {
+	b.supplementaryDocumentTextDataChecks = append(
+		b.supplementaryDocumentTextDataChecks,
+		supplementaryDocumentTextDataCheck,
+	)
 	return b
 }
 
@@ -61,8 +73,6 @@ func (b *CheckReportsBuilder) WithLivenessCheck(livenessCheck *check.LivenessChe
 
 // WithIDDocumentComparisonCheck adds an identity document comparison check
 func (b *CheckReportsBuilder) WithIDDocumentComparisonCheck(idDocumentComparisonCheck *check.IDDocumentComparisonCheck) *CheckReportsBuilder {
-	// fmt.Printf("idDocumentComparisonCheck = %v", idDocumentComparisonCheck)
-	// fmt.Printf("b.idDocumentComparisonChecks = %v", b.idDocumentComparisonChecks)
 	b.idDocumentComparisonChecks = append(b.idDocumentComparisonChecks, idDocumentComparisonCheck)
 	return b
 }
@@ -76,11 +86,12 @@ func (b *CheckReportsBuilder) WithAsyncReportDelay(asyncReportDelay uint32) *Che
 // Build creates CheckReports
 func (b *CheckReportsBuilder) Build() (CheckReports, error) {
 	return CheckReports{
-		DocumentAuthenticityChecks: b.documentAuthenticityChecks,
-		DocumentTextDataChecks:     b.documentTextDataChecks,
-		DocumentFaceMatchChecks:    b.documentFaceMatchChecks,
-		LivenessChecks:             b.livenessChecks,
-		IDDocumentComparisonChecks: b.idDocumentComparisonChecks,
-		AsyncReportDelay:           b.asyncReportDelay,
+		DocumentAuthenticityChecks:          b.documentAuthenticityChecks,
+		DocumentTextDataChecks:              b.documentTextDataChecks,
+		DocumentFaceMatchChecks:             b.documentFaceMatchChecks,
+		LivenessChecks:                      b.livenessChecks,
+		IDDocumentComparisonChecks:          b.idDocumentComparisonChecks,
+		SupplementaryDocumentTextDataChecks: b.supplementaryDocumentTextDataChecks,
+		AsyncReportDelay:                    b.asyncReportDelay,
 	}, nil
 }

--- a/docscan/sandbox/request/check_reports_test.go
+++ b/docscan/sandbox/request/check_reports_test.go
@@ -54,6 +54,15 @@ func ExampleCheckReportsBuilder() {
 		return
 	}
 
+	supplementaryDocumentTextDataCheck, err := check.NewSupplementaryDocumentTextDataCheckBuilder().
+		WithBreakdown(breakdown).
+		WithRecommendation(recommendation).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	zoomLivenessCheck, err := check.NewZoomLivenessCheckBuilder().Build()
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())
@@ -75,6 +84,7 @@ func ExampleCheckReportsBuilder() {
 		WithDocumentTextDataCheck(textDataCheck).
 		WithLivenessCheck(zoomLivenessCheck).
 		WithIDDocumentComparisonCheck(idDocumentComparisonCheck).
+		WithSupplementaryDocumentTextDataCheck(supplementaryDocumentTextDataCheck).
 		WithAsyncReportDelay(10).
 		Build()
 	if err != nil {
@@ -84,7 +94,7 @@ func ExampleCheckReportsBuilder() {
 
 	data, _ := json.Marshal(checkReports)
 	fmt.Println(string(data))
-	// Output: {"ID_DOCUMENT_AUTHENTICITY":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"ID_DOCUMENT_TEXT_DATA_CHECK":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"ID_DOCUMENT_FACE_MATCH":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"LIVENESS":[{"result":{"report":{}},"liveness_type":"ZOOM"}],"ID_DOCUMENT_COMPARISON":[{"result":{"report":{}},"secondary_document_filter":{"document_types":[],"country_codes":[]}}],"async_report_delay":10}
+	// Output: {"ID_DOCUMENT_AUTHENTICITY":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"ID_DOCUMENT_TEXT_DATA_CHECK":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"ID_DOCUMENT_FACE_MATCH":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"LIVENESS":[{"result":{"report":{}},"liveness_type":"ZOOM"}],"ID_DOCUMENT_COMPARISON":[{"result":{"report":{}},"secondary_document_filter":{"document_types":[],"country_codes":[]}}],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"async_report_delay":10}
 }
 
 func ExampleCheckReportsBuilder_minimal() {
@@ -96,5 +106,5 @@ func ExampleCheckReportsBuilder_minimal() {
 
 	data, _ := json.Marshal(checkReports)
 	fmt.Println(string(data))
-	// Output: {"ID_DOCUMENT_AUTHENTICITY":[],"ID_DOCUMENT_TEXT_DATA_CHECK":[],"ID_DOCUMENT_FACE_MATCH":[],"LIVENESS":[],"ID_DOCUMENT_COMPARISON":[]}
+	// Output: {"ID_DOCUMENT_AUTHENTICITY":[],"ID_DOCUMENT_TEXT_DATA_CHECK":[],"ID_DOCUMENT_FACE_MATCH":[],"LIVENESS":[],"ID_DOCUMENT_COMPARISON":[],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK":[]}
 }

--- a/docscan/sandbox/request/check_reports_test.go
+++ b/docscan/sandbox/request/check_reports_test.go
@@ -92,7 +92,12 @@ func ExampleCheckReportsBuilder() {
 		return
 	}
 
-	data, _ := json.Marshal(checkReports)
+	data, err := json.Marshal(checkReports)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"ID_DOCUMENT_AUTHENTICITY":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"ID_DOCUMENT_TEXT_DATA_CHECK":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"ID_DOCUMENT_FACE_MATCH":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"LIVENESS":[{"result":{"report":{}},"liveness_type":"ZOOM"}],"ID_DOCUMENT_COMPARISON":[{"result":{"report":{}},"secondary_document_filter":{"document_types":[],"country_codes":[]}}],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK":[{"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}],"async_report_delay":10}
 }
@@ -104,7 +109,12 @@ func ExampleCheckReportsBuilder_minimal() {
 		return
 	}
 
-	data, _ := json.Marshal(checkReports)
+	data, err := json.Marshal(checkReports)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"ID_DOCUMENT_AUTHENTICITY":[],"ID_DOCUMENT_TEXT_DATA_CHECK":[],"ID_DOCUMENT_FACE_MATCH":[],"LIVENESS":[],"ID_DOCUMENT_COMPARISON":[],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK":[]}
 }

--- a/docscan/sandbox/request/response_config_test.go
+++ b/docscan/sandbox/request/response_config_test.go
@@ -38,7 +38,7 @@ func ExampleResponseConfigBuilder() {
 
 	data, _ := json.Marshal(responseConfig)
 	fmt.Println(string(data))
-	// Output: {"task_results":{"ID_DOCUMENT_TEXT_DATA_EXTRACTION":[]},"check_reports":{"ID_DOCUMENT_AUTHENTICITY":[],"ID_DOCUMENT_TEXT_DATA_CHECK":[],"ID_DOCUMENT_FACE_MATCH":[],"LIVENESS":[],"ID_DOCUMENT_COMPARISON":[]}}
+	// Output: {"task_results":{"ID_DOCUMENT_TEXT_DATA_EXTRACTION":[],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_EXTRACTION":[]},"check_reports":{"ID_DOCUMENT_AUTHENTICITY":[],"ID_DOCUMENT_TEXT_DATA_CHECK":[],"ID_DOCUMENT_FACE_MATCH":[],"LIVENESS":[],"ID_DOCUMENT_COMPARISON":[],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK":[]}}
 }
 
 func ExampleResponseConfigBuilder_minimal() {
@@ -58,5 +58,5 @@ func ExampleResponseConfigBuilder_minimal() {
 
 	data, _ := json.Marshal(responseConfig)
 	fmt.Println(string(data))
-	// Output: {"check_reports":{"ID_DOCUMENT_AUTHENTICITY":[],"ID_DOCUMENT_TEXT_DATA_CHECK":[],"ID_DOCUMENT_FACE_MATCH":[],"LIVENESS":[],"ID_DOCUMENT_COMPARISON":[]}}
+	// Output: {"check_reports":{"ID_DOCUMENT_AUTHENTICITY":[],"ID_DOCUMENT_TEXT_DATA_CHECK":[],"ID_DOCUMENT_FACE_MATCH":[],"LIVENESS":[],"ID_DOCUMENT_COMPARISON":[],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK":[]}}
 }

--- a/docscan/sandbox/request/task/supplementary_document_text_data_extraction_task.go
+++ b/docscan/sandbox/request/task/supplementary_document_text_data_extraction_task.go
@@ -1,0 +1,75 @@
+package task
+
+import (
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/filter"
+)
+
+// SupplementaryDocumentTextDataExtractionTask represents a document text data extraction task
+type SupplementaryDocumentTextDataExtractionTask struct {
+	*documentTask
+	Result supplementaryDocumentTextDataExtractionTaskResult `json:"result"`
+}
+
+// SupplementaryDocumentTextDataExtractionTaskBuilder builds a SupplementaryDocumentTextDataExtractionTask
+type SupplementaryDocumentTextDataExtractionTaskBuilder struct {
+	documentTaskBuilder
+	documentFields  map[string]interface{}
+	detectedCountry string
+	recommendation  *TextDataExtractionRecommendation
+}
+
+type supplementaryDocumentTextDataExtractionTaskResult struct {
+	DocumentFields  map[string]interface{}            `json:"document_fields,omitempty"`
+	DetectedCountry string                            `json:"detected_country,omitempty"`
+	Recommendation  *TextDataExtractionRecommendation `json:"recommendation,omitempty"`
+}
+
+// NewSupplementaryDocumentTextDataExtractionTaskBuilder creates a new SupplementaryDocumentTextDataExtractionTaskBuilder
+func NewSupplementaryDocumentTextDataExtractionTaskBuilder() *SupplementaryDocumentTextDataExtractionTaskBuilder {
+	return &SupplementaryDocumentTextDataExtractionTaskBuilder{}
+}
+
+// WithDocumentFilter adds a document filter to the task
+func (b *SupplementaryDocumentTextDataExtractionTaskBuilder) WithDocumentFilter(filter *filter.DocumentFilter) *SupplementaryDocumentTextDataExtractionTaskBuilder {
+	b.documentTaskBuilder.withDocumentFilter(filter)
+	return b
+}
+
+// WithDocumentField adds a document field to the task
+func (b *SupplementaryDocumentTextDataExtractionTaskBuilder) WithDocumentField(key string, value interface{}) *SupplementaryDocumentTextDataExtractionTaskBuilder {
+	if b.documentFields == nil {
+		b.documentFields = make(map[string]interface{})
+	}
+	b.documentFields[key] = value
+	return b
+}
+
+// WithDocumentFields sets document fields
+func (b *SupplementaryDocumentTextDataExtractionTaskBuilder) WithDocumentFields(documentFields map[string]interface{}) *SupplementaryDocumentTextDataExtractionTaskBuilder {
+	b.documentFields = documentFields
+	return b
+}
+
+// WithDetectedCountry sets the detected country
+func (b *SupplementaryDocumentTextDataExtractionTaskBuilder) WithDetectedCountry(detectedCountry string) *SupplementaryDocumentTextDataExtractionTaskBuilder {
+	b.detectedCountry = detectedCountry
+	return b
+}
+
+// WithRecommendation sets the recommendation
+func (b *SupplementaryDocumentTextDataExtractionTaskBuilder) WithRecommendation(recommendation *TextDataExtractionRecommendation) *SupplementaryDocumentTextDataExtractionTaskBuilder {
+	b.recommendation = recommendation
+	return b
+}
+
+// Build creates a new SupplementaryDocumentTextDataExtractionTask
+func (b *SupplementaryDocumentTextDataExtractionTaskBuilder) Build() (*SupplementaryDocumentTextDataExtractionTask, error) {
+	return &SupplementaryDocumentTextDataExtractionTask{
+		documentTask: b.documentTaskBuilder.build(),
+		Result: supplementaryDocumentTextDataExtractionTaskResult{
+			DocumentFields:  b.documentFields,
+			DetectedCountry: b.detectedCountry,
+			Recommendation:  b.recommendation,
+		},
+	}, nil
+}

--- a/docscan/sandbox/request/task/supplementary_document_text_data_extraction_task_test.go
+++ b/docscan/sandbox/request/task/supplementary_document_text_data_extraction_task_test.go
@@ -1,0 +1,106 @@
+package task
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/filter"
+)
+
+func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder() {
+	docFilter, err := filter.NewDocumentFilterBuilder().Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	task, err := NewSupplementaryDocumentTextDataExtractionTaskBuilder().
+		WithDocumentFilter(docFilter).
+		WithDocumentField("some-key", "some-value").
+		WithDocumentField("some-other-key", map[string]string{
+			"some-nested-key": "some-nested-value",
+		}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(task)
+	fmt.Println(string(data))
+	// Output: {"document_filter":{"document_types":[],"country_codes":[]},"result":{"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}}}
+}
+
+func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder_WithDocumentFields() {
+	docFilter, err := filter.NewDocumentFilterBuilder().Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	task, err := NewSupplementaryDocumentTextDataExtractionTaskBuilder().
+		WithDocumentFilter(docFilter).
+		WithDocumentFields(map[string]interface{}{
+			"some-key": "some-value",
+			"some-other-key": map[string]string{
+				"some-nested-key": "some-nested-value",
+			},
+		}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(task)
+	fmt.Println(string(data))
+	// Output: {"document_filter":{"document_types":[],"country_codes":[]},"result":{"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}}}
+}
+
+func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder_WithDetectedCountry() {
+	task, err := NewSupplementaryDocumentTextDataExtractionTaskBuilder().
+		WithDetectedCountry("some-country").
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(task)
+	fmt.Println(string(data))
+	// Output: {"result":{"detected_country":"some-country"}}
+}
+
+func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder_WithRecommendation() {
+	recommendation, err := NewTextDataExtractionRecommendationBuilder().
+		ForProgress().
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	task, err := NewSupplementaryDocumentTextDataExtractionTaskBuilder().
+		WithRecommendation(recommendation).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(task)
+	fmt.Println(string(data))
+	// Output: {"result":{"recommendation":{"value":"PROGRESS"}}}
+}
+
+func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder_minimal() {
+	task, err := NewSupplementaryDocumentTextDataExtractionTaskBuilder().Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(task)
+	fmt.Println(string(data))
+	// Output: {"result":{}}
+}

--- a/docscan/sandbox/request/task/supplementary_document_text_data_extraction_task_test.go
+++ b/docscan/sandbox/request/task/supplementary_document_text_data_extraction_task_test.go
@@ -26,7 +26,12 @@ func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder() {
 		return
 	}
 
-	data, _ := json.Marshal(task)
+	data, err := json.Marshal(task)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"document_filter":{"document_types":[],"country_codes":[]},"result":{"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}}}
 }
@@ -52,7 +57,12 @@ func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder_WithDocumentField
 		return
 	}
 
-	data, _ := json.Marshal(task)
+	data, err := json.Marshal(task)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"document_filter":{"document_types":[],"country_codes":[]},"result":{"document_fields":{"some-key":"some-value","some-other-key":{"some-nested-key":"some-nested-value"}}}}
 }
@@ -66,7 +76,12 @@ func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder_WithDetectedCount
 		return
 	}
 
-	data, _ := json.Marshal(task)
+	data, err := json.Marshal(task)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"result":{"detected_country":"some-country"}}
 }
@@ -88,7 +103,12 @@ func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder_WithRecommendatio
 		return
 	}
 
-	data, _ := json.Marshal(task)
+	data, err := json.Marshal(task)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"result":{"recommendation":{"value":"PROGRESS"}}}
 }
@@ -100,7 +120,12 @@ func ExampleSupplementaryDocumentTextDataExtractionTaskBuilder_minimal() {
 		return
 	}
 
-	data, _ := json.Marshal(task)
+	data, err := json.Marshal(task)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"result":{}}
 }

--- a/docscan/sandbox/request/task_results.go
+++ b/docscan/sandbox/request/task_results.go
@@ -6,30 +6,40 @@ import (
 
 // TaskResults represents task results
 type TaskResults struct {
-	DocumentTextDataExtractionTasks []*task.DocumentTextDataExtractionTask `json:"ID_DOCUMENT_TEXT_DATA_EXTRACTION"`
+	DocumentTextDataExtractionTasks              []*task.DocumentTextDataExtractionTask              `json:"ID_DOCUMENT_TEXT_DATA_EXTRACTION"`
+	SupplementaryDocumentTextDataExtractionTasks []*task.SupplementaryDocumentTextDataExtractionTask `json:"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_EXTRACTION"`
 }
 
 // TaskResultsBuilder builds TaskResults
 type TaskResultsBuilder struct {
-	documentTextDataExtractionTasks []*task.DocumentTextDataExtractionTask
+	documentTextDataExtractionTasks              []*task.DocumentTextDataExtractionTask
+	supplementaryDocumentTextDataExtractionTasks []*task.SupplementaryDocumentTextDataExtractionTask
 }
 
 // NewTaskResultsBuilder creates a new TaskResultsBuilder
 func NewTaskResultsBuilder() *TaskResultsBuilder {
 	return &TaskResultsBuilder{
-		documentTextDataExtractionTasks: []*task.DocumentTextDataExtractionTask{},
+		documentTextDataExtractionTasks:              []*task.DocumentTextDataExtractionTask{},
+		supplementaryDocumentTextDataExtractionTasks: []*task.SupplementaryDocumentTextDataExtractionTask{},
 	}
 }
 
-// WithDocumentTextDataExtractionTask adds a document text data extraction task
-func (b *TaskResultsBuilder) WithDocumentTextDataExtractionTask(documentTextDataExtractionTasks *task.DocumentTextDataExtractionTask) *TaskResultsBuilder {
-	b.documentTextDataExtractionTasks = append(b.documentTextDataExtractionTasks, documentTextDataExtractionTasks)
+// WithDocumentTextDataExtractionTask adds a supplementary document text data extraction task
+func (b *TaskResultsBuilder) WithDocumentTextDataExtractionTask(documentTextDataExtractionTask *task.DocumentTextDataExtractionTask) *TaskResultsBuilder {
+	b.documentTextDataExtractionTasks = append(b.documentTextDataExtractionTasks, documentTextDataExtractionTask)
+	return b
+}
+
+// WithSupplementaryDocumentTextDataExtractionTask adds a supplementary document text data extraction task
+func (b *TaskResultsBuilder) WithSupplementaryDocumentTextDataExtractionTask(supplementaryTextDataExtractionTask *task.SupplementaryDocumentTextDataExtractionTask) *TaskResultsBuilder {
+	b.supplementaryDocumentTextDataExtractionTasks = append(b.supplementaryDocumentTextDataExtractionTasks, supplementaryTextDataExtractionTask)
 	return b
 }
 
 // Build creates TaskResults
 func (b *TaskResultsBuilder) Build() (TaskResults, error) {
 	return TaskResults{
-		DocumentTextDataExtractionTasks: b.documentTextDataExtractionTasks,
+		DocumentTextDataExtractionTasks:              b.documentTextDataExtractionTasks,
+		SupplementaryDocumentTextDataExtractionTasks: b.supplementaryDocumentTextDataExtractionTasks,
 	}, nil
 }

--- a/docscan/sandbox/request/task_results_test.go
+++ b/docscan/sandbox/request/task_results_test.go
@@ -31,7 +31,12 @@ func ExampleTaskResultsBuilder() {
 		return
 	}
 
-	data, _ := json.Marshal(taskResults)
+	data, err := json.Marshal(taskResults)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"ID_DOCUMENT_TEXT_DATA_EXTRACTION":[{"result":{}}],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_EXTRACTION":[{"result":{}}]}
 }

--- a/docscan/sandbox/request/task_results_test.go
+++ b/docscan/sandbox/request/task_results_test.go
@@ -15,8 +15,16 @@ func ExampleTaskResultsBuilder() {
 		return
 	}
 
+	supplementaryTextDataExtractionTask, err := task.NewSupplementaryDocumentTextDataExtractionTaskBuilder().
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	taskResults, err := NewTaskResultsBuilder().
 		WithDocumentTextDataExtractionTask(textDataExtractionTask).
+		WithSupplementaryDocumentTextDataExtractionTask(supplementaryTextDataExtractionTask).
 		Build()
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())
@@ -25,5 +33,5 @@ func ExampleTaskResultsBuilder() {
 
 	data, _ := json.Marshal(taskResults)
 	fmt.Println(string(data))
-	// Output: {"ID_DOCUMENT_TEXT_DATA_EXTRACTION":[{"result":{}}]}
+	// Output: {"ID_DOCUMENT_TEXT_DATA_EXTRACTION":[{"result":{}}],"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_EXTRACTION":[{"result":{}}]}
 }

--- a/docscan/session/create/filter/constants.go
+++ b/docscan/session/create/filter/constants.go
@@ -4,7 +4,8 @@ const (
 	includeList string = "WHITELIST"
 	excludeList string = "BLACKLIST"
 
-	identityDocument string = "ID_DOCUMENT"
+	identityDocument      string = "ID_DOCUMENT"
+	supplementaryDocument string = "SUPPLEMENTARY_DOCUMENT"
 
 	orthogonalRestriction string = "ORTHOGONAL_RESTRICTIONS"
 	documentRestriction   string = "DOCUMENT_RESTRICTIONS"

--- a/docscan/session/create/filter/required_supplementary_document.go
+++ b/docscan/session/create/filter/required_supplementary_document.go
@@ -1,0 +1,84 @@
+package filter
+
+import (
+	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/objective"
+)
+
+// RequiredSupplementaryDocument details a required supplementary document
+type RequiredSupplementaryDocument struct {
+	Filter        RequestedDocumentFilter
+	DocumentTypes *[]string
+	CountryCodes  *[]string
+	Objective     objective.Objective
+}
+
+// Type returns the type of the supplementary document
+func (r *RequiredSupplementaryDocument) Type() string {
+	return supplementaryDocument
+}
+
+// MarshalJSON returns the JSON encoding
+func (r *RequiredSupplementaryDocument) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type          string                  `json:"type"`
+		Filter        RequestedDocumentFilter `json:"filter,omitempty"`
+		CountryCodes  *[]string               `json:"country_codes,omitempty"`
+		DocumentTypes *[]string               `json:"document_types,omitempty"`
+		Objective     objective.Objective     `json:"objective,omitempty"`
+	}{
+		Type:          r.Type(),
+		Filter:        r.Filter,
+		CountryCodes:  r.CountryCodes,
+		DocumentTypes: r.DocumentTypes,
+		Objective:     r.Objective,
+	})
+}
+
+// NewRequiredSupplementaryDocumentBuilder creates a new RequiredSupplementaryDocumentBuilder
+func NewRequiredSupplementaryDocumentBuilder() *RequiredSupplementaryDocumentBuilder {
+	return &RequiredSupplementaryDocumentBuilder{}
+}
+
+// RequiredSupplementaryDocumentBuilder builds a RequiredSupplementaryDocument
+type RequiredSupplementaryDocumentBuilder struct {
+	filter        RequestedDocumentFilter
+	documentTypes *[]string
+	countryCodes  *[]string
+	objective     objective.Objective
+}
+
+// WithFilter sets the filter on the required supplementary document
+func (r *RequiredSupplementaryDocumentBuilder) WithFilter(filter RequestedDocumentFilter) *RequiredSupplementaryDocumentBuilder {
+	r.filter = filter
+	return r
+}
+
+// WithCountryCodes sets the country codes on the required supplementary document
+func (r *RequiredSupplementaryDocumentBuilder) WithCountryCodes(countryCodes []string) *RequiredSupplementaryDocumentBuilder {
+	r.countryCodes = &countryCodes
+	return r
+}
+
+// WithDocumentTypes sets the document types on the required supplementary document
+func (r *RequiredSupplementaryDocumentBuilder) WithDocumentTypes(documentTypes []string) *RequiredSupplementaryDocumentBuilder {
+	r.documentTypes = &documentTypes
+	return r
+}
+
+// WithObjective sets the objective for the required supplementary document
+func (r *RequiredSupplementaryDocumentBuilder) WithObjective(objective objective.Objective) *RequiredSupplementaryDocumentBuilder {
+	r.objective = objective
+	return r
+}
+
+// Build builds the RequiredSupplementaryDocument struct
+func (r *RequiredSupplementaryDocumentBuilder) Build() (*RequiredSupplementaryDocument, error) {
+	return &RequiredSupplementaryDocument{
+		Filter:        r.filter,
+		DocumentTypes: r.documentTypes,
+		CountryCodes:  r.countryCodes,
+		Objective:     r.objective,
+	}, nil
+}

--- a/docscan/session/create/filter/required_supplementary_document.go
+++ b/docscan/session/create/filter/required_supplementary_document.go
@@ -9,8 +9,8 @@ import (
 // RequiredSupplementaryDocument details a required supplementary document
 type RequiredSupplementaryDocument struct {
 	Filter        RequestedDocumentFilter
-	DocumentTypes *[]string
-	CountryCodes  *[]string
+	DocumentTypes []string
+	CountryCodes  []string
 	Objective     objective.Objective
 }
 
@@ -24,8 +24,8 @@ func (r *RequiredSupplementaryDocument) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Type          string                  `json:"type"`
 		Filter        RequestedDocumentFilter `json:"filter,omitempty"`
-		CountryCodes  *[]string               `json:"country_codes,omitempty"`
-		DocumentTypes *[]string               `json:"document_types,omitempty"`
+		CountryCodes  []string                `json:"country_codes,omitempty"`
+		DocumentTypes []string                `json:"document_types,omitempty"`
 		Objective     objective.Objective     `json:"objective,omitempty"`
 	}{
 		Type:          r.Type(),
@@ -44,8 +44,8 @@ func NewRequiredSupplementaryDocumentBuilder() *RequiredSupplementaryDocumentBui
 // RequiredSupplementaryDocumentBuilder builds a RequiredSupplementaryDocument
 type RequiredSupplementaryDocumentBuilder struct {
 	filter        RequestedDocumentFilter
-	documentTypes *[]string
-	countryCodes  *[]string
+	documentTypes []string
+	countryCodes  []string
 	objective     objective.Objective
 }
 
@@ -57,13 +57,13 @@ func (r *RequiredSupplementaryDocumentBuilder) WithFilter(filter RequestedDocume
 
 // WithCountryCodes sets the country codes on the required supplementary document
 func (r *RequiredSupplementaryDocumentBuilder) WithCountryCodes(countryCodes []string) *RequiredSupplementaryDocumentBuilder {
-	r.countryCodes = &countryCodes
+	r.countryCodes = countryCodes
 	return r
 }
 
 // WithDocumentTypes sets the document types on the required supplementary document
 func (r *RequiredSupplementaryDocumentBuilder) WithDocumentTypes(documentTypes []string) *RequiredSupplementaryDocumentBuilder {
-	r.documentTypes = &documentTypes
+	r.documentTypes = documentTypes
 	return r
 }
 

--- a/docscan/session/create/filter/required_supplementary_document_test.go
+++ b/docscan/session/create/filter/required_supplementary_document_test.go
@@ -81,7 +81,7 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithCountryCodes_empty() {
 
 	data, _ := json.Marshal(requiredSupplementaryDocument)
 	fmt.Println(string(data))
-	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","country_codes":[]}
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT"}
 }
 
 func ExampleRequiredSupplementaryDocumentBuilder_WithDocumentTypes() {
@@ -111,7 +111,7 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithDocumentTypes_empty() {
 
 	data, _ := json.Marshal(requiredSupplementaryDocument)
 	fmt.Println(string(data))
-	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","document_types":[]}
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT"}
 }
 
 func ExampleRequiredSupplementaryDocumentBuilder_WithObjective() {

--- a/docscan/session/create/filter/required_supplementary_document_test.go
+++ b/docscan/session/create/filter/required_supplementary_document_test.go
@@ -16,7 +16,12 @@ func ExampleRequiredSupplementaryDocument() {
 		return
 	}
 
-	data, _ := json.Marshal(requiredSupplementaryDocument)
+	data, err := json.Marshal(requiredSupplementaryDocument)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT"}
 }
@@ -49,7 +54,12 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithFilter() {
 		return
 	}
 
-	data, _ := json.Marshal(requiredSupplementaryDocument)
+	data, err := json.Marshal(requiredSupplementaryDocument)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","filter":{"type":"DOCUMENT_RESTRICTIONS","inclusion":"WHITELIST","documents":[{"document_types":["UTILITY_BILL"]}]}}
 }
@@ -64,7 +74,12 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithCountryCodes() {
 		return
 	}
 
-	data, _ := json.Marshal(requiredSupplementaryDocument)
+	data, err := json.Marshal(requiredSupplementaryDocument)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","country_codes":["SOME_COUNTRY"]}
 }
@@ -79,7 +94,12 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithCountryCodes_empty() {
 		return
 	}
 
-	data, _ := json.Marshal(requiredSupplementaryDocument)
+	data, err := json.Marshal(requiredSupplementaryDocument)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT"}
 }
@@ -94,7 +114,12 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithDocumentTypes() {
 		return
 	}
 
-	data, _ := json.Marshal(requiredSupplementaryDocument)
+	data, err := json.Marshal(requiredSupplementaryDocument)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","document_types":["SOME_DOCUMENT_TYPE"]}
 }
@@ -109,7 +134,12 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithDocumentTypes_empty() {
 		return
 	}
 
-	data, _ := json.Marshal(requiredSupplementaryDocument)
+	data, err := json.Marshal(requiredSupplementaryDocument)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT"}
 }
@@ -124,7 +154,12 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithObjective() {
 		return
 	}
 
-	data, _ := json.Marshal(requiredSupplementaryDocument)
+	data, err := json.Marshal(requiredSupplementaryDocument)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","objective":{"type":"SOME_OBJECTIVE"}}
 }
@@ -146,7 +181,12 @@ func ExampleRequiredSupplementaryDocumentBuilder_WithObjective_proofOfAddress() 
 		return
 	}
 
-	data, _ := json.Marshal(requiredSupplementaryDocument)
+	data, err := json.Marshal(requiredSupplementaryDocument)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","objective":{"type":"PROOF_OF_ADDRESS"}}
 }

--- a/docscan/session/create/filter/required_supplementary_document_test.go
+++ b/docscan/session/create/filter/required_supplementary_document_test.go
@@ -1,0 +1,167 @@
+package filter
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/objective"
+)
+
+func ExampleRequiredSupplementaryDocument() {
+	var requiredSupplementaryDocument *RequiredSupplementaryDocument
+	requiredSupplementaryDocument, err := NewRequiredSupplementaryDocumentBuilder().
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(requiredSupplementaryDocument)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT"}
+}
+
+func ExampleRequiredSupplementaryDocumentBuilder_WithFilter() {
+	docRestriction, err := NewRequestedDocumentRestrictionBuilder().
+		WithDocumentTypes([]string{"UTILITY_BILL"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	var docFilter *RequestedDocumentRestrictionsFilter
+	docFilter, err = NewRequestedDocumentRestrictionsFilterBuilder().
+		ForIncludeList().
+		WithDocumentRestriction(docRestriction).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	var requiredSupplementaryDocument *RequiredSupplementaryDocument
+	requiredSupplementaryDocument, err = NewRequiredSupplementaryDocumentBuilder().
+		WithFilter(docFilter).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(requiredSupplementaryDocument)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","filter":{"type":"DOCUMENT_RESTRICTIONS","inclusion":"WHITELIST","documents":[{"document_types":["UTILITY_BILL"]}]}}
+}
+
+func ExampleRequiredSupplementaryDocumentBuilder_WithCountryCodes() {
+	var requiredSupplementaryDocument *RequiredSupplementaryDocument
+	requiredSupplementaryDocument, err := NewRequiredSupplementaryDocumentBuilder().
+		WithCountryCodes([]string{"SOME_COUNTRY"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(requiredSupplementaryDocument)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","country_codes":["SOME_COUNTRY"]}
+}
+
+func ExampleRequiredSupplementaryDocumentBuilder_WithCountryCodes_empty() {
+	var requiredSupplementaryDocument *RequiredSupplementaryDocument
+	requiredSupplementaryDocument, err := NewRequiredSupplementaryDocumentBuilder().
+		WithCountryCodes([]string{}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(requiredSupplementaryDocument)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","country_codes":[]}
+}
+
+func ExampleRequiredSupplementaryDocumentBuilder_WithDocumentTypes() {
+	var requiredSupplementaryDocument *RequiredSupplementaryDocument
+	requiredSupplementaryDocument, err := NewRequiredSupplementaryDocumentBuilder().
+		WithDocumentTypes([]string{"SOME_DOCUMENT_TYPE"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(requiredSupplementaryDocument)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","document_types":["SOME_DOCUMENT_TYPE"]}
+}
+
+func ExampleRequiredSupplementaryDocumentBuilder_WithDocumentTypes_empty() {
+	var requiredSupplementaryDocument *RequiredSupplementaryDocument
+	requiredSupplementaryDocument, err := NewRequiredSupplementaryDocumentBuilder().
+		WithDocumentTypes([]string{}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(requiredSupplementaryDocument)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","document_types":[]}
+}
+
+func ExampleRequiredSupplementaryDocumentBuilder_WithObjective() {
+	var requiredSupplementaryDocument *RequiredSupplementaryDocument
+	requiredSupplementaryDocument, err := NewRequiredSupplementaryDocumentBuilder().
+		WithObjective(&mockObjective{}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(requiredSupplementaryDocument)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","objective":{"type":"SOME_OBJECTIVE"}}
+}
+
+func ExampleRequiredSupplementaryDocumentBuilder_WithObjective_proofOfAddress() {
+	var proofOfAddress objective.Objective
+	proofOfAddress, err := objective.NewProofOfAddressObjectiveBuilder().Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	var requiredSupplementaryDocument *RequiredSupplementaryDocument
+	requiredSupplementaryDocument, err = NewRequiredSupplementaryDocumentBuilder().
+		WithObjective(proofOfAddress).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(requiredSupplementaryDocument)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT","objective":{"type":"PROOF_OF_ADDRESS"}}
+}
+
+type mockObjective struct{}
+
+func (o *mockObjective) Type() string {
+	return "SOME_OBJECTIVE"
+}
+
+// MarshalJSON returns the JSON encoding
+func (o *mockObjective) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type string `json:"type"`
+	}{
+		Type: o.Type(),
+	})
+}

--- a/docscan/session/create/objective/objective.go
+++ b/docscan/session/create/objective/objective.go
@@ -1,0 +1,6 @@
+package objective
+
+type Objective interface {
+	Type() string
+	MarshalJSON() ([]byte, error)
+}

--- a/docscan/session/create/objective/proof_of_address.go
+++ b/docscan/session/create/objective/proof_of_address.go
@@ -1,0 +1,39 @@
+package objective
+
+import (
+	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+)
+
+// ProofOfAddressObjective requests creation of a proof of address objective
+type ProofOfAddressObjective struct {
+}
+
+// Type is the objective type
+func (o *ProofOfAddressObjective) Type() string {
+	return constants.ProofOfAddress
+}
+
+// MarshalJSON returns the JSON encoding
+func (o *ProofOfAddressObjective) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type string `json:"type"`
+	}{
+		Type: o.Type(),
+	})
+}
+
+// NewProofOfAddressObjectiveBuilder creates a new ProofOfAddressObjectiveBuilder
+func NewProofOfAddressObjectiveBuilder() *ProofOfAddressObjectiveBuilder {
+	return &ProofOfAddressObjectiveBuilder{}
+}
+
+// ProofOfAddressObjectiveBuilder builds a ProofOfAddress
+type ProofOfAddressObjectiveBuilder struct {
+}
+
+// Build builds the ProofOfAddressObjective
+func (builder *ProofOfAddressObjectiveBuilder) Build() (*ProofOfAddressObjective, error) {
+	return &ProofOfAddressObjective{}, nil
+}

--- a/docscan/session/create/objective/proof_of_address_test.go
+++ b/docscan/session/create/objective/proof_of_address_test.go
@@ -13,7 +13,12 @@ func ExampleProofOfAddressObjectiveBuilder() {
 		return
 	}
 
-	data, _ := json.Marshal(objective)
+	data, err := json.Marshal(objective)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"PROOF_OF_ADDRESS"}
 }

--- a/docscan/session/create/objective/proof_of_address_test.go
+++ b/docscan/session/create/objective/proof_of_address_test.go
@@ -1,0 +1,19 @@
+package objective
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func ExampleProofOfAddressObjectiveBuilder() {
+	objective, err := NewProofOfAddressObjectiveBuilder().
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(objective)
+	fmt.Println(string(data))
+	// Output: {"type":"PROOF_OF_ADDRESS"}
+}

--- a/docscan/session/create/session_spec.go
+++ b/docscan/session/create/session_spec.go
@@ -97,8 +97,8 @@ func (b *SessionSpecificationBuilder) WithSDKConfig(SDKConfig *SDKConfig) *Sessi
 }
 
 // WithRequiredDocument adds a required document to the session specification
-func (b *SessionSpecificationBuilder) WithRequiredDocument(IDDocument filter.RequiredDocument) *SessionSpecificationBuilder {
-	b.requiredDocuments = append(b.requiredDocuments, IDDocument)
+func (b *SessionSpecificationBuilder) WithRequiredDocument(document filter.RequiredDocument) *SessionSpecificationBuilder {
+	b.requiredDocuments = append(b.requiredDocuments, document)
 	return b
 }
 

--- a/docscan/session/create/session_spec_test.go
+++ b/docscan/session/create/session_spec_test.go
@@ -119,3 +119,25 @@ func ExampleSessionSpecificationBuilder_Build_withBlockBiometricConsentFalse() {
 	fmt.Println(string(data))
 	// Output: {"block_biometric_consent":false}
 }
+
+func ExampleSessionSpecificationBuilder_WithRequiredDocument_supplementary() {
+	requiredSupplementaryDocument, err := filter.NewRequiredSupplementaryDocumentBuilder().
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	sessionSpecification, err := NewSessionSpecificationBuilder().
+		WithRequiredDocument(requiredSupplementaryDocument).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(sessionSpecification)
+	fmt.Println(string(data))
+	// Output: {"required_documents":[{"type":"SUPPLEMENTARY_DOCUMENT"}]}
+}

--- a/docscan/session/create/session_spec_test.go
+++ b/docscan/session/create/session_spec_test.go
@@ -137,7 +137,12 @@ func ExampleSessionSpecificationBuilder_WithRequiredDocument_supplementary() {
 		return
 	}
 
-	data, _ := json.Marshal(sessionSpecification)
+	data, err := json.Marshal(sessionSpecification)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"required_documents":[{"type":"SUPPLEMENTARY_DOCUMENT"}]}
 }

--- a/docscan/session/create/task/supplementary_text_extraction.go
+++ b/docscan/session/create/task/supplementary_text_extraction.go
@@ -1,0 +1,80 @@
+package task
+
+import (
+	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+)
+
+// RequestedSupplementaryDocTextExtractionTask requests creation of a Text Extraction Task
+type RequestedSupplementaryDocTextExtractionTask struct {
+	config RequestedSupplementaryDocTextExtractionTaskConfig
+}
+
+// Type is the type of the Requested Task
+func (t *RequestedSupplementaryDocTextExtractionTask) Type() string {
+	return constants.SupplementaryDocumentTextDataExtraction
+}
+
+// Config is the configuration of the Requested Task
+func (t *RequestedSupplementaryDocTextExtractionTask) Config() RequestedTaskConfig {
+	return t.config
+}
+
+// MarshalJSON marshals the RequestedSupplementaryDocTextExtractionTask to JSON
+func (t *RequestedSupplementaryDocTextExtractionTask) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type   string              `json:"type"`
+		Config RequestedTaskConfig `json:"config,omitempty"`
+	}{
+		Type:   t.Type(),
+		Config: t.Config(),
+	})
+}
+
+// NewRequestedSupplementaryDocTextExtractionTask creates a new supplementary document text extraction task
+func NewRequestedSupplementaryDocTextExtractionTask(config RequestedSupplementaryDocTextExtractionTaskConfig) *RequestedSupplementaryDocTextExtractionTask {
+	return &RequestedSupplementaryDocTextExtractionTask{config}
+}
+
+// RequestedSupplementaryDocTextExtractionTaskConfig is the configuration applied when creating a Text Extraction Task
+type RequestedSupplementaryDocTextExtractionTaskConfig struct {
+	ManualCheck string `json:"manual_check,omitempty"`
+}
+
+// NewRequestedSupplementaryDocTextExtractionTaskBuilder creates a new RequestedSupplementaryDocTextExtractionTaskBuilder
+func NewRequestedSupplementaryDocTextExtractionTaskBuilder() *RequestedSupplementaryDocTextExtractionTaskBuilder {
+	return &RequestedSupplementaryDocTextExtractionTaskBuilder{}
+}
+
+// RequestedSupplementaryDocTextExtractionTaskBuilder builds a RequestedSupplementaryDocTextExtractionTask
+type RequestedSupplementaryDocTextExtractionTaskBuilder struct {
+	manualCheck string
+}
+
+// WithManualCheckAlways sets the value of manual check to "ALWAYS"
+func (builder *RequestedSupplementaryDocTextExtractionTaskBuilder) WithManualCheckAlways() *RequestedSupplementaryDocTextExtractionTaskBuilder {
+	builder.manualCheck = constants.Always
+	return builder
+}
+
+// WithManualCheckFallback sets the value of manual check to "FALLBACK"
+func (builder *RequestedSupplementaryDocTextExtractionTaskBuilder) WithManualCheckFallback() *RequestedSupplementaryDocTextExtractionTaskBuilder {
+	builder.manualCheck = constants.Fallback
+	return builder
+}
+
+// WithManualCheckNever sets the value of manual check to "NEVER"
+func (builder *RequestedSupplementaryDocTextExtractionTaskBuilder) WithManualCheckNever() *RequestedSupplementaryDocTextExtractionTaskBuilder {
+	builder.manualCheck = constants.Never
+	return builder
+}
+
+// Build builds the RequestedSupplementaryDocTextExtractionTask
+func (builder *RequestedSupplementaryDocTextExtractionTaskBuilder) Build() (*RequestedSupplementaryDocTextExtractionTask, error) {
+	config := RequestedSupplementaryDocTextExtractionTaskConfig{
+		builder.manualCheck,
+	}
+
+	return NewRequestedSupplementaryDocTextExtractionTask(config), nil
+}

--- a/docscan/session/create/task/supplementary_text_extraction_test.go
+++ b/docscan/session/create/task/supplementary_text_extraction_test.go
@@ -1,0 +1,73 @@
+package task
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func ExampleRequestedSupplementaryDocTextExtractionTaskBuilder() {
+	task, err := NewRequestedSupplementaryDocTextExtractionTaskBuilder().
+		WithManualCheckAlways().
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, _ := json.Marshal(task)
+	fmt.Println(string(data))
+	// Output: {"type":"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_EXTRACTION","config":{"manual_check":"ALWAYS"}}
+}
+
+func TestRequestedSupplementaryDocTextExtractionTaskBuilder_Build_UsesLastManualCheck(t *testing.T) {
+	task, err := NewRequestedSupplementaryDocTextExtractionTaskBuilder().
+		WithManualCheckAlways().
+		WithManualCheckNever().
+		WithManualCheckFallback().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedSupplementaryDocTextExtractionTaskConfig)
+	assert.Equal(t, "FALLBACK", config.ManualCheck)
+}
+
+func TestRequestedSupplementaryDocTextExtractionTaskBuilder_WithManualCheckAlways(t *testing.T) {
+	task, err := NewRequestedSupplementaryDocTextExtractionTaskBuilder().
+		WithManualCheckAlways().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedSupplementaryDocTextExtractionTaskConfig)
+	assert.Equal(t, "ALWAYS", config.ManualCheck)
+}
+
+func TestRequestedSupplementaryDocTextExtractionTaskBuilder_WithManualCheckFallback(t *testing.T) {
+	task, err := NewRequestedSupplementaryDocTextExtractionTaskBuilder().
+		WithManualCheckFallback().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedSupplementaryDocTextExtractionTaskConfig)
+	assert.Equal(t, "FALLBACK", config.ManualCheck)
+}
+
+func TestRequestedSupplementaryDocTextExtractionTaskBuilder_WithManualCheckNever(t *testing.T) {
+	task, err := NewRequestedSupplementaryDocTextExtractionTaskBuilder().
+		WithManualCheckNever().
+		Build()
+	if err != nil {
+		t.Fail()
+	}
+
+	config := task.Config().(RequestedSupplementaryDocTextExtractionTaskConfig)
+	assert.Equal(t, "NEVER", config.ManualCheck)
+}

--- a/docscan/session/create/task/supplementary_text_extraction_test.go
+++ b/docscan/session/create/task/supplementary_text_extraction_test.go
@@ -17,7 +17,12 @@ func ExampleRequestedSupplementaryDocTextExtractionTaskBuilder() {
 		return
 	}
 
-	data, _ := json.Marshal(task)
+	data, err := json.Marshal(task)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
 	fmt.Println(string(data))
 	// Output: {"type":"SUPPLEMENTARY_DOCUMENT_TEXT_DATA_EXTRACTION","config":{"manual_check":"ALWAYS"}}
 }

--- a/docscan/session/create/task/text_extraction.go
+++ b/docscan/session/create/task/text_extraction.go
@@ -11,12 +11,12 @@ type RequestedTextExtractionTask struct {
 	config RequestedTextExtractionTaskConfig
 }
 
-// Type is the type of the Requested Check
+// Type is the type of the Requested Task
 func (t *RequestedTextExtractionTask) Type() string {
 	return constants.IDDocumentTextDataExtraction
 }
 
-// Config is the configuration of the Requested Check
+// Config is the configuration of the Requested Task
 func (t *RequestedTextExtractionTask) Config() RequestedTaskConfig {
 	return t.config
 }
@@ -32,7 +32,7 @@ func (t *RequestedTextExtractionTask) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// NewRequestedTextExtractionTask creates a new Document Authenticity Check
+// NewRequestedTextExtractionTask creates a new text extraction task
 func NewRequestedTextExtractionTask(config RequestedTextExtractionTaskConfig) *RequestedTextExtractionTask {
 	return &RequestedTextExtractionTask{config}
 }

--- a/docscan/session/retrieve/check_response.go
+++ b/docscan/session/retrieve/check_response.go
@@ -40,3 +40,8 @@ type TextDataCheckResponse struct {
 type IDDocumentComparisonCheckResponse struct {
 	*CheckResponse
 }
+
+// SupplementaryDocumentTextDataCheckResponse represents a supplementary document text data check for a given session
+type SupplementaryDocumentTextDataCheckResponse struct {
+	*CheckResponse
+}

--- a/docscan/session/retrieve/file_response.go
+++ b/docscan/session/retrieve/file_response.go
@@ -1,0 +1,6 @@
+package retrieve
+
+// FileResponse represents a file
+type FileResponse struct {
+	Media *MediaResponse `json:"media"`
+}

--- a/docscan/session/retrieve/generated_check_response.go
+++ b/docscan/session/retrieve/generated_check_response.go
@@ -6,7 +6,12 @@ type GeneratedCheckResponse struct {
 	Type string `json:"type"`
 }
 
-// GeneratedTextDataCheckResponse represents a Text Extraction task response
+// GeneratedTextDataCheckResponse represents a text data check response
 type GeneratedTextDataCheckResponse struct {
+	*GeneratedCheckResponse
+}
+
+// GeneratedSupplementaryTextDataCheckResponse represents a supplementary text data check response
+type GeneratedSupplementaryTextDataCheckResponse struct {
 	*GeneratedCheckResponse
 }

--- a/docscan/session/retrieve/get_session_result.go
+++ b/docscan/session/retrieve/get_session_result.go
@@ -9,19 +9,20 @@ import (
 
 // GetSessionResult contains the information about a created session
 type GetSessionResult struct {
-	ClientSessionTokenTTL      int                `json:"client_session_token_ttl"`
-	ClientSessionToken         string             `json:"client_session_token"`
-	SessionID                  string             `json:"session_id"`
-	UserTrackingID             string             `json:"user_tracking_id"`
-	State                      string             `json:"state"`
-	Checks                     []*CheckResponse   `json:"checks"`
-	Resources                  *ResourceContainer `json:"resources"`
-	BiometricConsentTimestamp  *time.Time         `json:"biometric_consent"`
-	authenticityChecks         []*AuthenticityCheckResponse
-	faceMatchChecks            []*FaceMatchCheckResponse
-	textDataChecks             []*TextDataCheckResponse
-	livenessChecks             []*LivenessCheckResponse
-	idDocumentComparisonChecks []*IDDocumentComparisonCheckResponse
+	ClientSessionTokenTTL               int                `json:"client_session_token_ttl"`
+	ClientSessionToken                  string             `json:"client_session_token"`
+	SessionID                           string             `json:"session_id"`
+	UserTrackingID                      string             `json:"user_tracking_id"`
+	State                               string             `json:"state"`
+	Checks                              []*CheckResponse   `json:"checks"`
+	Resources                           *ResourceContainer `json:"resources"`
+	BiometricConsentTimestamp           *time.Time         `json:"biometric_consent"`
+	authenticityChecks                  []*AuthenticityCheckResponse
+	faceMatchChecks                     []*FaceMatchCheckResponse
+	textDataChecks                      []*TextDataCheckResponse
+	livenessChecks                      []*LivenessCheckResponse
+	idDocumentComparisonChecks          []*IDDocumentComparisonCheckResponse
+	supplementaryDocumentTextDataChecks []*SupplementaryDocumentTextDataCheckResponse
 }
 
 // AuthenticityChecks filters the checks, returning only document authenticity checks
@@ -34,8 +35,14 @@ func (g *GetSessionResult) FaceMatchChecks() []*FaceMatchCheckResponse {
 	return g.faceMatchChecks
 }
 
-// TextDataChecks filters the checks, returning only Text Data checks
+// TextDataChecks filters the checks, returning only ID Document Text Data checks
+// Deprecated: replaced by IDDocumentTextDataChecks()
 func (g *GetSessionResult) TextDataChecks() []*TextDataCheckResponse {
+	return g.IDDocumentTextDataChecks()
+}
+
+// IDDocumentTextDataChecks filters the checks, returning only ID Document Text Data checks
+func (g *GetSessionResult) IDDocumentTextDataChecks() []*TextDataCheckResponse {
 	return g.textDataChecks
 }
 
@@ -47,6 +54,11 @@ func (g *GetSessionResult) LivenessChecks() []*LivenessCheckResponse {
 // IDDocumentComparisonChecks filters the checks, returning only the identity document comparison checks
 func (g *GetSessionResult) IDDocumentComparisonChecks() []*IDDocumentComparisonCheckResponse {
 	return g.idDocumentComparisonChecks
+}
+
+// SupplementaryDocumentTextDataChecks filters the checks, returning only the supplementary document text data checks
+func (g *GetSessionResult) SupplementaryDocumentTextDataChecks() []*SupplementaryDocumentTextDataCheckResponse {
+	return g.supplementaryDocumentTextDataChecks
 }
 
 // UnmarshalJSON handles the custom JSON unmarshalling
@@ -72,6 +84,14 @@ func (g *GetSessionResult) UnmarshalJSON(data []byte) error {
 
 		case constants.IDDocumentComparison:
 			g.idDocumentComparisonChecks = append(g.idDocumentComparisonChecks, &IDDocumentComparisonCheckResponse{CheckResponse: check})
+
+		case constants.SupplementaryDocumentTextDataCheck:
+			g.supplementaryDocumentTextDataChecks = append(
+				g.supplementaryDocumentTextDataChecks,
+				&SupplementaryDocumentTextDataCheckResponse{
+					CheckResponse: check,
+				},
+			)
 		}
 	}
 

--- a/docscan/session/retrieve/get_session_result_test.go
+++ b/docscan/session/retrieve/get_session_result_test.go
@@ -36,6 +36,11 @@ func TestGetSessionResult_UnmarshalJSON(t *testing.T) {
 		State: "PENDING",
 	}
 
+	supplementaryTextDataCheckResponse := &CheckResponse{
+		Type:   constants.SupplementaryDocumentTextDataCheck,
+		Report: &ReportResponse{},
+	}
+
 	var checks []*CheckResponse
 	checks = append(checks, &CheckResponse{Type: "OTHER_TYPE", ID: "id"})
 	checks = append(checks, authenticityCheckResponse)
@@ -43,6 +48,7 @@ func TestGetSessionResult_UnmarshalJSON(t *testing.T) {
 	checks = append(checks, textDataCheckResponse)
 	checks = append(checks, livenessCheckResponse)
 	checks = append(checks, idDocComparisonCheckResponse)
+	checks = append(checks, supplementaryTextDataCheckResponse)
 
 	biometricConsentTimestamp := time.Date(2020, 01, 01, 1, 2, 3, 4, time.UTC)
 
@@ -57,7 +63,7 @@ func TestGetSessionResult_UnmarshalJSON(t *testing.T) {
 	err = json.Unmarshal(marshalled, &result)
 	assert.NilError(t, err)
 
-	assert.Equal(t, 6, len(result.Checks))
+	assert.Equal(t, 7, len(result.Checks))
 
 	assert.Equal(t, 1, len(result.AuthenticityChecks()))
 	assert.Equal(t, "DONE", result.AuthenticityChecks()[0].State)
@@ -68,11 +74,17 @@ func TestGetSessionResult_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, 1, len(result.TextDataChecks()))
 	assert.DeepEqual(t, &ReportResponse{}, result.TextDataChecks()[0].Report)
 
+	assert.Equal(t, 1, len(result.IDDocumentTextDataChecks()))
+	assert.DeepEqual(t, &ReportResponse{}, result.TextDataChecks()[0].Report)
+
 	assert.Equal(t, 1, len(result.LivenessChecks()))
 	assert.Check(t, result.LivenessChecks()[0].LastUpdated.Equal(testDate))
 
 	assert.Equal(t, 1, len(result.IDDocumentComparisonChecks()))
 	assert.Equal(t, "PENDING", result.IDDocumentComparisonChecks()[0].State)
+
+	assert.Equal(t, 1, len(result.SupplementaryDocumentTextDataChecks()))
+	assert.DeepEqual(t, &ReportResponse{}, result.SupplementaryDocumentTextDataChecks()[0].Report)
 
 	assert.Equal(t, biometricConsentTimestamp, *result.BiometricConsentTimestamp)
 }

--- a/docscan/session/retrieve/id_document_text_extraction_task_response.go
+++ b/docscan/session/retrieve/id_document_text_extraction_task_response.go
@@ -1,0 +1,11 @@
+package retrieve
+
+// TextExtractionTaskResponse represents a Text Extraction task response
+type TextExtractionTaskResponse struct {
+	*TaskResponse
+}
+
+// GeneratedTextDataChecks filters the checks, returning only text data checks
+func (t *TextExtractionTaskResponse) GeneratedTextDataChecks() []*GeneratedTextDataCheckResponse {
+	return t.generatedTextDataChecks
+}

--- a/docscan/session/retrieve/id_document_text_extraction_task_response_test.go
+++ b/docscan/session/retrieve/id_document_text_extraction_task_response_test.go
@@ -1,0 +1,30 @@
+package retrieve
+
+import (
+	"testing"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+	"gotest.tools/v3/assert"
+)
+
+func TestTextExtractionTaskResponse_GeneratedTextDataChecks(t *testing.T) {
+	var checks []*GeneratedTextDataCheckResponse
+	checks = append(
+		checks,
+		&GeneratedTextDataCheckResponse{
+			&GeneratedCheckResponse{
+				Type: constants.IDDocumentTextDataCheck,
+				ID:   "some-id",
+			},
+		},
+	)
+
+	taskResponse := &TextExtractionTaskResponse{
+		TaskResponse: &TaskResponse{
+			generatedTextDataChecks: checks,
+		},
+	}
+
+	assert.Equal(t, 1, len(taskResponse.GeneratedTextDataChecks()))
+	assert.Equal(t, "some-id", taskResponse.GeneratedTextDataChecks()[0].ID)
+}

--- a/docscan/session/retrieve/resource_container.go
+++ b/docscan/session/retrieve/resource_container.go
@@ -8,10 +8,11 @@ import (
 
 // ResourceContainer contains different resources that are part of the Yoti Doc Scan session
 type ResourceContainer struct {
-	IDDocuments           []*IDDocumentResourceResponse `json:"id_documents"`
-	LivenessCapture       []*LivenessResourceResponse
-	RawLivenessCapture    []json.RawMessage `json:"liveness_capture"`
-	zoomLivenessResources []*ZoomLivenessResourceResponse
+	IDDocuments            []*IDDocumentResourceResponse            `json:"id_documents"`
+	SupplementaryDocuments []*SupplementaryDocumentResourceResponse `json:"supplementary_documents"`
+	LivenessCapture        []*LivenessResourceResponse
+	RawLivenessCapture     []json.RawMessage `json:"liveness_capture"`
+	zoomLivenessResources  []*ZoomLivenessResourceResponse
 }
 
 // ZoomLivenessResources  filters the liveness resources, returning only the "Zoom" liveness resources

--- a/docscan/session/retrieve/supplementary_document_resource_response.go
+++ b/docscan/session/retrieve/supplementary_document_resource_response.go
@@ -1,0 +1,50 @@
+package retrieve
+
+import (
+	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+)
+
+// SupplementaryDocumentResourceResponse represents an supplementary document resource for a given session
+type SupplementaryDocumentResourceResponse struct {
+	*ResourceResponse
+	// DocumentType is the supplementary document type, e.g. "UTILITY_BILL"
+	DocumentType string `json:"document_type"`
+	// IssuingCountry is the issuing country of the supplementary document
+	IssuingCountry string `json:"issuing_country"`
+	// Pages are the individual pages of the supplementary document
+	Pages []*PageResponse `json:"pages"`
+	// DocumentFields are the associated document fields of a document
+	DocumentFields *DocumentFieldsResponse `json:"document_fields"`
+	// DocumentFile is the associated document file
+	DocumentFile        *FileResponse `json:"file"`
+	textExtractionTasks []*SupplementaryDocumentTextExtractionTaskResponse
+}
+
+// TextExtractionTasks returns a slice of text extraction tasks associated with the supplementary document
+func (i *SupplementaryDocumentResourceResponse) TextExtractionTasks() []*SupplementaryDocumentTextExtractionTaskResponse {
+	return i.textExtractionTasks
+}
+
+// UnmarshalJSON handles the custom JSON unmarshalling
+func (i *SupplementaryDocumentResourceResponse) UnmarshalJSON(data []byte) error {
+	type result SupplementaryDocumentResourceResponse // declared as "type" to prevent recursive unmarshalling
+	if err := json.Unmarshal(data, (*result)(i)); err != nil {
+		return err
+	}
+
+	for _, task := range i.Tasks {
+		switch task.Type {
+		case constants.SupplementaryDocumentTextDataExtraction:
+			i.textExtractionTasks = append(
+				i.textExtractionTasks,
+				&SupplementaryDocumentTextExtractionTaskResponse{
+					TaskResponse: task,
+				},
+			)
+		}
+	}
+
+	return nil
+}

--- a/docscan/session/retrieve/supplementary_document_resource_response_test.go
+++ b/docscan/session/retrieve/supplementary_document_resource_response_test.go
@@ -1,0 +1,44 @@
+package retrieve
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSupplementaryDocumentResourceResponse_UnmarshalJSON(t *testing.T) {
+	idDocumentResource := &SupplementaryDocumentResourceResponse{
+		ResourceResponse: &ResourceResponse{
+			ID: "",
+			Tasks: []*TaskResponse{
+				{
+					ID:   "some-id",
+					Type: "SUPPLEMENTARY_DOCUMENT_TEXT_DATA_EXTRACTION",
+				},
+				{
+					ID:   "other-id",
+					Type: "OTHER_TASK_TYPE",
+				},
+			},
+		},
+	}
+
+	marshalledResource, err := json.Marshal(idDocumentResource)
+	assert.NilError(t, err)
+
+	var result SupplementaryDocumentResourceResponse
+	err = json.Unmarshal(marshalledResource, &result)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 2, len(result.ResourceResponse.Tasks))
+
+	assert.Equal(t, 1, len(result.TextExtractionTasks()))
+	assert.Equal(t, "some-id", result.TextExtractionTasks()[0].ID)
+}
+
+func TestSupplementaryDocumentResourceResponse_UnmarshalJSON_Invalid(t *testing.T) {
+	var result SupplementaryDocumentResourceResponse
+	err := result.UnmarshalJSON([]byte("some-invalid-json"))
+	assert.ErrorContains(t, err, "invalid character")
+}

--- a/docscan/session/retrieve/supplementary_document_text_extraction_task_response.go
+++ b/docscan/session/retrieve/supplementary_document_text_extraction_task_response.go
@@ -1,0 +1,11 @@
+package retrieve
+
+// SupplementaryDocumentTextExtractionTaskResponse represents a Supplementary Text Extraction task response
+type SupplementaryDocumentTextExtractionTaskResponse struct {
+	*TaskResponse
+}
+
+// GeneratedTextDataChecks filters the checks, returning only text data checks
+func (t *SupplementaryDocumentTextExtractionTaskResponse) GeneratedTextDataChecks() []*GeneratedSupplementaryTextDataCheckResponse {
+	return t.generatedSupplementaryTextDataChecks
+}

--- a/docscan/session/retrieve/supplementary_document_text_extraction_task_response.go
+++ b/docscan/session/retrieve/supplementary_document_text_extraction_task_response.go
@@ -1,6 +1,6 @@
 package retrieve
 
-// SupplementaryDocumentTextExtractionTaskResponse represents a Supplementary Text Extraction task response
+// SupplementaryDocumentTextExtractionTaskResponse represents a Supplementary Document Text Extraction task response
 type SupplementaryDocumentTextExtractionTaskResponse struct {
 	*TaskResponse
 }

--- a/docscan/session/retrieve/supplementary_document_text_extraction_task_response_test.go
+++ b/docscan/session/retrieve/supplementary_document_text_extraction_task_response_test.go
@@ -1,0 +1,28 @@
+package retrieve
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSupplementaryDocumentTextExtractionTaskResponse_GeneratedTextDataChecks(t *testing.T) {
+	var checks []*GeneratedSupplementaryTextDataCheckResponse
+	checks = append(
+		checks,
+		&GeneratedSupplementaryTextDataCheckResponse{
+			&GeneratedCheckResponse{
+				ID: "some-id",
+			},
+		},
+	)
+
+	taskResponse := &SupplementaryDocumentTextExtractionTaskResponse{
+		TaskResponse: &TaskResponse{
+			generatedSupplementaryTextDataChecks: checks,
+		},
+	}
+
+	assert.Equal(t, 1, len(taskResponse.GeneratedTextDataChecks()))
+	assert.Equal(t, "some-id", taskResponse.GeneratedTextDataChecks()[0].ID)
+}

--- a/docscan/session/retrieve/task_response.go
+++ b/docscan/session/retrieve/task_response.go
@@ -9,24 +9,21 @@ import (
 
 // TaskResponse represents the attributes of a task, for any given session
 type TaskResponse struct {
-	ID                      string                    `json:"id"`
-	Type                    string                    `json:"type"`
-	State                   string                    `json:"state"`
-	Created                 *time.Time                `json:"created"`
-	LastUpdated             *time.Time                `json:"last_updated"`
-	GeneratedChecks         []*GeneratedCheckResponse `json:"generated_checks"`
-	GeneratedMedia          []*GeneratedMedia         `json:"generated_media"`
-	generatedTextDataChecks []*GeneratedTextDataCheckResponse
+	ID                                   string                    `json:"id"`
+	Type                                 string                    `json:"type"`
+	State                                string                    `json:"state"`
+	Created                              *time.Time                `json:"created"`
+	LastUpdated                          *time.Time                `json:"last_updated"`
+	GeneratedChecks                      []*GeneratedCheckResponse `json:"generated_checks"`
+	GeneratedMedia                       []*GeneratedMedia         `json:"generated_media"`
+	generatedTextDataChecks              []*GeneratedTextDataCheckResponse
+	generatedSupplementaryTextDataChecks []*GeneratedSupplementaryTextDataCheckResponse
 }
 
 // GeneratedTextDataChecks filters the checks, returning only text data checks
+// Deprecated: this function is now implemented on specific task types
 func (t *TaskResponse) GeneratedTextDataChecks() []*GeneratedTextDataCheckResponse {
 	return t.generatedTextDataChecks
-}
-
-// TextExtractionTaskResponse represents a Text Extraction task response
-type TextExtractionTaskResponse struct {
-	*TaskResponse
 }
 
 // UnmarshalJSON handles the custom JSON unmarshalling
@@ -39,7 +36,19 @@ func (t *TaskResponse) UnmarshalJSON(data []byte) error {
 	for _, check := range t.GeneratedChecks {
 		switch check.Type {
 		case constants.IDDocumentTextDataCheck:
-			t.generatedTextDataChecks = append(t.generatedTextDataChecks, &GeneratedTextDataCheckResponse{GeneratedCheckResponse: check})
+			t.generatedTextDataChecks = append(
+				t.generatedTextDataChecks,
+				&GeneratedTextDataCheckResponse{
+					GeneratedCheckResponse: check,
+				},
+			)
+		case constants.SupplementaryDocumentTextDataCheck:
+			t.generatedSupplementaryTextDataChecks = append(
+				t.generatedSupplementaryTextDataChecks,
+				&GeneratedSupplementaryTextDataCheckResponse{
+					GeneratedCheckResponse: check,
+				},
+			)
 		}
 	}
 

--- a/docscan/session/retrieve/task_response_test.go
+++ b/docscan/session/retrieve/task_response_test.go
@@ -9,14 +9,20 @@ import (
 )
 
 func TestTaskResponse_UnmarshalJSON(t *testing.T) {
-	generatedTextDataCheck := GeneratedCheckResponse{
-		Type: constants.IDDocumentTextDataCheck,
-		ID:   "some-id",
+	checks := []*GeneratedCheckResponse{
+		{
+			Type: constants.IDDocumentTextDataCheck,
+			ID:   "some-id",
+		},
+		{
+			Type: constants.SupplementaryDocumentTextDataCheck,
+			ID:   "supplementary-id",
+		},
+		{
+			Type: "OTHER_TYPE",
+			ID:   "other-id",
+		},
 	}
-
-	var checks []*GeneratedCheckResponse
-	checks = append(checks, &GeneratedCheckResponse{Type: "OTHER_TYPE", ID: "other-id"})
-	checks = append(checks, &generatedTextDataCheck)
 
 	taskResponse := TaskResponse{
 		GeneratedChecks: checks,
@@ -30,6 +36,12 @@ func TestTaskResponse_UnmarshalJSON(t *testing.T) {
 
 	assert.Equal(t, 1, len(result.GeneratedTextDataChecks()))
 	assert.Equal(t, "some-id", result.GeneratedTextDataChecks()[0].ID)
+
+	assert.Equal(t, 1, len(result.generatedTextDataChecks))
+	assert.Equal(t, "some-id", result.generatedTextDataChecks[0].ID)
+
+	assert.Equal(t, 1, len(result.generatedSupplementaryTextDataChecks))
+	assert.Equal(t, "supplementary-id", result.generatedSupplementaryTextDataChecks[0].ID)
 }
 
 func TestTaskResponse_UnmarshalJSON_Invalid(t *testing.T) {


### PR DESCRIPTION
## Doc Scan
### Added
- Supplementary Document Support

#### Example

```go
import (
	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create"
	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/filter"
	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/objective"
	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/task"
)
```

Build supplementary document text extraction task
```go
supplementaryDocTextExtractionTask, err := task.NewRequestedSupplementaryDocTextExtractionTaskBuilder().
	WithManualCheckAlways().
	Build()
```

Request supplementary document:
```go
proofOfAddressObjective, err := objective.NewProofOfAddressObjectiveBuilder().Build()
if err != nil {
	return nil, err
}

supplementaryDoc, err := filter.NewRequiredSupplementaryDocumentBuilder().
	WithObjective(proofOfAddressObjective).
	Build()
```

Adding to session spec:
```go
sessionSpec, err := create.NewSessionSpecificationBuilder().
	WithRequestedTask(supplementaryDocTextExtractionTask).
	WithRequiredDocument(supplementaryDoc).
	Build()
```

### Deprecated
- `func (g *GetSessionResult) TextDataChecks()` replaced by `IDDocumentTextDataChecks()`

## Doc Scan Sandbox
### Added
- Support for setting supplementary document text extraction task results
- Support for setting supplementary document text data check results

#### Example

```go
import (
	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request"
	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/check"
	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/task"
)
```

Create supplementary document text data check:
```go
textDataCheck, err := check.NewSupplementaryDocumentTextDataCheckBuilder().
	WithBreakdown(breakdown).
	WithRecommendation(recommendation).
	Build()
```

Add supplementary document text data check to check reports:
```go
checkReports, err := NewCheckReportsBuilder().
	WithSupplementaryDocumentTextDataCheck(textDataCheck).
	Build()
```

Create supplementary document text data extraction task:

```go
textDataExtractionTask, err := task.NewSupplementaryDocumentTextDataExtractionTaskBuilder().
	Build()
```

Add supplementary document text data check to check reports:
```go
taskResults, err := request.NewTaskResultsBuilder().
	WithSupplementaryDocumentTextDataExtractionTask(textDataExtractionTask).
	Build()
```