### PR TITLE
SDK-2498 addet support for ephemeral media

### DIFF
--- a/docscan/session/create/session_spec.go
+++ b/docscan/session/create/session_spec.go
@@ -54,6 +54,9 @@ type SessionSpecification struct {
 
 	// ImportToken requests the creation of an import_token.
 	ImportToken *ImportToken `json:"import_token,omitempty"`
+
+	//Ephemeral Media to set ephemeral or not
+	EphemeralMedia *bool `json:"ephemeral_media,omitempty"`
 }
 
 // SessionSpecificationBuilder builds the SessionSpecification struct
@@ -72,6 +75,7 @@ type SessionSpecificationBuilder struct {
 	createIdentityProfilePreview        bool
 	subject                             *json.RawMessage
 	importToken                         *ImportToken
+	ephemeralMedia                      *bool
 }
 
 // NewSessionSpecificationBuilder creates a new SessionSpecificationBuilder
@@ -163,6 +167,12 @@ func (b *SessionSpecificationBuilder) WithImportToken(importToken *ImportToken) 
 	return b
 }
 
+// WithEphemeralMedia sets whether to block or not to block the collection of ephemeral media
+func (b *SessionSpecificationBuilder) WithEphemeralMedia(ephemeralMedia bool) *SessionSpecificationBuilder {
+	b.ephemeralMedia = &ephemeralMedia
+	return b
+}
+
 // Build builds the SessionSpecification struct
 func (b *SessionSpecificationBuilder) Build() (*SessionSpecification, error) {
 	return &SessionSpecification{
@@ -180,5 +190,6 @@ func (b *SessionSpecificationBuilder) Build() (*SessionSpecification, error) {
 		b.createIdentityProfilePreview,
 		b.subject,
 		b.importToken,
+		b.ephemeralMedia,
 	}, nil
 }

--- a/docscan/session/create/session_spec_test.go
+++ b/docscan/session/create/session_spec_test.go
@@ -363,3 +363,23 @@ func ExampleSessionSpecificationBuilder_Build_withCreateIdentityProfilePreview()
 	fmt.Println(string(data))
 	// Output: {"create_identity_profile_preview":true}
 }
+
+func ExampleSessionSpecificationBuilder_Build_withEphemeralMedia() {
+	sessionSpecification, err := NewSessionSpecificationBuilder().
+		WithEphemeralMedia(true).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sessionSpecification)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"ephemeral_media":true}
+}


### PR DESCRIPTION
```go

sessionSpec, err = create.NewSessionSpecificationBuilder().
		WithClientSessionTokenTTL(600).
		WithResourcesTTL(87000).
		WithUserTrackingID("some-tracking-id").
		WithRequestedCheck(faceMatchCheck).
		WithRequestedCheck(documentAuthenticityCheck).
		WithRequestedCheck(livenessCheck).
		WithRequestedCheck(idDocsComparisonCheck).
		WithRequestedCheck(thirdPartyCheck).
		WithRequestedCheck(watchlistScreeningCheck).
		WithRequestedCheck(yotiAccountWatchlistAdvancedCACheck).
		WithRequestedTask(textExtractionTask).
		WithRequestedTask(supplementaryDocTextExtractionTask).
		WithSDKConfig(sdkConfig).
		//Below line will be enabled when orthogonal Restriction is Needed
		//WithRequiredDocument(passportDoc).
		WithRequiredDocument(idDoc).
		WithRequiredDocument(supplementaryDoc).
		WithEphemeralMedia(true).
		Build()

```