### PR TITLE
SDK-2761: Go - Support handled_check_limit property for checks in IDV sandbox - go

### DIFF
--- a/docscan/sandbox/request/check/check.go
+++ b/docscan/sandbox/request/check/check.go
@@ -5,12 +5,14 @@ import (
 )
 
 type check struct {
-	Result checkResult `json:"result"`
+	Result            checkResult `json:"result"`
+	HandledCheckLimit *int        `json:"handled_check_limit,omitempty"`
 }
 
 type checkBuilder struct {
-	recommendation *report.Recommendation
-	breakdowns     []*report.Breakdown
+	recommendation    *report.Recommendation
+	breakdowns        []*report.Breakdown
+	handledCheckLimit *int
 }
 
 type checkResult struct {
@@ -30,6 +32,10 @@ func (b *checkBuilder) withBreakdown(breakdown *report.Breakdown) {
 	b.breakdowns = append(b.breakdowns, breakdown)
 }
 
+func (b *checkBuilder) withHandledCheckLimit(handledCheckLimit int) {
+	b.handledCheckLimit = &handledCheckLimit
+}
+
 func (b *checkBuilder) build() *check {
 	return &check{
 		Result: checkResult{
@@ -38,5 +44,6 @@ func (b *checkBuilder) build() *check {
 				Breakdown:      b.breakdowns,
 			},
 		},
+		HandledCheckLimit: b.handledCheckLimit,
 	}
 }

--- a/docscan/sandbox/request/check/document_authenticity_check.go
+++ b/docscan/sandbox/request/check/document_authenticity_check.go
@@ -38,6 +38,13 @@ func (b *DocumentAuthenticityCheckBuilder) WithDocumentFilter(filter *filter.Doc
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check report configuration will be used
+// by the sandbox before moving to the next configured response.
+func (b *DocumentAuthenticityCheckBuilder) WithHandledCheckLimit(handledCheckLimit int) *DocumentAuthenticityCheckBuilder {
+	b.withHandledCheckLimit(handledCheckLimit)
+	return b
+}
+
 // Build creates a new DocumentAuthenticityCheck
 func (b *DocumentAuthenticityCheckBuilder) Build() (*DocumentAuthenticityCheck, error) {
 	return &DocumentAuthenticityCheck{

--- a/docscan/sandbox/request/check/document_authenticity_check_test.go
+++ b/docscan/sandbox/request/check/document_authenticity_check_test.go
@@ -51,3 +51,22 @@ func ExampleDocumentAuthenticityCheckBuilder() {
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}},"document_filter":{"document_types":[],"country_codes":[]}}
 }
+
+func ExampleDocumentAuthenticityCheckBuilder_WithHandledCheckLimit() {
+	check, err := NewDocumentAuthenticityCheckBuilder().
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}},"handled_check_limit":3}
+}

--- a/docscan/sandbox/request/check/document_face_match_check.go
+++ b/docscan/sandbox/request/check/document_face_match_check.go
@@ -38,6 +38,13 @@ func (b *DocumentFaceMatchCheckBuilder) WithDocumentFilter(filter *filter.Docume
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check report configuration will be used
+// by the sandbox before moving to the next configured response.
+func (b *DocumentFaceMatchCheckBuilder) WithHandledCheckLimit(handledCheckLimit int) *DocumentFaceMatchCheckBuilder {
+	b.withHandledCheckLimit(handledCheckLimit)
+	return b
+}
+
 // Build creates a new DocumentFaceMatchCheck
 func (b *DocumentFaceMatchCheckBuilder) Build() (*DocumentFaceMatchCheck, error) {
 	return &DocumentFaceMatchCheck{

--- a/docscan/sandbox/request/check/document_face_match_check_test.go
+++ b/docscan/sandbox/request/check/document_face_match_check_test.go
@@ -51,3 +51,22 @@ func ExampleDocumentFaceMatchCheckBuilder() {
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}},"document_filter":{"document_types":[],"country_codes":[]}}
 }
+
+func ExampleDocumentFaceMatchCheckBuilder_WithHandledCheckLimit() {
+	check, err := NewDocumentFaceMatchCheckBuilder().
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}},"handled_check_limit":3}
+}

