### PR TITLE
SDK-1909: Add Advanced CA Check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
       - id: go-vet
         exclude: _examples
       - id: go-cyclo
+        exclude: _examples
         args: [ "-over", "15", "-ignore", ".pb.go" ]
       - id: golangci-lint
         args: ["-e", "SA1019"]

--- a/_examples/aml/go.mod
+++ b/_examples/aml/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/joho/godotenv v1.3.0
 )
 
-require google.golang.org/protobuf v1.26.0 // indirect
+require google.golang.org/protobuf v1.28.0 // indirect
 
 replace github.com/getyoti/yoti-go-sdk/v3 => ../../

--- a/_examples/aml/go.sum
+++ b/_examples/aml/go.sum
@@ -6,6 +6,6 @@ github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gotest.tools/v3 v3.2.0 h1:I0DwBVMGAx26dttAj1BtJLAkVGncrkkUXfJLC4Flt/I=

--- a/_examples/docscansandbox/go.sum
+++ b/_examples/docscansandbox/go.sum
@@ -151,7 +151,7 @@ google.golang.org/genproto v0.0.0-20190626174449-989357319d63/go.mod h1:z3L6/3dT
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=

--- a/_examples/idv/go.mod
+++ b/_examples/idv/go.mod
@@ -23,7 +23,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 

--- a/_examples/idv/go.sum
+++ b/_examples/idv/go.sum
@@ -57,8 +57,9 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/_examples/idv/models.sessionspec.go
+++ b/_examples/idv/models.sessionspec.go
@@ -33,24 +33,8 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 		return nil, err
 	}
 
-	var textExtractionTask *task.RequestedTextExtractionTask
-	textExtractionTask, err = task.NewRequestedTextExtractionTaskBuilder().
-		WithManualCheckAlways().
-		Build()
-	if err != nil {
-		return nil, err
-	}
-
 	var idDocsComparisonCheck *check.RequestedIDDocumentComparisonCheck
 	idDocsComparisonCheck, err = check.NewRequestedIDDocumentComparisonCheckBuilder().
-		Build()
-	if err != nil {
-		return nil, err
-	}
-
-	var supplementaryDocTextExtractionTask *task.RequestedSupplementaryDocTextExtractionTask
-	supplementaryDocTextExtractionTask, err = task.NewRequestedSupplementaryDocTextExtractionTaskBuilder().
-		WithManualCheckAlways().
 		Build()
 	if err != nil {
 		return nil, err
@@ -72,6 +56,33 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 		return nil, err
 	}
 
+	yotiAccountWatchlistAdvancedCACheck, err := check.NewRequestedWatchlistAdvancedCACheckYotiAccountBuilder().
+		WithRemoveDeceased(true).
+		WithShareURL(true).
+		WithSources(check.RequestedTypeListSources{
+			Types: []string{"pep", "fitness-probity", "warning"}}).
+		WithMatchingStrategy(check.RequestedFuzzyMatchingStrategy{Fuzziness: 0.5}).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	var textExtractionTask *task.RequestedTextExtractionTask
+	textExtractionTask, err = task.NewRequestedTextExtractionTaskBuilder().
+		WithManualCheckAlways().
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	var supplementaryDocTextExtractionTask *task.RequestedSupplementaryDocTextExtractionTask
+	supplementaryDocTextExtractionTask, err = task.NewRequestedSupplementaryDocTextExtractionTaskBuilder().
+		WithManualCheckAlways().
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
 	var sdkConfig *create.SDKConfig
 	sdkConfig, err = create.NewSdkConfigBuilder().
 		WithAllowsCameraAndUpload().
@@ -84,7 +95,6 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 		WithErrorUrl("https://localhost:8080/error").
 		WithPrivacyPolicyUrl("https://localhost:8080/privacy-policy").
 		Build()
-
 	if err != nil {
 		return nil, err
 	}
@@ -104,6 +114,9 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 	}
 
 	idDoc, err := filter.NewRequiredIDDocumentBuilder().Build()
