### PR TITLE
Sdk 2039 go support for non latin documents when fetching supported documents

### DIFF
--- a/_examples/idv/models.sessionspec.go
+++ b/_examples/idv/models.sessionspec.go
@@ -102,7 +102,9 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 
 	passportFilter, err := filter.NewRequestedOrthogonalRestrictionsFilterBuilder().
 		WithIncludedDocumentTypes(
-			[]string{"PASSPORT"}).
+			[]string{"PASSPORT", "DRIVING_LICENCE"}).
+		WithExpiredDocuments(true).
+		WithNonLatinDocuments(true).
 		Build()
 	if err != nil {
 		return nil, err

--- a/_examples/idv/models.sessionspec.go
+++ b/_examples/idv/models.sessionspec.go
@@ -102,7 +102,7 @@ func buildSessionSpec() (sessionSpec *create.SessionSpecification, err error) {
 
 	passportFilter, err := filter.NewRequestedOrthogonalRestrictionsFilterBuilder().
 		WithIncludedDocumentTypes(
-			[]string{"PASSPORT", "DRIVING_LICENCE"}).
+			[]string{"PASSPORT"}).
 		WithExpiredDocuments(true).
 		WithNonLatinDocuments(true).
 		Build()

--- a/docscan/client.go
+++ b/docscan/client.go
@@ -243,8 +243,13 @@ func (c *Client) DeleteMediaContent(sessionID, mediaID string) error {
 	return nil
 }
 
-// GetSupportedDocuments gets a slice of supported documents
-func (c *Client) GetSupportedDocuments(includeNonLatin bool) (*supported.DocumentsResponse, error) {
+// GetSupportedDocuments gets a slice of supported documents (defaults includeNonLatin to false)
+func (c *Client) GetSupportedDocuments() (*supported.DocumentsResponse, error) {
+	return c.GetSupportedDocumentsWithNonLatin(false)
+}
+
+// GetSupportedDocuments gets a slice of supported documents with bool param includeNonLatin
+func (c *Client) GetSupportedDocumentsWithNonLatin(includeNonLatin bool) (*supported.DocumentsResponse, error) {
 
 	request, err := (&requests.SignedRequest{
 		Key:        c.Key,

--- a/docscan/client.go
+++ b/docscan/client.go
@@ -243,17 +243,12 @@ func (c *Client) DeleteMediaContent(sessionID, mediaID string) error {
 }
 
 // GetSupportedDocuments gets a slice of supported documents
-func (c *Client) GetSupportedDocuments(isStrictlyLatin bool) (*supported.DocumentsResponse, error) {
-	includeNonLatin := "0"
-	if isStrictlyLatin {
-		includeNonLatin = "1"
-	}
+func (c *Client) GetSupportedDocuments() (*supported.DocumentsResponse, error) {
 	request, err := (&requests.SignedRequest{
 		Key:        c.Key,
 		HTTPMethod: http.MethodGet,
 		BaseURL:    c.apiURL,
 		Endpoint:   getSupportedDocumentsPath(),
-		Params:     map[string]string{"includeNonLatin": includeNonLatin},
 	}).Request()
 	if err != nil {
 		return nil, err

--- a/docscan/client.go
+++ b/docscan/client.go
@@ -243,12 +243,17 @@ func (c *Client) DeleteMediaContent(sessionID, mediaID string) error {
 }
 
 // GetSupportedDocuments gets a slice of supported documents
-func (c *Client) GetSupportedDocuments() (*supported.DocumentsResponse, error) {
+func (c *Client) GetSupportedDocuments(isStrictlyLatin bool) (*supported.DocumentsResponse, error) {
+	includeNonLatin := "0"
+	if isStrictlyLatin {
+		includeNonLatin = "1"
+	}
 	request, err := (&requests.SignedRequest{
 		Key:        c.Key,
 		HTTPMethod: http.MethodGet,
 		BaseURL:    c.apiURL,
 		Endpoint:   getSupportedDocumentsPath(),
+		Params:     map[string]string{"includeNonLatin": includeNonLatin},
 	}).Request()
 	if err != nil {
 		return nil, err

--- a/docscan/client.go
+++ b/docscan/client.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/getyoti/yoti-go-sdk/v3/cryptoutil"
@@ -243,17 +244,14 @@ func (c *Client) DeleteMediaContent(sessionID, mediaID string) error {
 }
 
 // GetSupportedDocuments gets a slice of supported documents
-func (c *Client) GetSupportedDocuments(isStrictlyLatin bool) (*supported.DocumentsResponse, error) {
-	includeNonLatin := "0"
-	if isStrictlyLatin {
-		includeNonLatin = "1"
-	}
+func (c *Client) GetSupportedDocuments(includeNonLatin bool) (*supported.DocumentsResponse, error) {
+
 	request, err := (&requests.SignedRequest{
 		Key:        c.Key,
 		HTTPMethod: http.MethodGet,
 		BaseURL:    c.apiURL,
 		Endpoint:   getSupportedDocumentsPath(),
-		Params:     map[string]string{"includeNonLatin": includeNonLatin},
+		Params:     map[string]string{"includeNonLatin": strconv.FormatBool(includeNonLatin)},
 	}).Request()
 	if err != nil {
 		return nil, err

--- a/docscan/client_test.go
+++ b/docscan/client_test.go
@@ -450,7 +450,7 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 		apiURL:     "https://apiurl.com",
 	}
 
-	result, err := client.GetSupportedDocuments()
+	result, err := client.GetSupportedDocuments(false)
 	assert.NilError(t, err)
 
 	assert.Equal(t, result.SupportedCountries[0].Code, countryCodeUSA)
@@ -460,7 +460,7 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 
 func TestClient_GetSupportedDocuments_ShouldReturnMissingKeyError(t *testing.T) {
 	client := Client{}
-	_, err := client.GetSupportedDocuments()
+	_, err := client.GetSupportedDocuments(false)
 	assert.ErrorContains(t, err, "missing private key")
 }
 
@@ -483,7 +483,7 @@ func TestClient_GetSupportedDocuments_ShouldReturnResponseError(t *testing.T) {
 		apiURL:     "https://apiurl.com",
 	}
 
-	_, err = client.GetSupportedDocuments()
+	_, err = client.GetSupportedDocuments(false)
 	assert.ErrorContains(t, err, "400: unknown HTTP error")
 }
 

--- a/docscan/client_test.go
+++ b/docscan/client_test.go
@@ -450,7 +450,7 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 		apiURL:     "https://apiurl.com",
 	}
 
-	result, err := client.GetSupportedDocuments(false)
+	result, err := client.GetSupportedDocuments()
 	assert.NilError(t, err)
 
 	assert.Equal(t, result.SupportedCountries[0].Code, countryCodeUSA)
@@ -460,7 +460,7 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 
 func TestClient_GetSupportedDocuments_ShouldReturnMissingKeyError(t *testing.T) {
 	client := Client{}
-	_, err := client.GetSupportedDocuments(false)
+	_, err := client.GetSupportedDocuments()
 	assert.ErrorContains(t, err, "missing private key")
 }
 
@@ -483,7 +483,7 @@ func TestClient_GetSupportedDocuments_ShouldReturnResponseError(t *testing.T) {
 		apiURL:     "https://apiurl.com",
 	}
 
-	_, err = client.GetSupportedDocuments(false)
+	_, err = client.GetSupportedDocuments()
 	assert.ErrorContains(t, err, "400: unknown HTTP error")
 }
 

--- a/docscan/client_test.go
+++ b/docscan/client_test.go
@@ -416,15 +416,13 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 
 	countryCodeUSA := "USA"
 	documentTypePassport := "PASSPORT"
-	isStrictlyLatin := true
 	documentsResponse := supported.DocumentsResponse{
 		SupportedCountries: []*supported.Country{
 			{
 				Code: countryCodeUSA,
 				SupportedDocuments: []*supported.Document{
 					{
-						Type:            documentTypePassport,
-						IsStrictlyLatin: isStrictlyLatin,
+						Type: documentTypePassport,
 					},
 				},
 			},
@@ -450,17 +448,16 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 		apiURL:     "https://apiurl.com",
 	}
 
-	result, err := client.GetSupportedDocuments(false)
+	result, err := client.GetSupportedDocuments()
 	assert.NilError(t, err)
 
 	assert.Equal(t, result.SupportedCountries[0].Code, countryCodeUSA)
 	assert.Equal(t, result.SupportedCountries[0].SupportedDocuments[0].Type, documentTypePassport)
-	assert.Equal(t, result.SupportedCountries[0].SupportedDocuments[0].IsStrictlyLatin, isStrictlyLatin)
 }
 
 func TestClient_GetSupportedDocuments_ShouldReturnMissingKeyError(t *testing.T) {
 	client := Client{}
-	_, err := client.GetSupportedDocuments(false)
+	_, err := client.GetSupportedDocuments()
 	assert.ErrorContains(t, err, "missing private key")
 }
 
@@ -483,7 +480,7 @@ func TestClient_GetSupportedDocuments_ShouldReturnResponseError(t *testing.T) {
 		apiURL:     "https://apiurl.com",
 	}
 
-	_, err = client.GetSupportedDocuments(false)
+	_, err = client.GetSupportedDocuments()
 	assert.ErrorContains(t, err, "400: unknown HTTP error")
 }
 

--- a/docscan/client_test.go
+++ b/docscan/client_test.go
@@ -416,13 +416,15 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 
 	countryCodeUSA := "USA"
 	documentTypePassport := "PASSPORT"
+	isStrictlyLatin := true
 	documentsResponse := supported.DocumentsResponse{
 		SupportedCountries: []*supported.Country{
 			{
 				Code: countryCodeUSA,
 				SupportedDocuments: []*supported.Document{
 					{
-						Type: documentTypePassport,
+						Type:            documentTypePassport,
+						IsStrictlyLatin: isStrictlyLatin,
 					},
 				},
 			},
@@ -453,6 +455,7 @@ func TestClient_GetSupportedDocuments(t *testing.T) {
 
 	assert.Equal(t, result.SupportedCountries[0].Code, countryCodeUSA)
 	assert.Equal(t, result.SupportedCountries[0].SupportedDocuments[0].Type, documentTypePassport)
+	assert.Equal(t, result.SupportedCountries[0].SupportedDocuments[0].IsStrictlyLatin, isStrictlyLatin)
 }
 
 func TestClient_GetSupportedDocuments_ShouldReturnMissingKeyError(t *testing.T) {

--- a/docscan/session/create/filter/orthogonal_restrictions_filter.go
+++ b/docscan/session/create/filter/orthogonal_restrictions_filter.go
@@ -4,8 +4,10 @@ import "encoding/json"
 
 // RequestedOrthogonalRestrictionsFilter filters for a required document, allowing specification of restrictive parameters
 type RequestedOrthogonalRestrictionsFilter struct {
-	countryRestriction *CountryRestriction
-	typeRestriction    *TypeRestriction
+	countryRestriction     *CountryRestriction
+	typeRestriction        *TypeRestriction
+	allowExpiredDocuments  *bool
+	allowNonLatinDocuments *bool
 }
 
 // Type returns the type of the RequestedOrthogonalRestrictionsFilter
@@ -16,27 +18,35 @@ func (r RequestedOrthogonalRestrictionsFilter) Type() string {
 // MarshalJSON returns the JSON encoding
 func (r RequestedOrthogonalRestrictionsFilter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type               string              `json:"type"`
-		CountryRestriction *CountryRestriction `json:"country_restriction,omitempty"`
-		TypeRestriction    *TypeRestriction    `json:"type_restriction,omitempty"`
+		Type                   string              `json:"type"`
+		CountryRestriction     *CountryRestriction `json:"country_restriction,omitempty"`
+		TypeRestriction        *TypeRestriction    `json:"type_restriction,omitempty"`
+		AllowExpiredDocuments  *bool               `json:"allow_expired_documents,omitempty"`
+		AllowNonLatinDocuments *bool               `json:"allow_non_latin_documents,omitempty"`
 	}{
-		CountryRestriction: r.countryRestriction,
-		TypeRestriction:    r.typeRestriction,
-		Type:               r.Type(),
+		CountryRestriction:     r.countryRestriction,
+		TypeRestriction:        r.typeRestriction,
+		Type:                   r.Type(),
+		AllowExpiredDocuments:  r.allowExpiredDocuments,
+		AllowNonLatinDocuments: r.allowNonLatinDocuments,
 	})
 }
 
 // RequestedOrthogonalRestrictionsFilterBuilder builds a RequestedOrthogonalRestrictionsFilter
 type RequestedOrthogonalRestrictionsFilterBuilder struct {
-	countryRestriction *CountryRestriction
-	typeRestriction    *TypeRestriction
+	countryRestriction     *CountryRestriction
+	typeRestriction        *TypeRestriction
+	allowExpiredDocuments  *bool
+	allowNonLatinDocuments *bool
 }
 
 // NewRequestedOrthogonalRestrictionsFilterBuilder creates a new RequestedOrthogonalRestrictionsFilterBuilder
 func NewRequestedOrthogonalRestrictionsFilterBuilder() *RequestedOrthogonalRestrictionsFilterBuilder {
 	return &RequestedOrthogonalRestrictionsFilterBuilder{
-		countryRestriction: nil,
-		typeRestriction:    nil,
+		countryRestriction:     nil,
+		typeRestriction:        nil,
+		allowExpiredDocuments:  nil,
+		allowNonLatinDocuments: nil,
 	}
 }
 
@@ -76,10 +86,22 @@ func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithExcludedDocumentTypes
 	return b
 }
 
+func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithNonLatinDocuments(allowNonLatinDocuments bool) *RequestedOrthogonalRestrictionsFilterBuilder {
+	b.allowNonLatinDocuments = &allowNonLatinDocuments
+	return b
+}
+
+func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithExpiredDocuments(allowExpiredDocuments bool) *RequestedOrthogonalRestrictionsFilterBuilder {
+	b.allowExpiredDocuments = &allowExpiredDocuments
+	return b
+}
+
 // Build creates a new RequestedOrthogonalRestrictionsFilter
 func (b *RequestedOrthogonalRestrictionsFilterBuilder) Build() (*RequestedOrthogonalRestrictionsFilter, error) {
 	return &RequestedOrthogonalRestrictionsFilter{
 		b.countryRestriction,
 		b.typeRestriction,
+		b.allowExpiredDocuments,
+		b.allowNonLatinDocuments,
 	}, nil
 }

--- a/docscan/session/create/filter/orthogonal_restrictions_filter_test.go
+++ b/docscan/session/create/filter/orthogonal_restrictions_filter_test.go
@@ -97,7 +97,7 @@ func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withExpiredDocuments() 
 	}
 
 	fmt.Println(string(data))
-	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","type_restriction": {"inclusion": "WHITELIST","document_types": ["PASSPORT"]},"allow_expired_documents": true}
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allow_expired_documents":true}
 
 }
 
@@ -117,7 +117,7 @@ func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withDenyExpiredDocument
 	}
 
 	fmt.Println(string(data))
-	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","type_restriction": {"inclusion": "WHITELIST","document_types": ["PASSPORT"]},"allow_expired_documents": false}
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allow_expired_documents":false}
 }
 
 func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withNonLatinDocuments() {
@@ -136,7 +136,8 @@ func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withNonLatinDocuments()
 	}
 
 	fmt.Println(string(data))
-	// Output: {"type": "ORTHOGONAL_RESTRICTIONS","type_restriction": {"inclusion": "WHITELIST","document_types": ["PASSPORT","DRIVING_LICENCE"]},"allow_non_latin_documents": true}
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allow_non_latin_documents":true}
+
 }
 
 func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withDenyNonLatinDocuments() {
@@ -155,5 +156,5 @@ func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withDenyNonLatinDocumen
 	}
 
 	fmt.Println(string(data))
-	// Output: {"type": "ORTHOGONAL_RESTRICTIONS","type_restriction": {"inclusion": "WHITELIST","document_types": ["PASSPORT","DRIVING_LICENCE"]},"allow_non_latin_documents": false}
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allow_non_latin_documents":false}
 }

--- a/docscan/session/create/filter/orthogonal_restrictions_filter_test.go
+++ b/docscan/session/create/filter/orthogonal_restrictions_filter_test.go
@@ -80,3 +80,80 @@ func ExampleRequestedOrthogonalRestrictionsFilterBuilder_WithExcludedCountries()
 	fmt.Println(string(data))
 	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","country_restriction":{"inclusion":"BLACKLIST","country_codes":["CAN","FJI"]}}
 }
+
+func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withExpiredDocuments() {
+	restriction, err := NewRequestedOrthogonalRestrictionsFilterBuilder().
+		WithExpiredDocuments(true).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","type_restriction": {"inclusion": "WHITELIST","document_types": ["PASSPORT"]},"allow_expired_documents": true}
+
+}
+
+func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withDenyExpiredDocuments() {
+	restriction, err := NewRequestedOrthogonalRestrictionsFilterBuilder().
+		WithExpiredDocuments(false).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","type_restriction": {"inclusion": "WHITELIST","document_types": ["PASSPORT"]},"allow_expired_documents": false}
+}
+
+func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withNonLatinDocuments() {
+	restriction, err := NewRequestedOrthogonalRestrictionsFilterBuilder().
+		WithNonLatinDocuments(true).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type": "ORTHOGONAL_RESTRICTIONS","type_restriction": {"inclusion": "WHITELIST","document_types": ["PASSPORT","DRIVING_LICENCE"]},"allow_non_latin_documents": true}
+}
+
+func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withDenyNonLatinDocuments() {
+	restriction, err := NewRequestedOrthogonalRestrictionsFilterBuilder().
+		WithNonLatinDocuments(false).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type": "ORTHOGONAL_RESTRICTIONS","type_restriction": {"inclusion": "WHITELIST","document_types": ["PASSPORT","DRIVING_LICENCE"]},"allow_non_latin_documents": false}
+}

--- a/docscan/supported/supported_documents.go
+++ b/docscan/supported/supported_documents.go
@@ -13,5 +13,6 @@ type Country struct {
 
 // Document is the document type that is supported
 type Document struct {
-	Type string `json:"type"`
+	Type            string `json:"type"`
+	IsStrictlyLatin bool   `json:"is_strictly_latin"`
 }


### PR DESCRIPTION
## IDV

**Added**

- Support for non latin documents when fetching supported documents

**Requested with**
```go	
result, err := client.GetSupportedDocuments(true)
```