--- a/docscan/sandbox/request/check/document_text_data_check.go
+++ b/docscan/sandbox/request/check/document_text_data_check.go
@@ -61,6 +61,13 @@ func (b *DocumentTextDataCheckBuilder) WithDocumentFields(documentFields map[str
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check report configuration will be used
+// by the sandbox before moving to the next configured response.
+func (b *DocumentTextDataCheckBuilder) WithHandledCheckLimit(handledCheckLimit int) *DocumentTextDataCheckBuilder {
+	b.withHandledCheckLimit(handledCheckLimit)
+	return b
+}
+
 // Build creates a new DocumentTextDataCheck
 func (b *DocumentTextDataCheckBuilder) Build() (*DocumentTextDataCheck, error) {
 	docCheck := b.documentCheckBuilder.build()

--- a/docscan/sandbox/request/check/document_text_data_check_test.go
+++ b/docscan/sandbox/request/check/document_text_data_check_test.go
@@ -96,3 +96,22 @@ func ExampleDocumentTextDataCheckBuilder_minimal() {
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{}}}
 }
+
+func ExampleDocumentTextDataCheckBuilder_WithHandledCheckLimit() {
+	check, err := NewDocumentTextDataCheckBuilder().
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}},"handled_check_limit":3}
+}

--- a/docscan/sandbox/request/check/id_document_comparison_check.go
+++ b/docscan/sandbox/request/check/id_document_comparison_check.go
@@ -40,6 +40,13 @@ func (b *IDDocumentComparisonCheckBuilder) WithSecondaryDocumentFilter(filter *f
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check report configuration will be used
+// by the sandbox before moving to the next configured response.
+func (b *IDDocumentComparisonCheckBuilder) WithHandledCheckLimit(handledCheckLimit int) *IDDocumentComparisonCheckBuilder {
+	b.withHandledCheckLimit(handledCheckLimit)
+	return b
+}
+
 // Build creates a new IDDocumentComparisonCheck
 func (b *IDDocumentComparisonCheckBuilder) Build() (*IDDocumentComparisonCheck, error) {
 	return &IDDocumentComparisonCheck{

--- a/docscan/sandbox/request/check/id_document_comparison_check_test.go
+++ b/docscan/sandbox/request/check/id_document_comparison_check_test.go
@@ -71,3 +71,22 @@ func ExampleIDDocumentComparisonCheckBuilder_minimal() {
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{}}}
 }
+
+func ExampleIDDocumentComparisonCheckBuilder_WithHandledCheckLimit() {
+	idDocumentComparisonCheck, err := NewIDDocumentComparisonCheckBuilder().
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(idDocumentComparisonCheck)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}},"handled_check_limit":3}
+}

--- a/docscan/sandbox/request/check/static_liveness_check.go
+++ b/docscan/sandbox/request/check/static_liveness_check.go
@@ -27,6 +27,13 @@ func (b *StaticLivenessCheckBuilder) WithBreakdown(breakdown *report.Breakdown) 
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check report configuration will be used
+// by the sandbox before moving to the next configured response.
+func (b *StaticLivenessCheckBuilder) WithHandledCheckLimit(handledCheckLimit int) *StaticLivenessCheckBuilder {
+	b.withHandledCheckLimit(handledCheckLimit)
+	return b
+}
+
 // Build creates a new LivenessCheck
 func (b *StaticLivenessCheckBuilder) Build() (*LivenessCheck, error) {
 	livenessCheck := b.livenessCheckBuilder.

--- a/docscan/sandbox/request/check/static_liveness_check_test.go
+++ b/docscan/sandbox/request/check/static_liveness_check_test.go
@@ -43,3 +43,22 @@ func ExampleStaticLivenessCheckBuilder() {
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}},"liveness_type":"STATIC"}
 }
+
+func ExampleStaticLivenessCheckBuilder_WithHandledCheckLimit() {
+	check, err := NewStaticLivenessCheckBuilder().
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}},"handled_check_limit":3,"liveness_type":"STATIC"}
+}

