### PR TITLE
SDK-2739: Go - Expose IDV breakdown "process" property - go

### DIFF
--- a/docscan/session/retrieve/breakdown_response.go
+++ b/docscan/session/retrieve/breakdown_response.go
@@ -5,4 +5,6 @@ type BreakdownResponse struct {
 	SubCheck string             `json:"sub_check"`
 	Result   string             `json:"result"`
 	Details  []*DetailsResponse `json:"details"`
+	// Process indicates how the check was performed: "AUTOMATED" or "EXPERT_REVIEW"
+	Process string `json:"process"`
 }

--- a/docscan/session/retrieve/breakdown_response_test.go
+++ b/docscan/session/retrieve/breakdown_response_test.go
@@ -1,0 +1,36 @@
+package retrieve_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/session/retrieve"
+	"gotest.tools/v3/assert"
+)
+
+func TestBreakdownResponse_ProcessAutomated(t *testing.T) {
+	payload := `{"sub_check":"doc_number_validation","result":"PASS","details":[],"process":"AUTOMATED"}`
+
+	var breakdown retrieve.BreakdownResponse
+	err := json.Unmarshal([]byte(payload), &breakdown)
+	assert.NilError(t, err)
+	assert.Equal(t, "AUTOMATED", breakdown.Process)
+}
+
+func TestBreakdownResponse_ProcessExpertReview(t *testing.T) {
+	payload := `{"sub_check":"doc_number_validation","result":"PASS","details":[],"process":"EXPERT_REVIEW"}`
+
+	var breakdown retrieve.BreakdownResponse
+	err := json.Unmarshal([]byte(payload), &breakdown)
+	assert.NilError(t, err)
+	assert.Equal(t, "EXPERT_REVIEW", breakdown.Process)
+}
+
+func TestBreakdownResponse_ProcessAbsent(t *testing.T) {
+	payload := `{"sub_check":"doc_number_validation","result":"PASS","details":[]}`
+
+	var breakdown retrieve.BreakdownResponse
+	err := json.Unmarshal([]byte(payload), &breakdown)
+	assert.NilError(t, err)
+	assert.Equal(t, "", breakdown.Process)
+}

--- a/docscan/session/retrieve/get_session_result_test.go
+++ b/docscan/session/retrieve/get_session_result_test.go
@@ -132,6 +132,12 @@ func TestGetSessionResult_UnmarshalJSON_Watchlist(t *testing.T) {
 	watchlistScreeningCheck := result.WatchlistScreeningChecks()[0]
 	assert.Equal(t, watchlistScreeningCheck.GeneratedProfile.Media.Type, "JSON")
 
+	breakdown := watchlistScreeningCheck.Report.Breakdown
+	assert.Equal(t, 5, len(breakdown))
+	assert.Equal(t, "AUTOMATED", breakdown[0].Process)
+	assert.Equal(t, "EXPERT_REVIEW", breakdown[2].Process)
+	assert.Equal(t, "", breakdown[4].Process)
+
 	watchlistSummary := watchlistScreeningCheck.Report.WatchlistSummary
 
 	assert.Equal(t, 0, watchlistSummary.TotalHits)

--- a/test/fixtures/watchlist_advanced_ca_profile_custom.json
+++ b/test/fixtures/watchlist_advanced_ca_profile_custom.json
@@ -91,17 +91,20 @@
           {
             "sub_check": "doc_number_validation",
             "result": "PASS",
-            "details": []
+            "details": [],
+            "process": "AUTOMATED"
           },
           {
             "sub_check": "document_in_date",
             "result": "PASS",
-            "details": []
+            "details": [],
+            "process": "AUTOMATED"
           },
           {
             "sub_check": "fraud_list_check",
             "result": "PASS",
-            "details": []
+            "details": [],
+            "process": "EXPERT_REVIEW"
           }
         ]
       },

