### PR TITLE
SDK-2788: Go - Add support for retrieving the extraction_image_ids field from the IDV pages - go

### DIFF
--- a/docscan/session/retrieve/page_response.go
+++ b/docscan/session/retrieve/page_response.go
@@ -2,7 +2,8 @@ package retrieve
 
 // PageResponse represents information about an uploaded document Page
 type PageResponse struct {
-	CaptureMethod string           `json:"capture_method"`
-	Media         *MediaResponse   `json:"media"`
-	Frames        []*FrameResponse `json:"frames"`
+	CaptureMethod      string           `json:"capture_method"`
+	Media              *MediaResponse   `json:"media"`
+	Frames             []*FrameResponse `json:"frames"`
+	ExtractionImageIds []string         `json:"extraction_image_ids"`
 }

--- a/docscan/session/retrieve/page_response_test.go
+++ b/docscan/session/retrieve/page_response_test.go
@@ -1,0 +1,80 @@
+package retrieve
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPageResponse_ExtractionImageIds_WithValues(t *testing.T) {
+	jsonData := []byte(`{
+		"capture_method": "UPLOAD",
+		"extraction_image_ids": ["uuid-1", "uuid-2"]
+	}`)
+
+	var page PageResponse
+	err := json.Unmarshal(jsonData, &page)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 2, len(page.ExtractionImageIds))
+	assert.Equal(t, "uuid-1", page.ExtractionImageIds[0])
+	assert.Equal(t, "uuid-2", page.ExtractionImageIds[1])
+}
+
+func TestPageResponse_ExtractionImageIds_EmptyArray(t *testing.T) {
+	jsonData := []byte(`{
+		"capture_method": "UPLOAD",
+		"extraction_image_ids": []
+	}`)
+
+	var page PageResponse
+	err := json.Unmarshal(jsonData, &page)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 0, len(page.ExtractionImageIds))
+}
+
+func TestPageResponse_ExtractionImageIds_NullValue(t *testing.T) {
+	jsonData := []byte(`{
+		"capture_method": "UPLOAD",
+		"extraction_image_ids": null
+	}`)
+
+	var page PageResponse
+	err := json.Unmarshal(jsonData, &page)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 0, len(page.ExtractionImageIds))
+}
+
+func TestPageResponse_ExtractionImageIds_FieldAbsent(t *testing.T) {
+	jsonData := []byte(`{
+		"capture_method": "UPLOAD"
+	}`)
+
+	var page PageResponse
+	err := json.Unmarshal(jsonData, &page)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 0, len(page.ExtractionImageIds))
+}
+
+func TestPageResponse_ExtractionImageIds_RoundTrip(t *testing.T) {
+	ids := []string{"uuid-aaa", "uuid-bbb"}
+	page := PageResponse{
+		CaptureMethod:      "CAMERA",
+		ExtractionImageIds: ids,
+	}
+
+	data, err := json.Marshal(page)
+	assert.NilError(t, err)
+
+	var result PageResponse
+	err = json.Unmarshal(data, &result)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 2, len(result.ExtractionImageIds))
+	assert.Equal(t, "uuid-aaa", result.ExtractionImageIds[0])
+	assert.Equal(t, "uuid-bbb", result.ExtractionImageIds[1])
+}

--- a/test/fixtures/watchlist_advanced_ca_profile_custom.json
+++ b/test/fixtures/watchlist_advanced_ca_profile_custom.json
@@ -41,7 +41,8 @@
               "created": "2022-01-14T14:54:30Z",
               "last_updated": "2022-01-14T14:54:30Z"
             },
-            "frames": [{}, {}]
+            "frames": [{}, {}],
+            "extraction_image_ids": ["b1c2d3e4-0000-0000-0000-000000000001", "b1c2d3e4-0000-0000-0000-000000000002"]
           },
           {
             "capture_method": "UPLOAD",
@@ -51,7 +52,8 @@
               "created": "2022-01-14T14:54:31Z",
               "last_updated": "2022-01-14T14:54:31Z"
             },