--- a/docscan/sandbox/request/check/supplementary_document_text_data_check.go
+++ b/docscan/sandbox/request/check/supplementary_document_text_data_check.go
@@ -61,6 +61,13 @@ func (b *SupplementaryDocumentTextDataCheckBuilder) WithDocumentFields(documentF
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check report configuration will be used
+// by the sandbox before moving to the next configured response.
+func (b *SupplementaryDocumentTextDataCheckBuilder) WithHandledCheckLimit(handledCheckLimit int) *SupplementaryDocumentTextDataCheckBuilder {
+	b.withHandledCheckLimit(handledCheckLimit)
+	return b
+}
+
 // Build creates a new SupplementaryDocumentTextDataCheck
 func (b *SupplementaryDocumentTextDataCheckBuilder) Build() (*SupplementaryDocumentTextDataCheck, error) {
 	docCheck := b.documentCheckBuilder.build()

--- a/docscan/sandbox/request/check/supplementary_document_text_data_check_test.go
+++ b/docscan/sandbox/request/check/supplementary_document_text_data_check_test.go
@@ -96,3 +96,22 @@ func ExampleSupplementaryDocumentTextDataCheckBuilder_minimal() {
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{}}}
 }
+
+func ExampleSupplementaryDocumentTextDataCheckBuilder_WithHandledCheckLimit() {
+	check, err := NewSupplementaryDocumentTextDataCheckBuilder().
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}},"handled_check_limit":3}
+}

--- a/docscan/sandbox/request/check/third_party_identity_check.go
+++ b/docscan/sandbox/request/check/third_party_identity_check.go
@@ -35,3 +35,10 @@ func (b *ThirdPartyIdentityCheckBuilder) WithRecommendation(recommendation *repo
 	b.checkBuilder.withRecommendation(recommendation)
 	return b
 }
+
+// WithHandledCheckLimit sets the number of times this check report configuration will be used
+// by the sandbox before moving to the next configured response.
+func (b *ThirdPartyIdentityCheckBuilder) WithHandledCheckLimit(handledCheckLimit int) *ThirdPartyIdentityCheckBuilder {
+	b.withHandledCheckLimit(handledCheckLimit)
+	return b
+}

--- a/docscan/sandbox/request/check/third_party_identity_check_test.go
+++ b/docscan/sandbox/request/check/third_party_identity_check_test.go
@@ -43,3 +43,22 @@ func ExampleThirdPartyIdentityCheckBuilder() {
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}}}
 }
+
+func ExampleThirdPartyIdentityCheckBuilder_WithHandledCheckLimit() {
+	check, err := NewThirdPartyIdentityCheckBuilder().
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}},"handled_check_limit":3}
+}

--- a/docscan/sandbox/request/check/zoom_liveness_check.go
+++ b/docscan/sandbox/request/check/zoom_liveness_check.go
@@ -27,6 +27,13 @@ func (b *ZoomLivenessCheckBuilder) WithBreakdown(breakdown *report.Breakdown) *Z
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check report configuration will be used
+// by the sandbox before moving to the next configured response.
+func (b *ZoomLivenessCheckBuilder) WithHandledCheckLimit(handledCheckLimit int) *ZoomLivenessCheckBuilder {
+	b.withHandledCheckLimit(handledCheckLimit)
+	return b
+}
+
 // Build creates a new LivenessCheck
 func (b *ZoomLivenessCheckBuilder) Build() (*LivenessCheck, error) {
 	livenessCheck := b.livenessCheckBuilder.

--- a/docscan/sandbox/request/check/zoom_liveness_check_test.go
+++ b/docscan/sandbox/request/check/zoom_liveness_check_test.go
@@ -43,3 +43,22 @@ func ExampleZoomLivenessCheckBuilder() {
 	fmt.Println(string(data))
 	// Output: {"result":{"report":{"recommendation":{"value":"some_value"},"breakdown":[{"sub_check":"some_check","result":"some_result","details":[]}]}},"liveness_type":"ZOOM"}
 }
+
+func ExampleZoomLivenessCheckBuilder_WithHandledCheckLimit() {
+	check, err := NewZoomLivenessCheckBuilder().
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{}},"handled_check_limit":3,"liveness_type":"ZOOM"}
+}


