### PR TITLE
Added support for ImportToken

### DIFF
--- a/_examples/idv/models.sessionspec.go
+++ b/_examples/idv/models.sessionspec.go
@@ -178,8 +178,7 @@ func buildDBSSessionSpec() (sessionSpec *create.SessionSpecification, err error)
 	identityProfile := []byte(`{
 		"trust_framework": "UK_TFIDA",
 		"scheme": {
-    		"type": "DBS",
-    		"objective": "BASIC"
+    		"type": "RTW"
 		}
 	}`)
 

--- a/_examples/idv/models.sessionspec.go
+++ b/_examples/idv/models.sessionspec.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create"
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/check"
 	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/create/filter"
@@ -181,6 +183,14 @@ func buildDBSSessionSpec() (sessionSpec *create.SessionSpecification, err error)
 		}
 	}`)
 
+	ttl := time.Hour * 24 * 30
+	importToken, err := create.NewImportTokenBuilder().
+		WithTTL(int(ttl.Seconds())).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
 	subject := []byte(`{
 		"subject_id": "unique-user-id-for-examples"
 	}`)
@@ -193,6 +203,7 @@ func buildDBSSessionSpec() (sessionSpec *create.SessionSpecification, err error)
 		WithIdentityProfileRequirements(identityProfile).
 		WithCreateIdentityProfilePreview(true).
 		WithSubject(subject).
+		WithImportToken(importToken).
 		Build()
 
 	if err != nil {

--- a/_examples/idv/templates/success.html
+++ b/_examples/idv/templates/success.html
@@ -99,6 +99,47 @@
         </div>
     </div>
     {{ end }}
+    {{ if .getSessionResult.ImportTokenResponse }}
+    <div class="row pt-4">
+        <div class="col">
+            <h2>Import token</h2>
+        </div>
+    </div>
+        {{ if .getSessionResult.ImportTokenResponse.Media }}
+        <div class="row pt-4">
+            <div class="col">
+                <table class="table table-striped table-light">
+                    <tbody>
+                    <tr>
+                        <td>ID</td>
+                        <td>
+                            <a href='/media?mediaId={{ .getSessionResult.ImportTokenResponse.Media.ID }}'>
+                                {{ .getSessionResult.ImportTokenResponse.Media.ID }}
+                            </a>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {{ end }}
+        {{ if .getSessionResult.ImportTokenResponse.FailureReasonResponse.ReasonCode }}
+            <div class="row pt-4">
+                <div class="col">
+                    <table class="table table-striped table-light">
+                        <tbody>
+                        <tr>
+                            <td>ID</td>
+                            <td>
+                                    {{ .getSessionResult.ImportTokenResponse.FailureReasonResponse.ReasonCode }}
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        {{ end }}
+    {{ end }}
     {{ if .getSessionResult.Checks }}
         <div class="row pt-4">
             <div class="col">

--- a/_examples/idv/templates/success.html
+++ b/_examples/idv/templates/success.html
@@ -123,15 +123,15 @@
             </div>
         </div>
         {{ end }}
-        {{ if .getSessionResult.ImportTokenResponse.FailureReasonResponse.ReasonCode }}
+        {{ if .getSessionResult.ImportTokenResponse.FailureReason }}
             <div class="row pt-4">
                 <div class="col">
                     <table class="table table-striped table-light">
                         <tbody>
                         <tr>
-                            <td>ID</td>
+                            <td><span class="badge badge-secondary">Error</span></td>
                             <td>
-                                    {{ .getSessionResult.ImportTokenResponse.FailureReasonResponse.ReasonCode }}
+                                    {{ .getSessionResult.ImportTokenResponse.FailureReason }}
                             </td>
                         </tr>
                         </tbody>

--- a/docscan/session/create/import_token.go
+++ b/docscan/session/create/import_token.go
@@ -7,7 +7,7 @@ type ImportToken struct {
 }
 
 // defaultImportTokenTTL is 12 Months
-const defaultImportTokenTTL = time.Hour * 24 * 30 * 12
+const defaultImportTokenTTL = time.Hour * 24 * 365
 
 // NewImportTokenBuilder creates a new ImportTokenBuilder
 func NewImportTokenBuilder() *ImportTokenBuilder {

--- a/docscan/session/create/import_token.go
+++ b/docscan/session/create/import_token.go
@@ -1,0 +1,35 @@
+package create
+
+import "time"
+
+type ImportToken struct {
+	Ttl int `json:"ttl"`
+}
+
+// defaultImportTokenTTL is 12 Months
+const defaultImportTokenTTL = time.Hour * 24 * 30 * 12
+
+// NewImportTokenBuilder creates a new ImportTokenBuilder
+func NewImportTokenBuilder() *ImportTokenBuilder {
+	return &ImportTokenBuilder{
+		Ttl: int(defaultImportTokenTTL.Seconds()),
+	}
+}
+
+// ImportTokenBuilder builds the ImportToken struct
+type ImportTokenBuilder struct {
+	Ttl int
+}
+
+// WithTTL sets the TTL of the import-token (in seconds)
+func (b *ImportTokenBuilder) WithTTL(ttl int) *ImportTokenBuilder {
+	b.Ttl = ttl
+	return b
+}
+
+// Build builds the ImportToken struct using the supplied values
+func (b *ImportTokenBuilder) Build() (*ImportToken, error) {
+	return &ImportToken{
+		Ttl: b.Ttl,
+	}, nil
+}

--- a/docscan/session/create/import_token_test.go
+++ b/docscan/session/create/import_token_test.go
@@ -1,0 +1,28 @@
+package create
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+func ExampleImportTokenBuilder_Build() {
+	ttl := time.Hour * 24 * 30
+	it, err := NewImportTokenBuilder().
+		WithTTL(int(ttl.Seconds())).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(it)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"ttl":2592000}
+}

--- a/docscan/session/create/session_spec.go
+++ b/docscan/session/create/session_spec.go
@@ -144,7 +144,7 @@ func (b *SessionSpecificationBuilder) WithSubject(subject json.RawMessage) *Sess
 	return b
 }
 
-// WithImportToken sets whether of not an ImportToken is to be generated.
+// WithImportToken sets whether an ImportToken is to be generated.
 func (b *SessionSpecificationBuilder) WithImportToken(importToken *ImportToken) *SessionSpecificationBuilder {
 	b.importToken = importToken
 	return b

--- a/docscan/session/create/session_spec.go
+++ b/docscan/session/create/session_spec.go
@@ -47,6 +47,9 @@ type SessionSpecification struct {
 	// Subject provides information on the subject allowing to track the same user across multiple sessions.
 	// Should not contain any personal identifiable information.
 	Subject *json.RawMessage `json:"subject,omitempty"`
+
+	// ImportToken requests the creation of an import_token.
+	ImportToken *ImportToken `json:"import_token,omitempty"`
 }
 
 // SessionSpecificationBuilder builds the SessionSpecification struct
@@ -63,6 +66,7 @@ type SessionSpecificationBuilder struct {
 	identityProfileRequirements  *json.RawMessage
 	createIdentityProfilePreview bool
 	subject                      *json.RawMessage
+	importToken                  *ImportToken
 }
 
 // NewSessionSpecificationBuilder creates a new SessionSpecificationBuilder
@@ -140,6 +144,12 @@ func (b *SessionSpecificationBuilder) WithSubject(subject json.RawMessage) *Sess
 	return b
 }
 
+// WithImportToken sets whether of not an ImportToken is to be generated.
+func (b *SessionSpecificationBuilder) WithImportToken(importToken *ImportToken) *SessionSpecificationBuilder {
+	b.importToken = importToken
+	return b
+}
+
 // Build builds the SessionSpecification struct
 func (b *SessionSpecificationBuilder) Build() (*SessionSpecification, error) {
 	return &SessionSpecification{
@@ -155,5 +165,6 @@ func (b *SessionSpecificationBuilder) Build() (*SessionSpecification, error) {
 		b.identityProfileRequirements,
 		b.createIdentityProfilePreview,
 		b.subject,
+		b.importToken,
 	}, nil
 }

--- a/docscan/session/retrieve/get_session_result.go
+++ b/docscan/session/retrieve/get_session_result.go
@@ -19,6 +19,7 @@ type GetSessionResult struct {
 	BiometricConsentTimestamp           *time.Time               `json:"biometric_consent"`
 	IdentityProfileResponse             *IdentityProfileResponse `json:"identity_profile"`
 	IdentityProfilePreview              *IdentityProfilePreview  `json:"identity_profile_preview"`
+	ImportTokenResponse                 *ImportTokenResponse     `json:"import_token"`
 	authenticityChecks                  []*AuthenticityCheckResponse
 	faceMatchChecks                     []*FaceMatchCheckResponse
 	textDataChecks                      []*TextDataCheckResponse

--- a/docscan/session/retrieve/import_token.go
+++ b/docscan/session/retrieve/import_token.go
@@ -2,6 +2,6 @@ package retrieve
 
 // ImportTokenResponse contains info about the media needed to retrieve the ImportToken.
 type ImportTokenResponse struct {
-	FailureReasonResponse FailureReasonResponse `json:"failure_reason"`
-	Media                 *MediaResponse        `json:"media"`
+	FailureReason string         `json:"failure_reason"`
+	Media         *MediaResponse `json:"media"`
 }

--- a/docscan/session/retrieve/import_token.go
+++ b/docscan/session/retrieve/import_token.go
@@ -1,0 +1,7 @@
+package retrieve
+
+// ImportTokenResponse contains info about the media needed to retrieve the ImportToken.
+type ImportTokenResponse struct {
+	FailureReasonResponse FailureReasonResponse `json:"failure_reason"`
+	Media                 *MediaResponse        `json:"media"`
+}


### PR DESCRIPTION
**Added**

- ImportToken to Session Specification Builder and a ImportTokenBuilder

**Requested with**
```go	
ttl := time.Hour * 24 * 30
importToken, err := create.NewImportTokenBuilder().
	WithTTL(int(ttl.Seconds())).
	Build()
if err != nil {
	return nil, err
}

sessionSpec, err = create.NewSessionSpecificationBuilder().
		WithClientSessionTokenTTL(6000).
		WithResourcesTTL(900000).
		WithUserTrackingID("some-tracking-id").
		WithSDKConfig(sdkConfig).
		WithIdentityProfileRequirements(identityProfile).
		WithCreateIdentityProfilePreview(true).
		WithSubject(subject).
                WithImportToken(importToken).
		Build()
```

- ImportTokenResponse to IDV GetSessionResult:

```go
getSessionResult, err := client.GetSession(sessionId)
if err != nil {
        return err
}
importTokenResponse := getSessionResult.ImportTokenResponse
```

Example available when running the idv example project at https://localhost:8080/dbs