### PR TITLE
Identity profile preview

### DIFF
--- a/_examples/idv/models.sessionspec.go
+++ b/_examples/idv/models.sessionspec.go
@@ -191,6 +191,7 @@ func buildDBSSessionSpec() (sessionSpec *create.SessionSpecification, err error)
 		WithUserTrackingID("some-tracking-id").
 		WithSDKConfig(sdkConfig).
 		WithIdentityProfileRequirements(identityProfile).
+		WithCreateIdentityProfilePreview(true).
 		WithSubject(subject).
 		Build()
 

--- a/_examples/idv/templates/success.html
+++ b/_examples/idv/templates/success.html
@@ -76,6 +76,29 @@
     {{ end }}
     {{ end }}
     {{ end }}
+    {{ if .getSessionResult.IdentityProfilePreview }}
+    <div class="row pt-4">
+        <div class="col">
+            <h2>Identity Profile Preview</h2>
+        </div>
+    </div>
+    <div class="row pt-4">
+        <div class="col">
+            <table class="table table-striped table-light">
+                <tbody>
+                <tr>
+                    <td>ID</td>
+                    <td>
+                        <a href='/media?mediaId={{ .getSessionResult.IdentityProfilePreview.Media.ID }}'>
+                            {{ .getSessionResult.IdentityProfilePreview.Media.ID }}
+                        </a>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {{ end }}
     {{ if .getSessionResult.Checks }}
         <div class="row pt-4">
             <div class="col">

--- a/docscan/session/create/session_spec.go
+++ b/docscan/session/create/session_spec.go
@@ -41,6 +41,9 @@ type SessionSpecification struct {
 	// within the scope of a trust framework and scheme.
 	IdentityProfileRequirements *json.RawMessage `json:"identity_profile_requirements,omitempty"`
 
+	// CreateIdentityProfilePreview is a bool for enabling the creation of the IdentityProfilePreview
+	CreateIdentityProfilePreview bool `json:"create_identity_profile_preview,omitempty"`
+
 	// Subject provides information on the subject allowing to track the same user across multiple sessions.
 	// Should not contain any personal identifiable information.
 	Subject *json.RawMessage `json:"subject,omitempty"`
@@ -48,17 +51,18 @@ type SessionSpecification struct {
 
 // SessionSpecificationBuilder builds the SessionSpecification struct
 type SessionSpecificationBuilder struct {
-	clientSessionTokenTTL       int
-	resourcesTTL                int
-	userTrackingID              string
-	notifications               *NotificationConfig
-	requestedChecks             []check.RequestedCheck
-	requestedTasks              []task.RequestedTask
-	sdkConfig                   *SDKConfig
-	requiredDocuments           []filter.RequiredDocument
-	blockBiometricConsent       *bool
-	identityProfileRequirements *json.RawMessage
-	subject                     *json.RawMessage
+	clientSessionTokenTTL        int
+	resourcesTTL                 int
+	userTrackingID               string
+	notifications                *NotificationConfig
+	requestedChecks              []check.RequestedCheck
+	requestedTasks               []task.RequestedTask
+	sdkConfig                    *SDKConfig
+	requiredDocuments            []filter.RequiredDocument
+	blockBiometricConsent        *bool
+	identityProfileRequirements  *json.RawMessage
+	createIdentityProfilePreview bool
+	subject                      *json.RawMessage
 }
 
 // NewSessionSpecificationBuilder creates a new SessionSpecificationBuilder
@@ -120,6 +124,11 @@ func (b *SessionSpecificationBuilder) WithBlockBiometricConsent(blockBiometricCo
 	return b
 }
 
+func (b *SessionSpecificationBuilder) WithCreateIdentityProfilePreview(createIdentityProfilePreview bool) *SessionSpecificationBuilder {
+	b.createIdentityProfilePreview = createIdentityProfilePreview
+	return b
+}
+
 // WithIdentityProfileRequirements adds Identity Profile Requirements to the session. Must be valid JSON.
 func (b *SessionSpecificationBuilder) WithIdentityProfileRequirements(identityProfile json.RawMessage) *SessionSpecificationBuilder {
 	b.identityProfileRequirements = &identityProfile
@@ -144,6 +153,7 @@ func (b *SessionSpecificationBuilder) Build() (*SessionSpecification, error) {
 		b.requiredDocuments,
 		b.blockBiometricConsent,
 		b.identityProfileRequirements,
+		b.createIdentityProfilePreview,
 		b.subject,
 	}, nil
 }

--- a/docscan/session/create/session_spec_test.go
+++ b/docscan/session/create/session_spec_test.go
@@ -267,3 +267,24 @@ func TestExampleSessionSpecificationBuilder_Build_WithSubject_InvalidJSON(t *tes
 		t.Errorf("wanted err to be of type '%v', got: '%v'", reflect.TypeOf(marshallerErr), reflect.TypeOf(err))
 	}
 }
+
+func ExampleSessionSpecificationBuilder_Build_withCreateIdentityProfilePreview() {
+
+	sessionSpecification, err := NewSessionSpecificationBuilder().
+		WithCreateIdentityProfilePreview(true).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sessionSpecification)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"create_identity_profile_preview":true}
+}