+	if err != nil {
+		return nil, err
+	}
 
 	proofOfAddressObjective, err := objective.NewProofOfAddressObjectiveBuilder().Build()
 	if err != nil {
@@ -127,6 +140,7 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 		WithRequestedCheck(idDocsComparisonCheck).
 		WithRequestedCheck(thirdPartyCheck).
 		WithRequestedCheck(watchlistScreeningCheck).
+		WithRequestedCheck(yotiAccountWatchlistAdvancedCACheck).
 		WithRequestedTask(textExtractionTask).
 		WithRequestedTask(supplementaryDocTextExtractionTask).
 		WithSDKConfig(sdkConfig).

--- a/_examples/idv/templates/success.html
+++ b/_examples/idv/templates/success.html
@@ -218,6 +218,26 @@
                     </div>
                     {{ end }}
 
+                    {{ if .getSessionResult.WatchlistAdvancedCAChecks }}
+                    <div class="card">
+                        <div class="card-header" id="watchlist-advanced-ca-checks">
+                            <h3 class="mb-0">
+                                <button class="btn btn-link" type="button" data-toggle="collapse"
+                                        data-target="#collapse-watchlist-advanced-ca-checks" aria-expanded="true"
+                                        aria-controls="collapse-watchlist-advanced-ca-checks">
+                                    Watchlist Advanced Checks
+                                </button>
+                            </h3>
+                        </div>
+                        <div id="collapse-watchlist-advanced-ca-checks" class="collapse" aria-labelledby="watchlist-advanced-ca-checks">
+                            <div class="card-body">
+                                {{ range $check :=  .getSessionResult.WatchlistAdvancedCAChecks }}
+                                {{ template "check.html" $check }}
+                                {{ end }}
+                            </div>
+                        </div>
+                    </div>
+                    {{ end }}
                 </div>
             </div>
         </div>

--- a/_examples/profile/go.mod
+++ b/_examples/profile/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/joho/godotenv v1.3.0
 )
 
-require google.golang.org/protobuf v1.26.0 // indirect
+require google.golang.org/protobuf v1.28.0 // indirect
 
 replace github.com/getyoti/yoti-go-sdk/v3 => ../../

--- a/_examples/profile/go.sum
+++ b/_examples/profile/go.sum
@@ -6,6 +6,6 @@ github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gotest.tools/v3 v3.2.0 h1:I0DwBVMGAx26dttAj1BtJLAkVGncrkkUXfJLC4Flt/I=

