### PR TITLE
SDK-2356: Added ErrorReason to SharedReceiptResponse

### DIFF
--- a/_examples/digitalidentity/error_receipt.html
+++ b/_examples/digitalidentity/error_receipt.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Yoti Example Project - Error</title>
+</head>
+<body style="text-align: center; margin: 200px 0">
+<h1>An Error Occurred</h1>
+<b>Error: {{.error}} </b>
+<p><b>Error Details: </b>
+    {{ range $detail := .errorReason.RequirementsNotMetDetails }}
+    {{ template "requirements_not_met_detail.html" $detail }}
+    {{ end }}</p>
+</body>
+</html>

--- a/_examples/digitalidentity/receipt.go
+++ b/_examples/digitalidentity/receipt.go
@@ -27,6 +27,29 @@ func receipt(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if receiptValue.Error != "" {
+		t, err := template.ParseFiles("error_receipt.html", "requirements_not_met_detail.html")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		templateVars := map[string]interface{}{
+			"error":       receiptValue.Error,
+			"errorReason": receiptValue.ErrorReason,
+		}
+		err = t.Execute(w, templateVars)
+		if err != nil {
+			errorPage(w, r.WithContext(context.WithValue(
+				r.Context(),
+				contextKey("yotiError"),
+				fmt.Sprintf("Error applying the parsed error_receipt template. Error: `%s`", err),
+			)))
+			return
+		}
+		return
+	}
+
 	userProfile := receiptValue.UserContent.UserProfile
 
 	selfie := userProfile.Selfie()

--- a/_examples/digitalidentity/requirements_not_met_detail.html
+++ b/_examples/digitalidentity/requirements_not_met_detail.html
@@ -1,0 +1,36 @@
+<table class="table table-bordered" >
+    <tbody>
+    {{ if .FailureType }}
+    <tr>
+        <td>FailureType</td>
+        <td>
+            {{ .FailureType }}
+        </td>
+    </tr>
+    {{ end }}
+    {{ if .DocumentType }}
+    <tr>
+        <td>DocumentType</td>
+        <td>{{ .DocumentType }}</td>
+    </tr>
+    {{ end }}
+    {{ if .DocumentCountryIsoCode }}
+    <tr>
+        <td>DocumentCountryIsoCode</td>
+        <td>{{ .DocumentCountryIsoCode }}</td>
+    </tr>
+    {{ end }}
+    {{ if .AuditId }}
+    <tr>
+        <td>AuditId</td>
+        <td>{{ .AuditId }}</td>
+    </tr>
+    {{ end }}
+    {{ if .Details }}
+    <tr>
+        <td>Details</td>
+        <td>{{ .Details }}</td>
+    </tr>
+    {{ end }}
+    </tbody>
+</table>

--- a/digitalidentity/receipt.go
+++ b/digitalidentity/receipt.go
@@ -5,15 +5,26 @@ type Content struct {
 	ExtraData []byte `json:"extraData"`
 }
 
+type ErrorReason struct {
+	RequirementsNotMetDetails []struct {
+		Details                string `json:"details"`
+		AuditId                string `json:"audit_id"`
+		FailureType            string `json:"failure_type"`
+		DocumentType           string `json:"document_type"`
+		DocumentCountryIsoCode string `json:"document_country_iso_code"`
+	} `json:"requirements_not_met_details"`
+}
+
 type ReceiptResponse struct {
-	ID                 string   `json:"id"`
-	SessionID          string   `json:"sessionId"`
-	Timestamp          string   `json:"timestamp"`
-	RememberMeID       string   `json:"rememberMeId,omitempty"`
-	ParentRememberMeID string   `json:"parentRememberMeId,omitempty"`
-	Content            *Content `json:"content,omitempty"`
-	OtherPartyContent  *Content `json:"otherPartyContent,omitempty"`
-	WrappedItemKeyId   string   `json:"wrappedItemKeyId"`
-	WrappedKey         []byte   `json:"wrappedKey"`
-	Error              string   `json:"error"`
+	ID                 string      `json:"id"`
+	SessionID          string      `json:"sessionId"`
+	Timestamp          string      `json:"timestamp"`
+	RememberMeID       string      `json:"rememberMeId,omitempty"`
+	ParentRememberMeID string      `json:"parentRememberMeId,omitempty"`
+	Content            *Content    `json:"content,omitempty"`
+	OtherPartyContent  *Content    `json:"otherPartyContent,omitempty"`
+	WrappedItemKeyId   string      `json:"wrappedItemKeyId"`
+	WrappedKey         []byte      `json:"wrappedKey"`
+	Error              string      `json:"error"`
+	ErrorReason        ErrorReason `json:"errorReason"`
 }

--- a/digitalidentity/receipt.go
+++ b/digitalidentity/receipt.go
@@ -5,14 +5,16 @@ type Content struct {
 	ExtraData []byte `json:"extraData"`
 }
 
+type RequirementsNotMetDetail struct {
+	Details                string `json:"details"`
+	AuditId                string `json:"audit_id"`
+	FailureType            string `json:"failure_type"`
+	DocumentType           string `json:"document_type"`
+	DocumentCountryIsoCode string `json:"document_country_iso_code"`
+}
+
 type ErrorReason struct {
-	RequirementsNotMetDetails []struct {
-		Details                string `json:"details"`
-		AuditId                string `json:"audit_id"`
-		FailureType            string `json:"failure_type"`
-		DocumentType           string `json:"document_type"`
-		DocumentCountryIsoCode string `json:"document_country_iso_code"`
-	} `json:"requirements_not_met_details"`
+	RequirementsNotMetDetails []RequirementsNotMetDetail `json:"requirements_not_met_details"`
 }
 
 type ReceiptResponse struct {

--- a/digitalidentity/service.go
+++ b/digitalidentity/service.go
@@ -226,6 +226,18 @@ func GetShareReceipt(httpClient requests.HttpClient, receiptId string, clientSdk
 		return receipt, fmt.Errorf("failed to get receipt: %v", err)
 	}
 
+	if receiptResponse.Error != "" {
+		return SharedReceiptResponse{
+			ID:                 receiptResponse.ID,
+			SessionID:          receiptResponse.SessionID,
+			RememberMeID:       receiptResponse.RememberMeID,
+			ParentRememberMeID: receiptResponse.ParentRememberMeID,
+			Timestamp:          receiptResponse.Timestamp,
+			Error:              receiptResponse.Error,
+			ErrorReason:        receiptResponse.ErrorReason,
+		}, nil
+	}
+
 	itemKeyId := receiptResponse.WrappedItemKeyId
 
 	encryptedItemKeyResponse, err := getReceiptItemKey(httpClient, itemKeyId, clientSdkId, apiUrl, key)

--- a/digitalidentity/service.go
+++ b/digitalidentity/service.go
@@ -228,13 +228,11 @@ func GetShareReceipt(httpClient requests.HttpClient, receiptId string, clientSdk
 
 	if receiptResponse.Error != "" {
 		return SharedReceiptResponse{
-			ID:                 receiptResponse.ID,
-			SessionID:          receiptResponse.SessionID,
-			RememberMeID:       receiptResponse.RememberMeID,
-			ParentRememberMeID: receiptResponse.ParentRememberMeID,
-			Timestamp:          receiptResponse.Timestamp,
-			Error:              receiptResponse.Error,
-			ErrorReason:        receiptResponse.ErrorReason,
+			ID:          receiptResponse.ID,
+			SessionID:   receiptResponse.SessionID,
+			Timestamp:   receiptResponse.Timestamp,
+			Error:       receiptResponse.Error,
+			ErrorReason: receiptResponse.ErrorReason,
 		}, nil
 	}
 
@@ -286,7 +284,6 @@ func GetShareReceipt(httpClient requests.HttpClient, receiptId string, clientSdk
 			ApplicationProfile: applicationProfile,
 			ExtraData:          extraDataValue,
 		},
-		Error: receiptResponse.Error,
 	}, nil
 }
 

--- a/digitalidentity/service_test.go
+++ b/digitalidentity/service_test.go
@@ -146,3 +146,22 @@ func TestGetQrCode(t *testing.T) {
 	assert.NilError(t, err)
 
 }
+
+func TestGetFailureReceipt(t *testing.T) {
+	key := test.GetValidKey("../test/test-key.pem")
+	mockQrId := "SOME_QR_CODE_ID"
+	mockClientSdkId := "SOME_CLIENT_SDK_ID"
+	mockApiUrl := "https://example.com/api"
+	client := &mockHTTPClient{
+		do: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 201,
+				Body:       io.NopCloser(strings.NewReader(`{"id":"tXTQK9E22lyzyIhVZM7pY1ctI7FHelLgvrVO35RO+vWKjJJJSJhu2ZLFBCce14Xy","sessionId":"ss.v2.ChZvRm1QTG5tT1FJMjZMYm9xeC1Fdlh3EgdsZDUuZ2Jy","timestamp":"2025-05-21T11:01:07Z","error":"MANDATORY_DOCUMENT_NOT_PROVIDED","errorReason":{"requirements_not_met_details":[{"details":"NOT_APPLICABLE_FOR_SCHEME","audit_id":"97001564-a18a-4afd-bf19-3ffacc88abbb","failure_type":"ID_DOCUMENT_COUNTRY","document_type":"PASSPORT","document_country_iso_code":"IRL"}]}}`)),
+			}, nil
+		},
+	}
+
+	r, err := GetShareReceipt(client, mockQrId, mockClientSdkId, mockApiUrl, key)
+	assert.Equal(t, len(r.ErrorReason.RequirementsNotMetDetails), 1)
+	assert.NilError(t, err)
+}

