### PR TITLE
Add subject to IDV request

### DIFF
--- a/_examples/idv/models.sessionspec.go
+++ b/_examples/idv/models.sessionspec.go
@@ -180,12 +180,17 @@ func buildDBSSessionSpec() (sessionSpec *create.SessionSpecification, err error)
 		}
 	}`)
 
+	subject := []byte(`{
+		"subject_id": "unique-user-id-for-examples"
+	}`)
+
 	sessionSpec, err = create.NewSessionSpecificationBuilder().
 		WithClientSessionTokenTTL(600).
 		WithResourcesTTL(90000).
 		WithUserTrackingID("some-tracking-id").
 		WithSDKConfig(sdkConfig).
 		WithIdentityProfileRequirements(identityProfile).
+		WithSubject(subject).
 		Build()
 
 	if err != nil {

--- a/docscan/session/create/session_spec.go
+++ b/docscan/session/create/session_spec.go
@@ -40,6 +40,10 @@ type SessionSpecification struct {
 	// IdentityProfileRequirements is a JSON object for defining a required identity profile
 	// within the scope of a trust framework and scheme.
 	IdentityProfileRequirements *json.RawMessage `json:"identity_profile_requirements,omitempty"`
+
+	// Subject provides information on the subject allowing to track the same user across multiple sessions.
+	// Should not contain any personal identifiable information.
+	Subject *json.RawMessage `json:"subject,omitempty"`
 }
 
 // SessionSpecificationBuilder builds the SessionSpecification struct
@@ -54,6 +58,7 @@ type SessionSpecificationBuilder struct {
 	requiredDocuments           []filter.RequiredDocument
 	blockBiometricConsent       *bool
 	identityProfileRequirements *json.RawMessage
+	subject                     *json.RawMessage
 }
 
 // NewSessionSpecificationBuilder creates a new SessionSpecificationBuilder
@@ -121,6 +126,11 @@ func (b *SessionSpecificationBuilder) WithIdentityProfileRequirements(identityPr
 	return b
 }
 
+func (b *SessionSpecificationBuilder) WithSubject(subject json.RawMessage) *SessionSpecificationBuilder {
+	b.subject = &subject
+	return b
+}
+
 // Build builds the SessionSpecification struct
 func (b *SessionSpecificationBuilder) Build() (*SessionSpecification, error) {
 	return &SessionSpecification{
@@ -134,5 +144,6 @@ func (b *SessionSpecificationBuilder) Build() (*SessionSpecification, error) {
 		b.requiredDocuments,
 		b.blockBiometricConsent,
 		b.identityProfileRequirements,
+		b.subject,
 	}, nil
 }

--- a/docscan/session/create/session_spec_test.go
+++ b/docscan/session/create/session_spec_test.go
@@ -218,3 +218,52 @@ func TestExampleSessionSpecificationBuilder_Build_WithIdentityProfileRequirement
 		t.Errorf("wanted err to be of type '%v', got: '%v'", reflect.TypeOf(marshallerErr), reflect.TypeOf(err))
 	}
 }
+
+func ExampleSessionSpecificationBuilder_Build_withSubject() {
+	subject := []byte(`{
+		"subject_id": "Original subject ID"
+	}`)
+
+	sessionSpecification, err := NewSessionSpecificationBuilder().
+		WithSubject(subject).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sessionSpecification)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"subject":{"subject_id":"Original subject ID"}}
+}
+
+func TestExampleSessionSpecificationBuilder_Build_WithSubject_InvalidJSON(t *testing.T) {
+	subject := []byte(`{
+		"Original subject ID"
+	}`)
+
+	sessionSpecification, err := NewSessionSpecificationBuilder().
+		WithSubject(subject).
+		Build()
+
+	if err != nil {
+		t.Errorf("error: %s", err.Error())
+		return
+	}
+
+	_, err = json.Marshal(sessionSpecification)
+	if err == nil {
+		t.Error("expected an error")
+		return
+	}
+	var marshallerErr *json.MarshalerError
+	if !errors.As(err, &marshallerErr) {
+		t.Errorf("wanted err to be of type '%v', got: '%v'", reflect.TypeOf(marshallerErr), reflect.TypeOf(err))
+	}
+}


### PR DESCRIPTION
**Added**

-  Subject to IDV request

requested with:

```go
	subject := []byte(`{
		"subject_id": "subject ID"
	}`)

	sessionSpecification, err := NewSessionSpecificationBuilder().
		WithSubject(subject).
		Build()
```

example of Session Result containing the subject_id specified when the session was crated:

```json
{
  "session_id": "a1746488-efcc-4c59-bd28-f849dcb933a2",
  "client_session_token_ttl": 599,
  "user_tracking_id": "user-tracking-id",
  "biometric_consent": "2022-03-29T11:39:08.473Z",
  "state": "COMPLETED",
  "client_session_token": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "identity_profile": {
    "subject_id": "subject ID",
    "result": "DONE",
    "failure_reason": {
      "reason_code": "MANDATORY_DOCUMENT_COULD_NOT_BE_PROVIDED"
    },
    "identity_profile_report": {
      "trust_framework": "UK_TFIDA",
      "schemes_compliance": [{
        "scheme": {
          "type": "DBS",
          "objective": "STANDARD"
        },
        "requirements_met": true,
        "requirements_not_met_info": "some string here"
      }],
      "media": {
        "id": "c69ff2db-6caf-4e74-8386-037711bbc8d7",
        "type": "IMAGE",
        "created": "2022-03-29T11:39:24Z",
        "last_updated": "2022-03-29T11:39:24Z"
      }
    }
  }
}
```