### PR TITLE
NA: Fix authenticty checks being shown under liveness checks

### DIFF
--- a/_examples/docscan/templates/success.html
+++ b/_examples/docscan/templates/success.html
@@ -127,7 +127,7 @@
                             </div>
                             <div id="collapse-liveness-checks" class="collapse" aria-labelledby="liveness-checks">
                                 <div class="card-body">
-                                    {{ range $check := .getSessionResult.AuthenticityChecks }}
+                                    {{ range $check := .getSessionResult.LivenessChecks }}
                                         {{ template "check.html"  $check}}
                                     {{ end }}
                                 </div>


### PR DESCRIPTION
### Fixed
 * Demo Docscan project template showing authenticity check instead of liveness check result