--- a/digitalidentity/share_receipt.go
+++ b/digitalidentity/share_receipt.go
@@ -9,6 +9,7 @@ type SharedReceiptResponse struct {
 	ParentRememberMeID string
 	Timestamp          string
 	Error              string
+	ErrorReason        ErrorReason
 	UserContent        UserContent
 	ApplicationContent ApplicationContent
 }


### PR DESCRIPTION
Expanded SharedReceiptResponse to include details about the error:

**Before:**

```go
type SharedReceiptResponse struct {
	ID                 string
	SessionID          string
	RememberMeID       string
	ParentRememberMeID string
	Timestamp          string
	Error              string
	UserContent        UserContent
	ApplicationContent ApplicationContent
}
```

**After:**

```go
type SharedReceiptResponse struct {
	ID                 string
	SessionID          string
	RememberMeID       string
	ParentRememberMeID string
	Timestamp          string
	Error              string
	ErrorReason        ErrorReason
	UserContent        UserContent
	ApplicationContent ApplicationContent
}

type ErrorReason struct {
	RequirementsNotMetDetails []RequirementsNotMetDetail `json:"requirements_not_met_details"`
}

type RequirementsNotMetDetail struct {
	Details                string `json:"details"`
	AuditId                string `json:"audit_id"`
	FailureType            string `json:"failure_type"`
	DocumentType           string `json:"document_type"`
	DocumentCountryIsoCode string `json:"document_country_iso_code"`
}
```

