### PR TITLE
Add Attempts Configuration to IDV with Relevant Tests

### DIFF
--- a/docscan/session/create/constants.go
+++ b/docscan/session/create/constants.go
@@ -1,0 +1,6 @@
+package create
+
+const (
+	reclassification string = "RECLASSIFICATION"
+	generic          string = "GENERIC"
+)

--- a/docscan/session/create/sdk_config.go
+++ b/docscan/session/create/sdk_config.go
@@ -4,15 +4,20 @@ import "github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
 
 // SDKConfig provides configuration properties for the the web/native clients
 type SDKConfig struct {
-	AllowedCaptureMethods string `json:"allowed_capture_methods,omitempty"`
-	PrimaryColour         string `json:"primary_colour,omitempty"`
-	SecondaryColour       string `json:"secondary_colour,omitempty"`
-	FontColour            string `json:"font_colour,omitempty"`
-	Locale                string `json:"locale,omitempty"`
-	PresetIssuingCountry  string `json:"preset_issuing_country,omitempty"`
-	SuccessUrl            string `json:"success_url,omitempty"`
-	ErrorUrl              string `json:"error_url,omitempty"`
-	PrivacyPolicyUrl      string `json:"privacy_policy_url,omitempty"`
+	AllowedCaptureMethods string                 `json:"allowed_capture_methods,omitempty"`
+	PrimaryColour         string                 `json:"primary_colour,omitempty"`
+	SecondaryColour       string                 `json:"secondary_colour,omitempty"`
+	FontColour            string                 `json:"font_colour,omitempty"`
+	Locale                string                 `json:"locale,omitempty"`
+	PresetIssuingCountry  string                 `json:"preset_issuing_country,omitempty"`
+	SuccessUrl            string                 `json:"success_url,omitempty"`
+	ErrorUrl              string                 `json:"error_url,omitempty"`
+	PrivacyPolicyUrl      string                 `json:"privacy_policy_url,omitempty"`
+	AttemptsConfiguration *AttemptsConfiguration `json:"attempts_configuration,omitempty"`
+}
+
+type AttemptsConfiguration struct {
+	IdDocumentTextDataExtraction map[string]int `json:"id_document_text_data_extraction,omitempty"`
 }
 
 // NewSdkConfigBuilder creates a new SdkConfigBuilder