--- a/test/fixtures/watchlist_screening.json
+++ b/test/fixtures/watchlist_screening.json
@@ -81,22 +81,26 @@
           {
             "sub_check": "adverse_media",
             "result": "PASS",
-            "details": []
+            "details": [],
+            "process": "AUTOMATED"
           },
           {
             "sub_check": "fitness_probity",
             "result": "PASS",
-            "details": []
+            "details": [],
+            "process": "AUTOMATED"
           },
           {
             "sub_check": "pep",
             "result": "PASS",
-            "details": []
+            "details": [],
+            "process": "EXPERT_REVIEW"
           },
           {
             "sub_check": "sanction",
             "result": "PASS",
-            "details": []
+            "details": [],
+            "process": "AUTOMATED"
           },
           {
             "sub_check": "warning",


### PR DESCRIPTION
## Summary

This PR exposes the `process` property from IDV (Identity Verification) check breakdown responses in the Go SDK. The `process` field indicates how a sub-check was performed — either `"AUTOMATED"` or `"EXPERT_REVIEW"` — and was already present in the API response payload but was not previously mapped in the `BreakdownResponse` struct.

## Changes

- **`docscan/session/retrieve/breakdown_response.go`** — Added `Process string` field (JSON: `"process"`) to `BreakdownResponse`, with a comment documenting the two possible values (`AUTOMATED`, `EXPERT_REVIEW`).
- **`docscan/session/retrieve/breakdown_response_test.go`** — New unit tests covering `AUTOMATED`, `EXPERT_REVIEW`, and absent `process` field deserialization.
- **`docscan/session/retrieve/get_session_result_test.go`** — Extended `TestGetSessionResult_UnmarshalJSON_Watchlist` to assert `Process` values from the watchlist screening fixture, validating both populated and empty cases.
- **`test/fixtures/watchlist_advanced_ca_profile_custom.json`** — Added `"process"` values (`AUTOMATED`, `EXPERT_REVIEW`) to breakdown entries in the WATCHLIST_ADVANCED_CA check fixture.
- **`test/fixtures/watchlist_screening.json`** — Added `"process"` values (`AUTOMATED`, `EXPERT_REVIEW`) to breakdown entries in the WATCHLIST_SCREENING check fixture; one entry deliberately left without the field to cover the absent/optional case.

## QA Test Steps

1. **Setup**: Check out branch `websdk-auto/SDK-2739-go-expose-idv-breakdown-process-property` and run `go test ./docscan/...` to confirm all tests pass.

2. **Happy path — `AUTOMATED` process**:
   - Construct or mock a session result JSON with a check report containing a breakdown entry where `"process": "AUTOMATED"`.
   - Deserialize into `retrieve.GetSessionResult` and access `Checks[n].Report.Breakdown[n].Process`.
   - Assert the value equals `"AUTOMATED"`.

3. **Happy path — `EXPERT_REVIEW` process**:
   - Same as above with `"process": "EXPERT_REVIEW"`.
   - Assert the value equals `"EXPERT_REVIEW"`.

4. **Edge case — absent `process` field**:
   - Use a breakdown entry JSON with no `process` key (e.g. `{"sub_check":"text_data_readable","result":"PASS","details":[]}`).
   - Assert `breakdown.Process` is an empty string `""`.

5. **Integration via fixture — watchlist screening**:
   - Run `TestGetSessionResult_UnmarshalJSON_Watchlist` which loads `test/fixtures/watchlist_screening.json`.
   - Confirm `breakdown[0].Process == "AUTOMATED"`, `breakdown[2].Process == "EXPERT_REVIEW"`, and `breakdown[4].Process == ""`.

6. **Integration via fixture — watchlist advanced CA**:
   - Run `TestGetSessionResult_UnmarshalJSON_Watchlist_Advanced_CA` which loads `test/fixtures/watchlist_advanced_ca_profile_custom.json`.
   - Confirm no regressions in existing assertions; the fixture now contains `process` values on its breakdown entries.

7. **Regression — other check types**:
   - Verify that check types without a `process` field in their breakdown (e.g. `ID_DOCUMENT_TEXT_DATA_CHECK` in the fixture) still deserialize correctly with `Process == ""`.

## Notes

- The `process` field is optional in the API response; the Go zero-value (`""`) is the natural representation when it is absent, which avoids a pointer or custom unmarshalling.
- No changes to public API surface other than the new exported `Process` field on `BreakdownResponse` — this is a non-breaking, additive change.
- Fixture files were updated to reflect realistic API payloads, including a mix of `AUTOMATED`, `EXPERT_REVIEW`, and absent `process` values to fully exercise the optional nature of the field.

---

*Related Jira:* SDK-2739
*Auto-generated by n8n + Claude CLI*