### PR DESCRIPTION
## Summary

Adds support for the `handled_check_limit` property on IDV sandbox check report configurations. This optional integer field controls how many times a particular check report configuration will be used by the sandbox before cycling to the next configured response, enabling more flexible multi-response sandbox testing. The field is omitted from JSON serialization when not set, maintaining full backward compatibility.

## Changes

- **`docscan/sandbox/request/check/check.go`** — Added `HandledCheckLimit *int` field (with `json:"handled_check_limit,omitempty"`) to the base `check` struct and corresponding `handledCheckLimit` field and `withHandledCheckLimit(int)` builder helper on `checkBuilder`.
- **`docscan/sandbox/request/check/document_authenticity_check.go`** — Added `WithHandledCheckLimit(int)` public builder method to `DocumentAuthenticityCheckBuilder`.
- **`docscan/sandbox/request/check/document_face_match_check.go`** — Added `WithHandledCheckLimit(int)` public builder method to `DocumentFaceMatchCheckBuilder`.
- **`docscan/sandbox/request/check/document_text_data_check.go`** — Added `WithHandledCheckLimit(int)` public builder method to `DocumentTextDataCheckBuilder`.
- **`docscan/sandbox/request/check/supplementary_document_text_data_check.go`** — Added `WithHandledCheckLimit(int)` public builder method to `SupplementaryDocumentTextDataCheckBuilder`.
- **`docscan/sandbox/request/check/id_document_comparison_check.go`** — Added `WithHandledCheckLimit(int)` public builder method to `IDDocumentComparisonCheckBuilder`.
- **`docscan/sandbox/request/check/third_party_identity_check.go`** — Added `WithHandledCheckLimit(int)` public builder method to `ThirdPartyIdentityCheckBuilder`.
- **`docscan/sandbox/request/check/zoom_liveness_check.go`** — Added `WithHandledCheckLimit(int)` public builder method to `ZoomLivenessCheckBuilder`.
- **`docscan/sandbox/request/check/static_liveness_check.go`** — Added `WithHandledCheckLimit(int)` public builder method to `StaticLivenessCheckBuilder`.
- **`*_test.go` files (8 files)** — Added Example tests for each builder demonstrating the `WithHandledCheckLimit` method.

## QA Test Steps

1. **Setup** — Clone the repo, checkout this branch, ensure Go toolchain is available (`go version`).
2. **Unit tests** — Run `go test ./docscan/sandbox/request/check/...` and confirm all tests pass with no regressions.
3. **Happy path — field serialises** — Build a check with `.WithHandledCheckLimit(3)` and marshal it to JSON; confirm `"handled_check_limit":3` appears in the output.
4. **Happy path — field absent when unset** — Build a check *without* calling `WithHandledCheckLimit` and marshal to JSON; confirm `handled_check_limit` key is absent (not `null`).
5. **Edge case — zero value** — Call `.WithHandledCheckLimit(0)` and marshal; confirm `"handled_check_limit":0` is present (pointer semantics ensure zero is serialised).
6. **Edge case — large value** — Call `.WithHandledCheckLimit(999)` and verify no overflow or serialisation issues.
7. **All eight builder types** — Repeat steps 3-4 for each builder: `DocumentAuthenticity`, `DocumentFaceMatch`, `DocumentTextData`, `SupplementaryDocumentTextData`, `IDDocumentComparison`, `ThirdPartyIdentity`, `ZoomLiveness`, `StaticLiveness`.
8. **Regression** — Run the full test suite `go test ./...` to confirm no existing tests are broken.
9. **Lint** — Run `golangci-lint run ./...` and confirm no new lint errors.

## Notes

- The field uses a pointer (`*int`) so that the zero value (`0`) is distinguishable from "not set", and `omitempty` correctly omits it when nil.
- No breaking changes are introduced; all existing builder APIs remain identical.
- This change is limited to the sandbox package and has no effect on production IDV request structures.
- Follow-up: other SDKs (PHP, .NET, etc.) will require equivalent changes tracked under SDK-2761.

---

*Related Jira:* SDK-2761
*Auto-generated by Claude dynamic workflow*