--- a/_examples/profilesandbox/go.mod
+++ b/_examples/profilesandbox/go.mod
@@ -10,7 +10,7 @@ require (
 
 require (
 	github.com/google/go-cmp v0.5.5 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 )
 
 replace github.com/getyoti/yoti-go-sdk/v3 => ../../

--- a/_examples/profilesandbox/go.sum
+++ b/_examples/profilesandbox/go.sum
@@ -29,7 +29,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gotest.tools/v3 v3.2.0 h1:I0DwBVMGAx26dttAj1BtJLAkVGncrkkUXfJLC4Flt/I=
 gotest.tools/v3 v3.2.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=

--- a/docscan/session/create/check/third_party_identity_test.go
+++ b/docscan/session/create/check/third_party_identity_test.go
@@ -7,7 +7,6 @@ import (
 
 func ExampleRequestedThirdPartyIdentityCheck() {
 	thirdPartyCheck, err := NewRequestedThirdPartyIdentityCheckBuilder().Build()
-
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())
 		return

--- a/docscan/session/create/check/watchlist_advanced_ca.go
+++ b/docscan/session/create/check/watchlist_advanced_ca.go
@@ -1,0 +1,9 @@
+package check
+
+type RequestedWatchlistAdvancedCAConfig struct {
+	Type             string                      `json:"type,omitempty"`
+	RemoveDeceased   bool                        `json:"remove_deceased,omitempty"`
+	ShareUrl         bool                        `json:"share_url,omitempty"`
+	Sources          RequestedCASources          `json:"sources,omitempty"`
+	MatchingStrategy RequestedCAMatchingStrategy `json:"matching_strategy,omitempty"`
+}

--- a/docscan/session/create/check/watchlist_advanced_ca_custom.go
+++ b/docscan/session/create/check/watchlist_advanced_ca_custom.go
@@ -1,0 +1,120 @@
+package check
+
+import (
+	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+)
+
+type RequestedWatchlistAdvancedCACustomAccountCheck struct {
+	config RequestedWatchlistAdvancedCACustomAccountConfig
+}
+
+// Type is the type of the requested check
+func (c RequestedWatchlistAdvancedCACustomAccountCheck) Type() string {
+	return constants.WatchlistAdvancedCA
+}
+
+// Config is the configuration of the requested check
+func (c RequestedWatchlistAdvancedCACustomAccountCheck) Config() RequestedCheckConfig {
+	return RequestedCheckConfig(c.config)
+}
+
+// MarshalJSON returns the JSON encoding
+func (c RequestedWatchlistAdvancedCACustomAccountCheck) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type   string               `json:"type"`
+		Config RequestedCheckConfig `json:"config,omitempty"`
+	}{
+		Type:   c.Type(),
+		Config: c.Config(),
+	})
+}
+
+func NewRequestedWatchlistAdvancedCACheckCustomAccountBuilder() *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	return &RequestedWatchlistAdvancedCACheckCustomAccountBuilder{}
+}
+
+type RequestedWatchlistAdvancedCACustomAccountConfig struct {
+	RequestedWatchlistAdvancedCAConfig
+	APIKey     string            `json:"api_key,omitempty"`
+	Monitoring bool              `json:"monitoring,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	ClientRef  string            `json:"client_ref,omitempty"`
+}
+
+type RequestedWatchlistAdvancedCACheckCustomAccountBuilder struct {
+	removeDeceased              bool
+	shareURL                    bool
+	requestedCASources          RequestedCASources
+	requestedCAMatchingStrategy RequestedCAMatchingStrategy
+	apiKey                      string
+	monitoring                  bool
+	tags                        map[string]string
+	clientRef                   string
+}
+
+// WithAPIKey sets the API key for the Watchlist Advanced CA check (custom account).
+func (b *RequestedWatchlistAdvancedCACheckCustomAccountBuilder) WithAPIKey(apiKey string) *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	b.apiKey = apiKey
+	return b
+}
+
+// WithMonitoring sets whether monitoring is used for the Watchlist Advanced CA check (custom account).
+func (b *RequestedWatchlistAdvancedCACheckCustomAccountBuilder) WithMonitoring(monitoring bool) *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	b.monitoring = monitoring
+	return b
+}
+
+// WithTags sets tags used for custom account Watchlist Advanced CA check.
+// Please note this will override any previously set tags
+func (b *RequestedWatchlistAdvancedCACheckCustomAccountBuilder) WithTags(tags map[string]string) *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	b.tags = tags
+	return b
+}
+
+// WithClientRef sets the client reference for the Watchlist Advanced CA check (custom account).
+func (b *RequestedWatchlistAdvancedCACheckCustomAccountBuilder) WithClientRef(clientRef string) *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	b.clientRef = clientRef
+	return b
+}
+
+func (b *RequestedWatchlistAdvancedCACheckCustomAccountBuilder) WithRemoveDeceased(removeDeceased bool) *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	b.removeDeceased = removeDeceased
+	return b
+}
+
+func (b *RequestedWatchlistAdvancedCACheckCustomAccountBuilder) WithShareURL(shareURL bool) *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	b.shareURL = shareURL
+	return b
+}
+
+func (b *RequestedWatchlistAdvancedCACheckCustomAccountBuilder) WithSources(requestedCASources RequestedCASources) *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	b.requestedCASources = requestedCASources
+	return b
+}
+
+func (b *RequestedWatchlistAdvancedCACheckCustomAccountBuilder) WithMatchingStrategy(requestedCAMatchingStrategy RequestedCAMatchingStrategy) *RequestedWatchlistAdvancedCACheckCustomAccountBuilder {
+	b.requestedCAMatchingStrategy = requestedCAMatchingStrategy
+	return b
+}
+
+func (b RequestedWatchlistAdvancedCACheckCustomAccountBuilder) Build() (RequestedWatchlistAdvancedCACustomAccountCheck, error) {
+	config := RequestedWatchlistAdvancedCACustomAccountConfig{
+		RequestedWatchlistAdvancedCAConfig: RequestedWatchlistAdvancedCAConfig{
+			Type:             constants.WithCustomAccount,
+			RemoveDeceased:   b.removeDeceased,
+			ShareUrl:         b.shareURL,
+			Sources:          b.requestedCASources,
+			MatchingStrategy: b.requestedCAMatchingStrategy,
+		},
+		APIKey:     b.apiKey,
+		Monitoring: b.monitoring,
+		Tags:       b.tags,
+		ClientRef:  b.clientRef,
+	}
+
+	return RequestedWatchlistAdvancedCACustomAccountCheck{
+		config: config,
+	}, nil
+}

--- a/docscan/session/create/check/watchlist_advanced_ca_custom_test.go
+++ b/docscan/session/create/check/watchlist_advanced_ca_custom_test.go
@@ -1,0 +1,32 @@
+package check_test
+
+import (
+	"fmt"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/check"
+)
+
+func ExampleRequestedWatchlistAdvancedCACheckCustomAccountBuilder_Build() {
+	advancedCACustomAccountCheck, err := check.NewRequestedWatchlistAdvancedCACheckCustomAccountBuilder().
+		WithAPIKey("api-key").
+		WithMonitoring(true).
+		WithTags(map[string]string{
+			"tag_name": "value",
+		}).
+		WithClientRef("client-ref").
+		WithMatchingStrategy(check.RequestedExactMatchingStrategy{ExactMatch: true}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := advancedCACustomAccountCheck.MarshalJSON()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"WATCHLIST_ADVANCED_CA","config":{"type":"WITH_CUSTOM_ACCOUNT","matching_strategy":{"type":"EXACT","exact_match":true},"api_key":"api-key","monitoring":true,"tags":{"tag_name":"value"},"client_ref":"client-ref"}}
+}

--- a/docscan/session/create/check/watchlist_advanced_ca_matching_strategy.go
+++ b/docscan/session/create/check/watchlist_advanced_ca_matching_strategy.go
@@ -1,0 +1,48 @@
+package check
+
+import (
+	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+)
+
+// RequestedCAMatchingStrategy is the base type which other CA matching strategies must satisfy
+type RequestedCAMatchingStrategy interface {
+	Type() string
+}
+
+func NewRequestedFuzzyMatchingStrategy() *RequestedFuzzyMatchingStrategy {
+	return &RequestedFuzzyMatchingStrategy{}
+}
+
+type RequestedFuzzyMatchingStrategy struct {
+	RequestedCAMatchingStrategy
+	Fuzziness float64
+}
+
+// MarshalJSON returns the JSON encoding
+func (c RequestedFuzzyMatchingStrategy) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type      string  `json:"type"`
+		Fuzziness float64 `json:"fuzziness"`
+	}{
+		Type:      constants.Fuzzy,
+		Fuzziness: c.Fuzziness,
+	})
+}
+
+type RequestedExactMatchingStrategy struct {
+	RequestedCAMatchingStrategy
+	ExactMatch bool
+}
+
+// MarshalJSON returns the JSON encoding
+func (c RequestedExactMatchingStrategy) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type       string `json:"type"`
+		ExactMatch bool   `json:"exact_match"`
+	}{
+		Type:       constants.Exact,
+		ExactMatch: c.ExactMatch,
+	})
+}

--- a/docscan/session/create/check/watchlist_advanced_ca_sources.go
+++ b/docscan/session/create/check/watchlist_advanced_ca_sources.go
@@ -1,0 +1,34 @@
+package check
+
+import (
+	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+)
+
+// RequestedCASources is the base type which other CA sources must satisfy
+type RequestedCASources interface {
+	Type() string
+	MarshalJSON() ([]byte, error)
+}
+
+type RequestedTypeListSources struct {
+	RequestedCASources
+	Types []string
+}
+
+// Type is the type of the Requested Check
+func (c RequestedTypeListSources) Type() string {
+	return constants.TypeList
+}
+
+// MarshalJSON returns the JSON encoding
+func (c RequestedTypeListSources) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type  string   `json:"type"`
+		Types []string `json:"types"`
+	}{
+		Type:  c.Type(),
+		Types: c.Types,
+	})
+}

--- a/docscan/session/create/check/watchlist_advanced_ca_yoti.go
+++ b/docscan/session/create/check/watchlist_advanced_ca_yoti.go
@@ -1,0 +1,84 @@
+package check
+
+import (
+	"encoding/json"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
+)
+
+type RequestedWatchlistAdvancedCAYotiAccountCheck struct {
+	config RequestedWatchlistAdvancedCAYotiAccountConfig
+}
+
+// Type is the type of the requested check
+func (c RequestedWatchlistAdvancedCAYotiAccountCheck) Type() string {
+	return constants.WatchlistAdvancedCA
+}
+
+// Config is the configuration of the requested check
+func (c RequestedWatchlistAdvancedCAYotiAccountCheck) Config() RequestedCheckConfig {
+	return RequestedCheckConfig(c.config)
+}
+
+// MarshalJSON returns the JSON encoding
+func (c RequestedWatchlistAdvancedCAYotiAccountCheck) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type   string               `json:"type"`
+		Config RequestedCheckConfig `json:"config,omitempty"`
+	}{
+		Type:   c.Type(),
+		Config: c.Config(),
+	})
+}
+
+type RequestedWatchlistAdvancedCACheckYotiAccountBuilder struct {
+	removeDeceased              bool
+	shareURL                    bool
+	requestedCASources          RequestedCASources
+	requestedCAMatchingStrategy RequestedCAMatchingStrategy
+}
+
+type RequestedWatchlistAdvancedCAYotiAccountConfig struct {
+	RequestedWatchlistAdvancedCAConfig
+}
+
+// NewRequestedWatchlistAdvancedCACheckYotiAccountBuilder creates a new builder for RequestedWatchlistAdvancedCACheckYotiAccountBuilder
+func NewRequestedWatchlistAdvancedCACheckYotiAccountBuilder() *RequestedWatchlistAdvancedCACheckYotiAccountBuilder {
+	return &RequestedWatchlistAdvancedCACheckYotiAccountBuilder{}
+}
+
+func (b *RequestedWatchlistAdvancedCACheckYotiAccountBuilder) WithRemoveDeceased(removeDeceased bool) *RequestedWatchlistAdvancedCACheckYotiAccountBuilder {
+	b.removeDeceased = removeDeceased
+	return b
+}
+
+func (b *RequestedWatchlistAdvancedCACheckYotiAccountBuilder) WithShareURL(shareURL bool) *RequestedWatchlistAdvancedCACheckYotiAccountBuilder {
+	b.shareURL = shareURL
+	return b
+}
+
+func (b *RequestedWatchlistAdvancedCACheckYotiAccountBuilder) WithSources(requestedCASources RequestedCASources) *RequestedWatchlistAdvancedCACheckYotiAccountBuilder {
+	b.requestedCASources = requestedCASources
+	return b
+}
+
+func (b *RequestedWatchlistAdvancedCACheckYotiAccountBuilder) WithMatchingStrategy(requestedCAMatchingStrategy RequestedCAMatchingStrategy) *RequestedWatchlistAdvancedCACheckYotiAccountBuilder {
+	b.requestedCAMatchingStrategy = requestedCAMatchingStrategy
+	return b
+}
+
+func (b RequestedWatchlistAdvancedCACheckYotiAccountBuilder) Build() (RequestedWatchlistAdvancedCAYotiAccountCheck, error) {
+	config := RequestedWatchlistAdvancedCAYotiAccountConfig{
+		RequestedWatchlistAdvancedCAConfig{
+			Type:             constants.WithYotiAccounts,
+			RemoveDeceased:   b.removeDeceased,
+			ShareUrl:         b.shareURL,
+			Sources:          b.requestedCASources,
+			MatchingStrategy: b.requestedCAMatchingStrategy,
+		},
+	}
+
+	return RequestedWatchlistAdvancedCAYotiAccountCheck{
+		config: config,
+	}, nil
+}

--- a/docscan/session/create/check/watchlist_advanced_ca_yoti_test.go
+++ b/docscan/session/create/check/watchlist_advanced_ca_yoti_test.go
@@ -1,0 +1,30 @@
+package check_test
+
+import (
+	"fmt"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/check"
+)
+
+func ExampleNewRequestedWatchlistAdvancedCACheckYotiAccountBuilder() {
+	advancedCAYotiAccountCheck, err := check.NewRequestedWatchlistAdvancedCACheckYotiAccountBuilder().
+		WithRemoveDeceased(true).
+		WithShareURL(true).
+		WithSources(check.RequestedTypeListSources{
+			Types: []string{"pep", "fitness-probity", "warning"}}).
+		WithMatchingStrategy(check.RequestedFuzzyMatchingStrategy{Fuzziness: 0.5}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := advancedCAYotiAccountCheck.MarshalJSON()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"WATCHLIST_ADVANCED_CA","config":{"type":"WITH_YOTI_ACCOUNT","remove_deceased":true,"share_url":true,"sources":{"type":"TYPE_LIST","types":["pep","fitness-probity","warning"]},"matching_strategy":{"type":"FUZZY","fuzziness":0.5}}}
+}

--- a/docscan/session/retrieve/ca_sources.go
+++ b/docscan/session/retrieve/ca_sources.go
@@ -1,0 +1,7 @@
+package retrieve
+
+type CASourcesResponse struct {
+	Type          string   `json:"type"`
+	SearchProfile string   `json:"search_profile"`
+	Types         []string `json:"types"`
+}

--- a/docscan/session/retrieve/check_response.go
+++ b/docscan/session/retrieve/check_response.go
@@ -56,3 +56,8 @@ type ThirdPartyIdentityCheckResponse struct {
 type WatchlistScreeningCheckResponse struct {
 	*CheckResponse
 }
+
+// WatchlistAdvancedCACheckResponse represents an advanced CA watchlist screening check
+type WatchlistAdvancedCACheckResponse struct {
+	*CheckResponse
+}

--- a/docscan/session/retrieve/get_session_result.go
+++ b/docscan/session/retrieve/get_session_result.go
@@ -25,6 +25,7 @@ type GetSessionResult struct {
 	idDocumentComparisonChecks          []*IDDocumentComparisonCheckResponse
 	supplementaryDocumentTextDataChecks []*SupplementaryDocumentTextDataCheckResponse
 	watchlistScreeningChecks            []*WatchlistScreeningCheckResponse
+	watchlistAdvancedCAChecks           []*WatchlistAdvancedCACheckResponse
 }
 
 // AuthenticityChecks filters the checks, returning only document authenticity checks
@@ -73,6 +74,11 @@ func (g *GetSessionResult) WatchlistScreeningChecks() []*WatchlistScreeningCheck
 	return g.watchlistScreeningChecks
 }
 
+// WatchlistAdvancedCAChecks filters the checks, returning only the Watchlist Advanced CA Screening checks
+func (g *GetSessionResult) WatchlistAdvancedCAChecks() []*WatchlistAdvancedCACheckResponse {
+	return g.watchlistAdvancedCAChecks
+}
+
 // UnmarshalJSON handles the custom JSON unmarshalling
 func (g *GetSessionResult) UnmarshalJSON(data []byte) error {
 	type result GetSessionResult // declared as "type" to prevent recursive unmarshalling
@@ -116,6 +122,14 @@ func (g *GetSessionResult) UnmarshalJSON(data []byte) error {
 			g.watchlistScreeningChecks = append(
 				g.watchlistScreeningChecks,
 				&WatchlistScreeningCheckResponse{
+					CheckResponse: check,
+				},
+			)
+
+		case constants.WatchlistAdvancedCA:
+			g.watchlistAdvancedCAChecks = append(
+				g.watchlistAdvancedCAChecks,
+				&WatchlistAdvancedCACheckResponse{
 					CheckResponse: check,
 				},
 			)

--- a/docscan/session/retrieve/search_config.go
+++ b/docscan/session/retrieve/search_config.go
@@ -1,6 +1,20 @@
 package retrieve
 
 type SearchConfig struct {
-	Type       string   `json:"type"`
-	Categories []string `json:"categories"`
+	Type             string                     `json:"type"`
+	Categories       []string                   `json:"categories"`
+	RemoveDeceased   bool                       `json:"remove_deceased"`
+	ShareURL         bool                       `json:"share_url"`
+	Sources          CASourcesResponse          `json:"sources"`
+	MatchingStrategy CAMatchingStrategyResponse `json:"matching_strategy"`
+	APIKey           string                     `json:"api_key"`
+	Monitoring       bool                       `json:"monitoring"`
+	Tags             map[string]string          `json:"tags"`
+	ClientRef        string                     `json:"client_ref"`
+}
+
+type CAMatchingStrategyResponse struct {
+	Type       string  `json:"type"`
+	ExactMatch string  `json:"exact_match"`
+	Fuzziness  float64 `json:"fuzziness"`
 }

--- a/requests/signed_message_test.go
+++ b/requests/signed_message_test.go
@@ -78,7 +78,9 @@ func TestRequestShouldBuildForValid(t *testing.T) {
 	urlCheck, err := regexp.Match(baseURL+endpoint, []byte(signed.URL.String()))
 	assert.NilError(t, err)
 	assert.Check(t, urlCheck)
-	assert.Check(t, signed.Header["X-Yoti-Auth-Digest"][0] != "")
+	assert.Check(t, signed.Header.Get("X-Yoti-Auth-Digest") != "")
+	assert.Equal(t, signed.Header.Get("X-Yoti-SDK"), "Go")
+	assert.Equal(t, signed.Header.Get("X-Yoti-SDK-Version"), "3.6.0")
 }
 
 func TestRequestShouldAddHeaders(t *testing.T) {

--- a/test/fixtures/watchlist_advanced_ca_profile_custom.json
+++ b/test/fixtures/watchlist_advanced_ca_profile_custom.json
@@ -1,0 +1,257 @@
+{
+  "client_session_token_ttl": 155057,
+  "session_id": "a3819be3-df1f-4d8c-9161-abfe1b19d9e8",
+  "state": "COMPLETED",
+  "resources": {
+    "id_documents": [
+      {
+        "id": "d99241db-243f-472d-84a2-d956b87db5f8",
+        "tasks": [
+          {
+            "type": "ID_DOCUMENT_TEXT_DATA_EXTRACTION",
+            "id": "e1995b9a-9b6f-43b9-a179-32bbe2d25586",
+            "state": "DONE",
+            "created": "2022-01-14T14:54:14Z",
+            "last_updated": "2022-01-14T14:59:13Z",
+            "generated_checks": [
+              {
+                "id": "851cec96-7459-49d3-b9b2-bcbc4c759987",
+                "type": "ID_DOCUMENT_TEXT_DATA_CHECK"
+              }
+            ],
+            "generated_media": [
+              {
+                "id": "a8c9e973-4e58-43d8-952d-17f36f12bce2",
+                "type": "JSON"
+              }
+            ]
+          }
+        ],
+        "source": {
+          "type": "END_USER"
+        },
+        "document_type": "DRIVING_LICENCE",
+        "issuing_country": "GBR",
+        "pages": [
+          {
+            "capture_method": "UPLOAD",
+            "media": {
+              "id": "8c65cb1c-92cb-43df-bac1-65433ac3a1c1",
+              "type": "IMAGE",
+              "created": "2022-01-14T14:54:30Z",
+              "last_updated": "2022-01-14T14:54:30Z"
+            },
+            "frames": [{}, {}]
+          },
+          {
+            "capture_method": "UPLOAD",
+            "media": {
+              "id": "a7c8331c-6e29-4720-8818-27c02e6252b3",
+              "type": "IMAGE",
+              "created": "2022-01-14T14:54:31Z",
+              "last_updated": "2022-01-14T14:54:31Z"
+            },
+            "frames": [{}, {}]
+          }
+        ],
+        "document_fields": {
+          "media": {
+            "id": "b5cae0f3-ae43-41d3-b8a7-1b0d363938ef",
+            "type": "JSON",
+            "created": "2022-01-14T14:59:13Z",
+            "last_updated": "2022-01-14T14:59:13Z"
+          }
+        },
+        "document_id_photo": {
+          "media": {
+            "id": "ee3f9895-0552-4e16-ad9a-914e2f676c10",
+            "type": "IMAGE",
+            "created": "2022-01-14T14:54:34Z",
+            "last_updated": "2022-01-14T14:54:34Z"
+          }
+        }
+      }
+    ],
+    "supplementary_documents": [],
+    "liveness_capture": [],
+    "face_capture": []
+  },
+  "checks": [
+    {
+      "type": "ID_DOCUMENT_AUTHENTICITY",
+      "id": "f11efbfb-712c-4f9d-8328-2add190f32e3",
+      "state": "DONE",
+      "resources_used": ["d99241db-243f-472d-84a2-d956b87db5f8"],
+      "generated_media": [],
+      "report": {
+        "recommendation": {
+          "value": "APPROVE"
+        },
+        "breakdown": [
+          {
+            "sub_check": "doc_number_validation",
+            "result": "PASS",
+            "details": []
+          },
+          {
+            "sub_check": "document_in_date",
+            "result": "PASS",
+            "details": []
+          },
+          {
+            "sub_check": "fraud_list_check",
+            "result": "PASS",
+            "details": []
+          }
+        ]
+      },
+      "created": "2022-01-14T14:54:36Z",
+      "last_updated": "2022-01-14T14:59:14Z"
+    },
+    {
+      "type": "ID_DOCUMENT_TEXT_DATA_CHECK",
+      "id": "851cec96-7459-49d3-b9b2-bcbc4c759987",
+      "state": "DONE",
+      "resources_used": ["d99241db-243f-472d-84a2-d956b87db5f8"],
+      "generated_media": [
+        {
+          "id": "b5cae0f3-ae43-41d3-b8a7-1b0d363938ef",
+          "type": "JSON"
+        }
+      ],
+      "report": {
+        "recommendation": {
+          "value": "APPROVE"
+        },
+        "breakdown": [
+          {
+            "sub_check": "text_data_readable",
+            "result": "PASS",
+            "details": []
+          }
+        ]
+      },
+      "created": "2022-01-14T14:54:36Z",
+      "last_updated": "2022-01-14T14:59:13Z"
+    },
+    {
+      "type": "WATCHLIST_ADVANCED_CA",
+      "id": "06e661c5-0e24-44ed-8f6c-8b99807efc12",
+      "state": "DONE",
+      "resources_used": ["d99241db-243f-472d-84a2-d956b87db5f8"],
+      "generated_media": [
+        {
+          "id": "7c405b5e-348d-4a2c-87ff-787d4fb139c0",
+          "type": "JSON"
+        }
+      ],
+      "report": {
+        "recommendation": {
+          "value": "CONSIDER",
+          "reason": "POTENTIAL_MATCH"
+        },
+        "breakdown": [
+          {
+            "sub_check": "adverse_media",
+            "result": "FAIL",
+            "details": [
+              {
+                "name": "number_of_hits",
+                "value": "251"
+              },
+              {
+                "name": "closest_match",
+                "value": "name_exact,year_of_birth"
+              }
+            ]
+          },
+          {
+            "sub_check": "custom_search",
+            "result": "FAIL",
+            "details": []
+          },
+          {
+            "sub_check": "fitness_probity",
+            "result": "FAIL",
+            "details": [
+              {
+                "name": "number_of_hits",
+                "value": "3"
+              },
+              {
+                "name": "closest_match",
+                "value": "name_exact"
+              }
+            ]
+          },
+          {
+            "sub_check": "pep",
+            "result": "FAIL",
+            "details": [
+              {
+                "name": "number_of_hits",
+                "value": "13"
+              },
+              {
+                "name": "closest_match",
+                "value": "name_exact,year_of_birth"
+              }
+            ]
+          },
+          {
+            "sub_check": "warning",
+            "result": "FAIL",
+            "details": [
+              {
+                "name": "number_of_hits",
+                "value": "9"
+              },
+              {
+                "name": "closest_match",
+                "value": "name_exact,year_of_birth"
+              }
+            ]
+          }
+        ],
+        "watchlist_summary": {
+          "total_hits": 100,
+          "search_config": {
+            "type": "WITH_CUSTOM_ACCOUNT",
+            "remove_deceased": true,
+            "share_url": true,
+            "matching_strategy": {
+              "type": "FUZZY",
+              "fuzziness": 0.6
+            },
+            "sources": {
+              "type": "PROFILE",
+              "search_profile": "b41d82de-9a1d-4494-97a6-8b1b9895a908"
+            },
+            "api_key": "gQ2vf0STnF5nGy9SSdyuGJuYMFfNASmV",
+            "client_ref": "111111",
+            "monitoring": true
+          },
+          "raw_results": {
+            "media": {
+              "id": "0ebadb40-670a-4dd8-b0cc-5079d5d74c1c",
+              "type": "JSON",
+              "created": "2022-01-14T14:59:14Z",
+              "last_updated": "2022-01-14T14:59:14Z"
+            }
+          },
+          "associated_country_codes": ["GBR"]
+        }
+      },
+      "created": "2022-01-14T14:54:36Z",
+      "last_updated": "2022-01-14T14:59:14Z",
+      "generated_profile": {
+        "media": {
+          "id": "7c405b5e-348d-4a2c-87ff-787d4fb139c0",
+          "type": "JSON",
+          "created": "2022-01-14T14:59:14Z",
+          "last_updated": "2022-01-14T14:59:14Z"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Added
- Advanced CA Check
#### Requested With
```go
advancedCAYotiAccountCheck, err := check.NewRequestedWatchlistAdvancedCACheckYotiAccountBuilder().
	WithRemoveDeceased(true).
	WithShareURL(true).
	WithSources(check.RequestedTypeListSources{
		Types: []string{"pep", "fitness-probity", "warning"}}).
	WithMatchingStrategy(check.RequestedFuzzyMatchingStrategy{Fuzziness: 0.5}).
	Build()
```
OR
```go
advancedCACustomAccountCheck, err := check.NewRequestedWatchlistAdvancedCACheckCustomAccountBuilder().
	WithAPIKey("api-key").
	WithMonitoring(true).
	WithTags(map[string]string{
		"tag_name": "value",
	}).
	WithClientRef("client-ref").
	WithMatchingStrategy(check.RequestedExactMatchingStrategy{ExactMatch: true}).
	Build()
```
#### Response retrieved with:
```go
getSessionResult.WatchlistAdvancedCAChecks()
```

Demo Project screenshot:
![image](https://user-images.githubusercontent.com/1381991/175321460-e95835da-1737-4996-82d2-40f77cc24cdf.png)