--- a/docscan/session/retrieve/get_session_result.go
+++ b/docscan/session/retrieve/get_session_result.go
@@ -18,6 +18,7 @@ type GetSessionResult struct {
 	Resources                           *ResourceContainer       `json:"resources"`
 	BiometricConsentTimestamp           *time.Time               `json:"biometric_consent"`
 	IdentityProfileResponse             *IdentityProfileResponse `json:"identity_profile"`
+	IdentityProfilePreview              *IdentityProfilePreview  `json:"identity_profile_preview"`
 	authenticityChecks                  []*AuthenticityCheckResponse
 	faceMatchChecks                     []*FaceMatchCheckResponse
 	textDataChecks                      []*TextDataCheckResponse

--- a/docscan/session/retrieve/get_session_result_test.go
+++ b/docscan/session/retrieve/get_session_result_test.go
@@ -214,3 +214,19 @@ func TestGetSessionResult_UnmarshalJSON_IdentityProfile(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, mid, "c69ff2db-6caf-4e74-8386-037711bbc8d7")
 }
+
+func TestGetSessionResult_UnmarshalJSON_IdentityProfilePreview(t *testing.T) {
+	bytes, err := file.ReadFile("../../../test/fixtures/GetSessionResultWithIdentityProfile.json")
+	assert.NilError(t, err)
+
+	var result retrieve.GetSessionResult
+	err = result.UnmarshalJSON(bytes)
+	assert.NilError(t, err)
+
+	identityProfilePreview := result.IdentityProfilePreview
+	assert.Assert(t, identityProfilePreview != nil)
+
+	assert.Assert(t, identityProfilePreview.Media != nil)
+	assert.Equal(t, identityProfilePreview.Media.ID, "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+	assert.Equal(t, identityProfilePreview.Media.Type, "IMAGE")
+}

--- a/docscan/session/retrieve/identity_profile_preview.go
+++ b/docscan/session/retrieve/identity_profile_preview.go
@@ -1,0 +1,6 @@
+package retrieve
+
+// IdentityProfilePreview contains info about the media needed to retrieve the Identity Profile Preview.
+type IdentityProfilePreview struct {
+	Media *MediaResponse `json:"media"`
+}

--- a/test/fixtures/GetSessionResultWithIdentityProfile.json
+++ b/test/fixtures/GetSessionResultWithIdentityProfile.json
@@ -28,5 +28,13 @@
         "last_updated": "2022-03-29T11:39:24Z"
       }
     }
+  },
+  "identity_profile_preview": {
+    "media": {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "type": "IMAGE",
+      "created": "2021-06-11T11:39:24Z",
+      "last_updated": "2021-06-11T11:39:24Z"
+    }
   }
 }


### PR DESCRIPTION
**Added**

- IdentityProfilePreview to Session Specification Builder

**Requested with**
```go	
sessionSpec, err = create.NewSessionSpecificationBuilder().
		WithClientSessionTokenTTL(6000).
		WithResourcesTTL(900000).
		WithUserTrackingID("some-tracking-id").
		WithSDKConfig(sdkConfig).
		WithIdentityProfileRequirements(identityProfile).
		WithCreateIdentityProfilePreview(true).
		WithSubject(subject).
		Build()
```

- IdentityProfilePreview to IDV GetSessionResult:

```go
getSessionResult, err := client.GetSession(sessionId)
if err != nil {
        return err
}
identityProfilePreview := getSessionResult.IdentityProfilePreview
```

Example available when running the idv example project at https://localhost:8080/dbs