### PR TITLE
SDK-1808: Handle media 204 no content response

### DIFF
--- a/_examples/docscan/handlers.session.go
+++ b/_examples/docscan/handlers.session.go
@@ -159,6 +159,11 @@ func getMedia(c *gin.Context) {
 
 	media, err := client.GetMediaContent(sessionId, mediaID)
 
+	if media == nil && err == nil {
+		c.Status(http.StatusNoContent)
+		return
+	}
+
 	if err != nil || sessionId == "" {
 		c.HTML(
 			http.StatusBadRequest,

--- a/_examples/docscan/models.sessionspec.go
+++ b/_examples/docscan/models.sessionspec.go
@@ -71,13 +71,7 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 		WithFilter(passportFilter).
 		Build()
 
-	drivingLicenceFilter, err := filter.NewRequestedOrthogonalRestrictionsFilterBuilder().
-		WithIncludedDocumentTypes(
-			[]string{"DRIVING_LICENCE"}).
-		Build()
-	drivingLicenceDoc, err := filter.NewRequiredIDDocumentBuilder().
-		WithFilter(drivingLicenceFilter).
-		Build()
+	idDoc, err := filter.NewRequiredIDDocumentBuilder().Build()
 
 	sessionSpec, err = create.NewSessionSpecificationBuilder().
 		WithClientSessionTokenTTL(600).
@@ -90,7 +84,7 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 		WithRequestedTask(textExtractionTask).
 		WithSDKConfig(sdkConfig).
 		WithRequiredDocument(passportDoc).
-		WithRequiredDocument(drivingLicenceDoc).
+		WithRequiredDocument(idDoc).
 		Build()
 
 	if err != nil {

--- a/docscan/client.go
+++ b/docscan/client.go
@@ -193,6 +193,10 @@ func (c *Client) GetMediaContent(sessionID, mediaID string) (media.Media, error)
 		return nil, err
 	}
 
+	if response.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
 	var responseBytes []byte
 	responseBytes, err = ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/docscan/client_test.go
+++ b/docscan/client_test.go
@@ -269,6 +269,30 @@ func TestClient_GetMediaContent(t *testing.T) {
 	assert.Equal(t, media.ImageTypeJPEG, result.MIME())
 }
 
+func TestClient_GetMediaContent_NoContent(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+
+	HTTPClient := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Header:     map[string][]string{},
+			}, nil
+		},
+	}
+
+	client := Client{
+		SdkID:      "sdkId",
+		Key:        key,
+		HTTPClient: HTTPClient,
+		apiURL:     "https://apiurl.com",
+	}
+
+	media, err := client.GetMediaContent("some-sessionID", "some-mediaID")
+	assert.Equal(t, media, nil)
+	assert.NilError(t, err)
+}
+
 func TestClient_GetMediaContent_NoContentType(t *testing.T) {
 	key, _ := rsa.GenerateKey(rand.Reader, 1024)
 


### PR DESCRIPTION
### Fixed
#### Doc Scan
- `func (c *Client) GetMediaContent()` will now return `nil` media for `204` responses