-            "frames": [{}, {}]
+            "frames": [{}, {}],
+            "extraction_image_ids": []
           }
         ],
         "document_fields": {

--- a/test/fixtures/watchlist_screening.json
+++ b/test/fixtures/watchlist_screening.json
@@ -36,7 +36,8 @@
               "created": "2021-07-20T15:15:52Z",
               "last_updated": "2021-07-20T15:15:52Z"
             },
-            "frames": [{}, {}, {}]
+            "frames": [{}, {}, {}],
+            "extraction_image_ids": ["a1b2c3d4-0000-0000-0000-000000000001"]
           }
         ],
         "document_fields": {


### PR DESCRIPTION
## Summary
Adds support for the `extraction_image_ids` field on `PageResponse` in the IDV (Identity Verification) session retrieval API. This field returns a list of UUID strings identifying the images extracted from a document page during processing. The change extends the existing `PageResponse` struct with the new field and updates test fixtures to reflect the new API shape.

## Changes
- **`docscan/session/retrieve/page_response.go`** — Added `ExtractionImageIds []string` field with `json:"extraction_image_ids"` tag to `PageResponse`.
- **`docscan/session/retrieve/page_response_test.go`** — Added unit tests covering: populated array, empty array, `null` value, absent field, and JSON round-trip serialization for `ExtractionImageIds`.
- **`test/fixtures/watchlist_advanced_ca_profile_custom.json`** — Updated fixture pages to include `extraction_image_ids` with two UUIDs on one page and an empty array on the other, reflecting real API variance.
- **`test/fixtures/watchlist_screening.json`** — Updated fixture page to include a single UUID in `extraction_image_ids`, aligning the fixture with the updated API contract.

## QA Test Steps

1. **Setup**: Check out branch `websdk-auto/SDK-2788-go-add-support-for-retrieving-the-extraction-image-ids-field-from-the-idv-pages` and run `go test ./docscan/session/retrieve/...` — all tests should pass.

2. **Happy path — populated IDs**: Confirm `TestPageResponse_ExtractionImageIds_WithValues` passes: `PageResponse` unmarshals JSON with `extraction_image_ids: ["uuid-1", "uuid-2"]` and returns a slice of length 2 with correct values.

3. **Edge case — empty array**: Confirm `TestPageResponse_ExtractionImageIds_EmptyArray` passes: JSON with `extraction_image_ids: []` results in a zero-length slice, not `nil`.

4. **Edge case — null field**: Confirm `TestPageResponse_ExtractionImageIds_NullValue` passes: JSON with `extraction_image_ids: null` results in a zero-length slice.

5. **Edge case — field absent**: Confirm `TestPageResponse_ExtractionImageIds_FieldAbsent` passes: JSON without the field at all results in a zero-length slice (zero value for `[]string`).

6. **Round-trip serialization**: Confirm `TestPageResponse_ExtractionImageIds_RoundTrip` passes: marshal then unmarshal a `PageResponse` with IDs and verify the values survive intact.

7. **Fixture-driven integration tests**: Run the full test suite (`go test ./...`) and confirm tests that load `test/fixtures/watchlist_advanced_ca_profile_custom.json` and `test/fixtures/watchlist_screening.json` still pass with the updated fixture data.

8. **Regression**: Verify that existing `PageResponse` fields (`CaptureMethod`, `Media`, `Frames`) are still correctly populated when `extraction_image_ids` is present in the JSON.

## Notes
- `ExtractionImageIds` uses Go's zero value (`nil` slice) when absent or `null` in JSON; callers should use `len()` rather than a `nil` check to safely handle all cases.
- The fixture updates are non-breaking — they only add the new field to existing page objects, so no other fixture-consuming tests should regress.
- No getter method was added; the field is directly accessible on the struct, consistent with the pattern used by `CaptureMethod`, `Media`, and `Frames` in the same struct.

---

*Related Jira:* SDK-2788
*Auto-generated by n8n + Claude CLI*