### PR TITLE
Renamed Retries to Attempts

### DIFF
--- a/_examples/idv/models.sessionspec.go
+++ b/_examples/idv/models.sessionspec.go
@@ -94,7 +94,7 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 		WithSuccessUrl("https://localhost:8080/success").
 		WithErrorUrl("https://localhost:8080/error").
 		WithPrivacyPolicyUrl("https://localhost:8080/privacy-policy").
-		WithIdDocumentTextExtractionGenericRetries(2).
+		WithIdDocumentTextExtractionGenericAttempts(2).
 		Build()
 	if err != nil {
 		return nil, err

--- a/docscan/session/create/sdk_config.go
+++ b/docscan/session/create/sdk_config.go
@@ -27,16 +27,16 @@ func NewSdkConfigBuilder() *SdkConfigBuilder {
 
 // SdkConfigBuilder builds the SDKConfig struct
 type SdkConfigBuilder struct {
-	allowedCaptureMethods               string
-	primaryColour                       string
-	secondaryColour                     string
-	fontColour                          string
-	locale                              string
-	presetIssuingCountry                string
-	successUrl                          string
-	errorUrl                            string
-	privacyPolicyUrl                    string
-	idDocumentTextDataExtractionRetries map[string]int
+	allowedCaptureMethods                string
+	primaryColour                        string
+	secondaryColour                      string
+	fontColour                           string
+	locale                               string
+	presetIssuingCountry                 string
+	successUrl                           string
+	errorUrl                             string
+	privacyPolicyUrl                     string
+	idDocumentTextDataExtractionAttempts map[string]int
 }
 
 // WithAllowedCaptureMethods sets the allowed capture methods on the builder
@@ -103,20 +103,20 @@ func (b *SdkConfigBuilder) WithPrivacyPolicyUrl(url string) *SdkConfigBuilder {
 	return b
 }
 
-func (b *SdkConfigBuilder) WithIdDocumentTextExtractionCategoryRetries(category string, retries int) *SdkConfigBuilder {
-	if b.idDocumentTextDataExtractionRetries == nil {
-		b.idDocumentTextDataExtractionRetries = make(map[string]int)
+func (b *SdkConfigBuilder) WithIdDocumentTextExtractionCategoryAttempts(category string, attempts int) *SdkConfigBuilder {
+	if b.idDocumentTextDataExtractionAttempts == nil {
+		b.idDocumentTextDataExtractionAttempts = make(map[string]int)
 	}
-	b.idDocumentTextDataExtractionRetries[category] = retries
+	b.idDocumentTextDataExtractionAttempts[category] = attempts
 	return b
 }
 
-func (b *SdkConfigBuilder) WithIdDocumentTextExtractionReclassificationRetries(retries int) *SdkConfigBuilder {
-	return b.WithIdDocumentTextExtractionCategoryRetries(reclassification, retries)
+func (b *SdkConfigBuilder) WithIdDocumentTextExtractionReclassificationAttempts(attempts int) *SdkConfigBuilder {
+	return b.WithIdDocumentTextExtractionCategoryAttempts(reclassification, attempts)
 }
 
-func (b *SdkConfigBuilder) WithIdDocumentTextExtractionGenericRetries(retries int) *SdkConfigBuilder {
-	return b.WithIdDocumentTextExtractionCategoryRetries(generic, retries)
+func (b *SdkConfigBuilder) WithIdDocumentTextExtractionGenericAttempts(attempts int) *SdkConfigBuilder {
+	return b.WithIdDocumentTextExtractionCategoryAttempts(generic, attempts)
 }
 
 // Build builds the SDKConfig struct using the supplied values
@@ -134,9 +134,9 @@ func (b *SdkConfigBuilder) Build() (*SDKConfig, error) {
 		nil,
 	}
 
-	if b.idDocumentTextDataExtractionRetries != nil {
+	if b.idDocumentTextDataExtractionAttempts != nil {
 		sdkConf.AttemptsConfiguration = &AttemptsConfiguration{
-			IdDocumentTextDataExtraction: b.idDocumentTextDataExtractionRetries,
+			IdDocumentTextDataExtraction: b.idDocumentTextDataExtractionAttempts,
 		}
 	}
 	return sdkConf, nil

--- a/docscan/session/create/sdk_config_test.go
+++ b/docscan/session/create/sdk_config_test.go
@@ -16,7 +16,7 @@ func ExampleSdkConfigBuilder_Build() {
 		WithSecondaryColour("#bb2222").
 		WithSuccessUrl("https://example.com/success").
 		WithPrivacyPolicyUrl("https://example.com/privacy").
-		WithIdDocumentTextExtractionCategoryRetries("test_category", 3).
+		WithIdDocumentTextExtractionCategoryAttempts("test_category", 3).
 		Build()
 
 	if err != nil {
@@ -34,11 +34,11 @@ func ExampleSdkConfigBuilder_Build() {
 	// Output: {"allowed_capture_methods":"CAMERA","primary_colour":"#aa1111","secondary_colour":"#bb2222","font_colour":"#ff0000","locale":"fr_FR","preset_issuing_country":"USA","success_url":"https://example.com/success","error_url":"https://example.com/error","privacy_policy_url":"https://example.com/privacy","attempts_configuration":{"ID_DOCUMENT_TEXT_DATA_EXTRACTION":{"test_category":3}}}
 }
 
-func ExampleSdkConfigBuilder_Build_repeatedCallWithIdDocumentTextExtractionCategoryRetries() {
+func ExampleSdkConfigBuilder_Build_repeatedCallWithIdDocumentTextExtractionCategoryAttempts() {
 	sdkConfig, err := NewSdkConfigBuilder().
-		WithIdDocumentTextExtractionCategoryRetries("test_category", 3).
-		WithIdDocumentTextExtractionCategoryRetries("test_category", 2).
-		WithIdDocumentTextExtractionCategoryRetries("test_category", 1).
+		WithIdDocumentTextExtractionCategoryAttempts("test_category", 3).
+		WithIdDocumentTextExtractionCategoryAttempts("test_category", 2).
+		WithIdDocumentTextExtractionCategoryAttempts("test_category", 1).
 		Build()
 
 	if err != nil {
@@ -56,11 +56,11 @@ func ExampleSdkConfigBuilder_Build_repeatedCallWithIdDocumentTextExtractionCateg
 	// Output: {"attempts_configuration":{"ID_DOCUMENT_TEXT_DATA_EXTRACTION":{"test_category":1}}}
 }
 
-func ExampleSdkConfigBuilder_Build_multipleCategoriesWithIdDocumentTextExtractionCategoryRetries() {
+func ExampleSdkConfigBuilder_Build_multipleCategoriesWithIdDocumentTextExtractionCategoryAttempts() {
 	sdkConfig, err := NewSdkConfigBuilder().
-		WithIdDocumentTextExtractionGenericRetries(3).
-		WithIdDocumentTextExtractionCategoryRetries("test_category", 2).
-		WithIdDocumentTextExtractionReclassificationRetries(1).
+		WithIdDocumentTextExtractionGenericAttempts(3).
+		WithIdDocumentTextExtractionCategoryAttempts("test_category", 2).
+		WithIdDocumentTextExtractionReclassificationAttempts(1).
 		Build()
 
 	if err != nil {


### PR DESCRIPTION
**Added**
WithIdDocumentTextExtractionCategoryAttempts, WithIdDocumentTextExtractionReclassificationAttempts, WithIdDocumentTextExtractiongenericAttempts to the SdkConfig

```go
sdkConfig, err := NewSdkConfigBuilder().
	WithIdDocumentTextExtractionGenericAttempts(3).
	WithIdDocumentTextExtractionCategoryAttempts("CATEGORY", 2).
	WithIdDocumentTextExtractionReclassificationAttempts(2).
	Build()
```