### PR TITLE
Retrieve the identity profile in the IDV response

### DIFF
--- a/_examples/idv/main.go
+++ b/_examples/idv/main.go
@@ -3,6 +3,9 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"html/template"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -17,6 +20,14 @@ func main() {
 	// Set the router as the default one provided by Gin
 	router = gin.Default()
 
+	router.SetFuncMap(template.FuncMap{
+		"jsonMarshallIndent": func(data interface{}) string {
+			json, err := json.MarshalIndent(data, "", "\t")
+			if err != nil {
+				fmt.Println(err)
+			}
+			return string(json)
+		}})
 	// Process the templates at the start so that they don't have to be loaded
 	// from the disk again. This makes serving HTML pages very fast.
 	router.LoadHTMLGlob("templates/*")

--- a/_examples/idv/templates/success.html
+++ b/_examples/idv/templates/success.html
@@ -47,6 +47,12 @@
         </div>
     </div>
 
+    {{ if .getSessionResult.IdentityProfile }}
+        <div class="col">
+            <h1>Identity Profile</h1>
+            <pre>{{ jsonMarshallIndent .getSessionResult.IdentityProfile }}</pre>
+        </div>
+    {{ end }}
     {{ if .getSessionResult.Checks }}
         <div class="row pt-4">
             <div class="col">

--- a/docscan/session/retrieve/failure_reason_response.go
+++ b/docscan/session/retrieve/failure_reason_response.go
@@ -1,0 +1,5 @@
+package retrieve
+
+type FailureReasonResponse struct {
+	ReasonCode string `json:"reason_code"`
+}

--- a/docscan/session/retrieve/get_session_result.go
+++ b/docscan/session/retrieve/get_session_result.go
@@ -9,14 +9,15 @@ import (
 
 // GetSessionResult contains the information about a created session
 type GetSessionResult struct {
-	ClientSessionTokenTTL               int                `json:"client_session_token_ttl"`
-	ClientSessionToken                  string             `json:"client_session_token"`
-	SessionID                           string             `json:"session_id"`
-	UserTrackingID                      string             `json:"user_tracking_id"`
-	State                               string             `json:"state"`
-	Checks                              []*CheckResponse   `json:"checks"`
-	Resources                           *ResourceContainer `json:"resources"`
-	BiometricConsentTimestamp           *time.Time         `json:"biometric_consent"`
+	ClientSessionTokenTTL               int                      `json:"client_session_token_ttl"`
+	ClientSessionToken                  string                   `json:"client_session_token"`
+	SessionID                           string                   `json:"session_id"`
+	UserTrackingID                      string                   `json:"user_tracking_id"`
+	State                               string                   `json:"state"`
+	Checks                              []*CheckResponse         `json:"checks"`
+	Resources                           *ResourceContainer       `json:"resources"`
+	BiometricConsentTimestamp           *time.Time               `json:"biometric_consent"`
+	IdentityProfileResponse             *IdentityProfileResponse `json:"identity_profile"`
 	authenticityChecks                  []*AuthenticityCheckResponse
 	faceMatchChecks                     []*FaceMatchCheckResponse
 	textDataChecks                      []*TextDataCheckResponse

--- a/docscan/session/retrieve/get_session_result_test.go
+++ b/docscan/session/retrieve/get_session_result_test.go
@@ -188,3 +188,29 @@ func TestGetSessionResult_UnmarshalJSON_WithoutBiometricConsentTimestamp(t *test
 	assert.NilError(t, err)
 	assert.Check(t, result.BiometricConsentTimestamp == nil)
 }
+
+func TestGetSessionResult_UnmarshalJSON_IdentityProfile(t *testing.T) {
+	bytes, err := file.ReadFile("../../../test/fixtures/GetSessionResultWithIdentityProfile.json")
+	assert.NilError(t, err)
+
+	var result retrieve.GetSessionResult
+	err = result.UnmarshalJSON(bytes)
+	assert.NilError(t, err)
+
+	identityProfile := result.IdentityProfileResponse
+	assert.Assert(t, identityProfile != nil)
+
+	assert.Equal(t, identityProfile.SubjectId, "someStringHere")
+	assert.Equal(t, identityProfile.Result, "DONE")
+	assert.Equal(t, identityProfile.FailureReasonResponse, retrieve.FailureReasonResponse{ReasonCode: "MANDATORY_DOCUMENT_COULD_NOT_BE_PROVIDED"})
+
+	assert.NilError(t, err)
+	tf, ok := identityProfile.Report["trust_framework"].(string)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, tf, "UK_TFIDA")
+	media, ok := identityProfile.Report["media"].(map[string]interface{})
+	assert.Equal(t, ok, true)
+	mid, ok := media["id"].(string)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, mid, "c69ff2db-6caf-4e74-8386-037711bbc8d7")
+}

--- a/docscan/session/retrieve/identity_profile_response.go
+++ b/docscan/session/retrieve/identity_profile_response.go
@@ -1,0 +1,10 @@
+package retrieve
+
+// IdentityProfileResponse contains the SubjectId, teh Result/FailureReasonResponse, verified identity details,
+// and the verification report that certifies how the identity was verified and how the verification level was achieved.
+type IdentityProfileResponse struct {
+	SubjectId             string                 `json:"subject_id"`
+	Result                string                 `json:"result"`
+	FailureReasonResponse FailureReasonResponse  `json:"failure_reason"`
+	Report                map[string]interface{} `json:"identity_profile_report"`
+}

--- a/test/fixtures/GetSessionResultWithIdentityProfile.json
+++ b/test/fixtures/GetSessionResultWithIdentityProfile.json
@@ -1,0 +1,32 @@
+{
+  "session_id": "a1746488-efcc-4c59-bd28-f849dcb933a2",
+  "client_session_token_ttl": 599,
+  "user_tracking_id": "user-tracking-id",
+  "biometric_consent": "2022-03-29T11:39:08.473Z",
+  "state": "COMPLETED",
+  "client_session_token": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "identity_profile": {
+    "subject_id": "someStringHere",
+    "result": "DONE",
+    "failure_reason": {
+      "reason_code": "MANDATORY_DOCUMENT_COULD_NOT_BE_PROVIDED"
+    },
+    "identity_profile_report": {
+      "trust_framework": "UK_TFIDA",
+      "schemes_compliance": [{
+        "scheme": {
+          "type": "DBS",
+          "objective": "STANDARD"
+        },
+        "requirements_met": true,
+        "requirements_not_met_info": "some string here"
+      }],
+      "media": {
+        "id": "c69ff2db-6caf-4e74-8386-037711bbc8d7",
+        "type": "IMAGE",
+        "created": "2022-03-29T11:39:24Z",
+        "last_updated": "2022-03-29T11:39:24Z"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Added**

- IdentityProfile to IDV GetSessionResult:

```go
getSessionResult, err := client.GetSession(sessionId)
if err != nil {
        return err
}
identityProfile := getSessionResult.IdentityProfileResponse
subjectId := identityProfile.SubjectId
result := identityProfile.Result
failureReasonCode := identityProfile.FailureReasonResponse.ReasonCode
```


example IdentityProfile.Report value:

```json
"trust_framework": "UK_TFIDA",
"schemes_compliance": [{
		"scheme": {
			"type": "DBS",
			"objective": "STANDARD"
		},
		"requirements_met": true,
		"requirements_not_met_info": "info here"
	}
],
"media": {
	"id": "c69ff2db-6caf-4e74-8386-037711bbc8d7",
	"type": "IMAGE",
	"created": "2022-03-29T11:39:24Z",
	"last_updated": "2022-03-29T11:39:24Z"
}
```


MediaID can be retrieved with:

```go
media := result.IdentityProfileResponse.Report["media"].(map[string]interface{})
mediaId := media["id"].(string)
```

and used to retrieve the full identity profile report as JSON with a separate call:

```go
mediaValue, err := client.GetMediaContent("your-session-id", mediaId)
```