@@ -22,15 +27,16 @@ func NewSdkConfigBuilder() *SdkConfigBuilder {
 
 // SdkConfigBuilder builds the SDKConfig struct
 type SdkConfigBuilder struct {
-	allowedCaptureMethods string
-	primaryColour         string
-	secondaryColour       string
-	fontColour            string
-	locale                string
-	presetIssuingCountry  string
-	successUrl            string
-	errorUrl              string
-	privacyPolicyUrl      string
+	allowedCaptureMethods               string
+	primaryColour                       string
+	secondaryColour                     string
+	fontColour                          string
+	locale                              string
+	presetIssuingCountry                string
+	successUrl                          string
+	errorUrl                            string
+	privacyPolicyUrl                    string
+	idDocumentTextDataExtractionRetries map[string]int
 }
 
 // WithAllowedCaptureMethods sets the allowed capture methods on the builder
@@ -97,9 +103,25 @@ func (b *SdkConfigBuilder) WithPrivacyPolicyUrl(url string) *SdkConfigBuilder {
 	return b
 }
 
+func (b *SdkConfigBuilder) WithIdDocumentTextExtractionCategoryRetries(category string, retries int) *SdkConfigBuilder {
+	if b.idDocumentTextDataExtractionRetries == nil {
+		b.idDocumentTextDataExtractionRetries = make(map[string]int)
+	}
+	b.idDocumentTextDataExtractionRetries[category] = retries
+	return b
+}
+
+func (b *SdkConfigBuilder) WithIdDocumentTextExtractionReclassificationRetries(retries int) *SdkConfigBuilder {
+	return b.WithIdDocumentTextExtractionCategoryRetries(reclassification, retries)
+}
+
+func (b *SdkConfigBuilder) WithIdDocumentTextExtractionGenericRetries(retries int) *SdkConfigBuilder {
+	return b.WithIdDocumentTextExtractionCategoryRetries(generic, retries)
+}
+
 // Build builds the SDKConfig struct using the supplied values
 func (b *SdkConfigBuilder) Build() (*SDKConfig, error) {
-	return &SDKConfig{
+	sdkConf := &SDKConfig{
 		b.allowedCaptureMethods,
 		b.primaryColour,
 		b.secondaryColour,
@@ -109,5 +131,13 @@ func (b *SdkConfigBuilder) Build() (*SDKConfig, error) {
 		b.successUrl,
 		b.errorUrl,
 		b.privacyPolicyUrl,
-	}, nil
+		nil,
+	}
+
+	if b.idDocumentTextDataExtractionRetries != nil {
+		sdkConf.AttemptsConfiguration = &AttemptsConfiguration{
+			IdDocumentTextDataExtraction: b.idDocumentTextDataExtractionRetries,
+		}
+	}
+	return sdkConf, nil
 }

--- a/docscan/session/create/sdk_config_test.go
+++ b/docscan/session/create/sdk_config_test.go
@@ -16,6 +16,7 @@ func ExampleSdkConfigBuilder_Build() {
 		WithSecondaryColour("#bb2222").
 		WithSuccessUrl("https://example.com/success").
 		WithPrivacyPolicyUrl("https://example.com/privacy").
+		WithIdDocumentTextExtractionCategoryRetries("test_category", 3).
 		Build()
 
 	if err != nil {
@@ -30,7 +31,51 @@ func ExampleSdkConfigBuilder_Build() {
 	}
 
 	fmt.Println(string(data))
-	// Output: {"allowed_capture_methods":"CAMERA","primary_colour":"#aa1111","secondary_colour":"#bb2222","font_colour":"#ff0000","locale":"fr_FR","preset_issuing_country":"USA","success_url":"https://example.com/success","error_url":"https://example.com/error","privacy_policy_url":"https://example.com/privacy"}
+	// Output: {"allowed_capture_methods":"CAMERA","primary_colour":"#aa1111","secondary_colour":"#bb2222","font_colour":"#ff0000","locale":"fr_FR","preset_issuing_country":"USA","success_url":"https://example.com/success","error_url":"https://example.com/error","privacy_policy_url":"https://example.com/privacy","attempts_configuration":{"id_document_text_data_extraction":{"test_category":3}}}
+}
+
+func ExampleSdkConfigBuilder_Build_repeatedCallWithIdDocumentTextExtractionCategoryRetries() {
+	sdkConfig, err := NewSdkConfigBuilder().
+		WithIdDocumentTextExtractionCategoryRetries("test_category", 3).
+		WithIdDocumentTextExtractionCategoryRetries("test_category", 2).
+		WithIdDocumentTextExtractionCategoryRetries("test_category", 1).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sdkConfig)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"attempts_configuration":{"id_document_text_data_extraction":{"test_category":1}}}
+}
+
+func ExampleSdkConfigBuilder_Build_multipleCategoriesWithIdDocumentTextExtractionCategoryRetries() {
+	sdkConfig, err := NewSdkConfigBuilder().
+		WithIdDocumentTextExtractionGenericRetries(3).
+		WithIdDocumentTextExtractionCategoryRetries("test_category", 2).
+		WithIdDocumentTextExtractionReclassificationRetries(1).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sdkConfig)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"attempts_configuration":{"id_document_text_data_extraction":{"GENERIC":3,"RECLASSIFICATION":1,"test_category":2}}}
 }
 
 func ExampleSdkConfigBuilder_WithAllowsCameraAndUpload() {


### PR DESCRIPTION
**Added**
WithIdDocumentTextExtractionCategoryRetries, WithIdDocumentTextExtractionReclassificationRetries, WithIdDocumentTextExtractiongenericRetries to the SdkConfig

```go
sdkConfig, err := NewSdkConfigBuilder().
	WithIdDocumentTextExtractionGenericRetries(3).
	WithIdDocumentTextExtractionCategoryRetries("CATEGORY", 2).
	WithIdDocumentTextExtractionReclassificationRetries(2).
	Build()
```