### PR TITLE
SDK-2769-go-support-central-auth-tokens

### DIFF
--- a/digital_identity_client.go
+++ b/digital_identity_client.go
@@ -2,10 +2,12 @@ package yoti
 
 import (
 	"crypto/rsa"
+	"errors"
 	"os"
 
 	"github.com/getyoti/yoti-go-sdk/v3/cryptoutil"
 	"github.com/getyoti/yoti-go-sdk/v3/digitalidentity"
+	direquests "github.com/getyoti/yoti-go-sdk/v3/digitalidentity/requests"
 	"github.com/getyoti/yoti-go-sdk/v3/requests"
 )
 
@@ -22,11 +24,16 @@ type DigitalIdentityClient struct {
 	// https://github.com/getyoti/yoti-go-sdk/blob/master/README.md
 	Key *rsa.PrivateKey
 
+	// AuthToken is the central auth bearer token. When set, the client uses
+	// bearer token authentication instead of signed-request authentication.
+	// This is mutually exclusive with SdkID/Key.
+	AuthToken string `json:"-"`
+
 	apiURL     string
 	HTTPClient requests.HttpClient // Mockable HTTP Client Interface
 }
 
-// NewDigitalIdentityClient constructs a Client object
+// NewDigitalIdentityClient constructs a Client object using signed-request authentication.
 func NewDigitalIdentityClient(sdkID string, key []byte) (*DigitalIdentityClient, error) {
 	decodedKey, err := cryptoutil.ParseRSAKey(key)
 
@@ -38,6 +45,36 @@ func NewDigitalIdentityClient(sdkID string, key []byte) (*DigitalIdentityClient,
 		SdkID: sdkID,
 		Key:   decodedKey,
 	}, err
+}
+
+// NewDigitalIdentityClientWithToken constructs a Client object using central auth
+// bearer token authentication. The token is provided by the relying business and
+// will be sent as an Authorization: Bearer header on all API requests.
+func NewDigitalIdentityClientWithToken(authToken string) (*DigitalIdentityClient, error) {
+	if authToken == "" {
+		return nil, errors.New("authentication token must not be empty")
+	}
+	return &DigitalIdentityClient{
+		AuthToken: authToken,
+	}, nil
+}
+
+// GetAuthStrategy returns the appropriate AuthStrategy based on the client configuration.
+func (client *DigitalIdentityClient) GetAuthStrategy() (direquests.AuthStrategy, error) {
+	if client.AuthToken != "" {
+		if client.Key != nil || client.SdkID != "" {
+			return nil, errors.New("must not supply both authentication token and SDK credentials (SdkID/Key)")
+		}
+		return direquests.NewBearerTokenStrategy(client.AuthToken)
+	}
+
+	if client.Key == nil {
+		return nil, errors.New("missing private key for signed-request authentication")
+	}
+	if client.SdkID == "" {
+		return nil, errors.New("missing SDK ID for signed-request authentication")
+	}
+	return direquests.NewSignedRequestStrategy(client.Key, client.SdkID)
 }
 
 // OverrideAPIURL overrides the default API URL for this Yoti Client
@@ -64,25 +101,49 @@ func (client *DigitalIdentityClient) GetSdkID() string {
 
 // CreateShareSession creates a sharing session to initiate a sharing process based on a policy
 func (client *DigitalIdentityClient) CreateShareSession(shareSessionRequest *digitalidentity.ShareSessionRequest) (shareSession *digitalidentity.ShareSession, err error) {
-	return digitalidentity.CreateShareSession(client.HTTPClient, shareSessionRequest, client.GetSdkID(), client.getAPIURL(), client.Key)
+	strategy, err := client.GetAuthStrategy()
+	if err != nil {
+		return nil, err
+	}
+	return digitalidentity.CreateShareSession(client.HTTPClient, shareSessionRequest, client.getAPIURL(), strategy)
 }
 
 // GetShareSession retrieves the sharing session.
 func (client *DigitalIdentityClient) GetShareSession(sessionID string) (*digitalidentity.ShareSession, error) {
-	return digitalidentity.GetShareSession(client.HTTPClient, sessionID, client.GetSdkID(), client.getAPIURL(), client.Key)
+	strategy, err := client.GetAuthStrategy()
+	if err != nil {
+		return nil, err
+	}
+	return digitalidentity.GetShareSession(client.HTTPClient, sessionID, client.getAPIURL(), strategy)
 }
 
 // CreateShareQrCode generates a sharing session QR code to initiate a sharing process based on session ID
 func (client *DigitalIdentityClient) CreateShareQrCode(sessionID string) (share *digitalidentity.QrCode, err error) {
-	return digitalidentity.CreateShareQrCode(client.HTTPClient, sessionID, client.GetSdkID(), client.getAPIURL(), client.Key)
+	strategy, err := client.GetAuthStrategy()
+	if err != nil {
+		return nil, err
+	}
+	return digitalidentity.CreateShareQrCode(client.HTTPClient, sessionID, client.getAPIURL(), strategy)
 }
 
 // Get session QR code based on generated Qr ID
 func (client *DigitalIdentityClient) GetQrCode(qrCodeId string) (share digitalidentity.ShareSessionQrCode, err error) {
-	return digitalidentity.GetShareSessionQrCode(client.HTTPClient, qrCodeId, client.GetSdkID(), client.getAPIURL(), client.Key)
+	strategy, err := client.GetAuthStrategy()
+	if err != nil {
+		return share, err
+	}
+	return digitalidentity.GetShareSessionQrCode(client.HTTPClient, qrCodeId, client.getAPIURL(), strategy)
 }
 
 // GetShareReceipt fetches the receipt of the share given a receipt id.
+// Requires a private key for receipt decryption; not available with bearer token authentication.
 func (client *DigitalIdentityClient) GetShareReceipt(receiptId string) (share digitalidentity.SharedReceiptResponse, err error) {
-	return digitalidentity.GetShareReceipt(client.HTTPClient, receiptId, client.GetSdkID(), client.getAPIURL(), client.Key)
+	if client.Key == nil {
+		return share, errors.New("GetShareReceipt requires a private key for receipt decryption and cannot be used with bearer token authentication")
+	}
+	strategy, err := client.GetAuthStrategy()
+	if err != nil {
+		return share, err
+	}
+	return digitalidentity.GetShareReceipt(client.HTTPClient, receiptId, client.getAPIURL(), strategy, client.Key)
 }

--- a/digital_identity_client_test.go
+++ b/digital_identity_client_test.go
@@ -73,7 +73,8 @@ func TestDigitalIDClient_HttpFailure_ReturnsUnKnownHttpError(t *testing.T) {
 				}, nil
 			},
 		},
-		Key: key,
+		SdkID: "some-sdk-id",
+		Key:   key,
 	}
 
 	_, err := client.GetShareSession("SOME ID")
@@ -165,4 +166,115 @@ func TestDigitalIDClient_GetAPIURLUsesDefaultUrlAsFallbackWithNoEnvValue(t *test
 
 func getDigitalValidKey() *rsa.PrivateKey {
 	return test.GetValidKey("test/test-key.pem")
+}
+
+func TestNewDigitalIdentityClientWithToken(t *testing.T) {
+	client, err := NewDigitalIdentityClientWithToken("my-auth-token")
+	assert.NilError(t, err)
+	assert.Equal(t, client.AuthToken, "my-auth-token")
+}
+
+func TestNewDigitalIdentityClientWithToken_EmptyToken(t *testing.T) {
+	_, err := NewDigitalIdentityClientWithToken("")
+	assert.ErrorContains(t, err, "authentication token must not be empty")
+}
+
+func TestDigitalIDClient_GetAuthStrategy_BearerToken(t *testing.T) {
+	client := DigitalIdentityClient{
+		AuthToken: "my-bearer-token",
+	}
+
+	strategy, err := client.GetAuthStrategy()
+	assert.NilError(t, err)
+
+	headers, err := strategy.CreateAuthHeaders("GET", "/v2/sessions", nil)
+	assert.NilError(t, err)
+	assert.Equal(t, headers["Authorization"][0], "Bearer my-bearer-token")
+}
+
+func TestDigitalIDClient_GetAuthStrategy_SignedRequest(t *testing.T) {
+	key := getDigitalValidKey()
+	client := DigitalIdentityClient{
+		SdkID: "test-sdk-id",
+		Key:   key,
+	}
+
+	strategy, err := client.GetAuthStrategy()
+	assert.NilError(t, err)
+
+	params, err := strategy.CreateQueryParams()
+	assert.NilError(t, err)
+	assert.Equal(t, params["sdkID"], "test-sdk-id")
+}
+
+func TestDigitalIDClient_GetAuthStrategy_MutualExclusion(t *testing.T) {
+	key := getDigitalValidKey()
+	client := DigitalIdentityClient{
+		AuthToken: "my-token",
+		SdkID:     "test-sdk-id",
+		Key:       key,
+	}
+
+	_, err := client.GetAuthStrategy()
+	assert.ErrorContains(t, err, "must not supply both authentication token and SDK credentials")
+}
+
+func TestDigitalIDClient_GetAuthStrategy_MissingKey(t *testing.T) {
+	client := DigitalIdentityClient{
+		SdkID: "test-sdk-id",
+	}
+
+	_, err := client.GetAuthStrategy()
+	assert.ErrorContains(t, err, "missing private key")
+}
+
+func TestDigitalIDClient_GetAuthStrategy_MissingSdkId(t *testing.T) {
+	key := getDigitalValidKey()
+	client := DigitalIdentityClient{
+		Key: key,
+	}
+
+	_, err := client.GetAuthStrategy()
+	assert.ErrorContains(t, err, "missing SDK ID")
+}
+
+func TestDigitalIDClient_WithToken_CreateShareSession(t *testing.T) {
+	client, err := NewDigitalIdentityClientWithToken("test-token")
+	assert.NilError(t, err)
+
+	client.HTTPClient = &mockHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			// Verify bearer token is sent
+			assert.Equal(t, req.Header.Get("Authorization"), "Bearer test-token")
+			// Verify no signed-request artifacts
+			assert.Equal(t, req.Header.Get("X-Yoti-Auth-Digest"), "")
+			assert.Equal(t, req.Header.Get("X-Yoti-Auth-Id"), "")
+			// Verify no nonce/timestamp query params
+			assert.Equal(t, req.URL.Query().Get("nonce"), "")
+			assert.Equal(t, req.URL.Query().Get("timestamp"), "")
+
+			return &http.Response{
+				StatusCode: 201,
+				Body:       io.NopCloser(strings.NewReader(`{"id":"SOME_ID","status":"SOME_STATUS","expiry":"SOME_EXPIRY"}`)),
+			}, nil
+		},
+	}
+
+	policy, err := (&digitalidentity.PolicyBuilder{}).WithFullName().Build()
+	assert.NilError(t, err)
+
+	session, err := (&digitalidentity.ShareSessionRequestBuilder{}).WithPolicy(policy).Build()
+	assert.NilError(t, err)
+
+	result, err := client.CreateShareSession(&session)
+	assert.NilError(t, err)
+	assert.Equal(t, result.Status, "SOME_STATUS")
+}
+
+func TestDigitalIDClient_WithToken_GetShareReceiptReturnsErrorNotPanic(t *testing.T) {
+	client, err := NewDigitalIdentityClientWithToken("test-token")
+	assert.NilError(t, err)
+
+	_, err = client.GetShareReceipt("some-receipt-id")
+	assert.ErrorContains(t, err, "GetShareReceipt requires a private key")
 }

--- a/digitalidentity/centralauth/token_generator.go
+++ b/digitalidentity/centralauth/token_generator.go
@@ -193,7 +193,9 @@ func (b *Builder) WithHTTPClient(httpClient requests.HttpClient) *Builder {
 
 func defaultJwtIDSupplier() string {
 	buf := make([]byte, 16)
-	_, _ = rand.Read(buf)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("fallback-%d", time.Now().UnixNano())
+	}
 	return fmt.Sprintf("%x-%x-%x-%x-%x", buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:])
 }
 

--- a/digitalidentity/centralauth/token_generator.go
+++ b/digitalidentity/centralauth/token_generator.go
@@ -1,0 +1,235 @@
+// Package centralauth provides utilities for generating central auth tokens
+// using the Yoti OAuth2 client_credentials grant.
+package centralauth
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/getyoti/yoti-go-sdk/v3/digitalidentity/requests"
+)
+
+const (
+	// DefaultAuthURL is the default Yoti authentication API URL.
+	DefaultAuthURL = "https://auth.api.yoti.com/v1/oauth/token"
+
+	// EnvAuthURL is the environment variable name for overriding the auth API URL.
+	EnvAuthURL = "YOTI_AUTH_URL"
+)
+
+// AuthenticationTokenResponse represents the response from the Yoti auth API
+// when generating a new authentication token.
+type AuthenticationTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope"`
+}
+
+// AuthenticationTokenGenerator generates authentication tokens by performing an
+// OAuth2 client_credentials grant using a PS384-signed JWT as the client assertion.
+// The generated token can then be used with BearerTokenStrategy for authorized requests.
+type AuthenticationTokenGenerator struct {
+	sdkID         string
+	key           *rsa.PrivateKey
+	jwtIDSupplier func() string
+	authAPIURL    string
+	httpClient    requests.HttpClient
+}
+
+// Generate creates a new authentication token with the specified scopes.
+// Scopes must not be empty.
+func (g *AuthenticationTokenGenerator) Generate(scopes []string) (*AuthenticationTokenResponse, error) {
+	if len(scopes) == 0 {
+		return nil, fmt.Errorf("scopes must not be empty")
+	}
+
+	jwt, err := g.createSignedJWT()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create signed JWT: %v", err)
+	}
+
+	formData := url.Values{
+		"grant_type":            {"client_credentials"},
+		"client_assertion_type": {"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"},
+		"scope":                 {strings.Join(scopes, " ")},
+		"client_assertion":      {jwt},
+	}
+
+	return g.performFormRequest(formData)
+}
+
+func (g *AuthenticationTokenGenerator) createSignedJWT() (string, error) {
+	sdkIDProperty := "sdk:" + g.sdkID
+	now := time.Now().Unix()
+	jwtID := g.jwtIDSupplier()
+
+	header := map[string]string{
+		"alg": "PS384",
+		"typ": "JWT",
+	}
+
+	claims := map[string]interface{}{
+		"iss": sdkIDProperty,
+		"sub": sdkIDProperty,
+		"jti": jwtID,
+		"aud": g.authAPIURL,
+		"exp": now + 300,
+		"iat": now,
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JWT header: %v", err)
+	}
+
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JWT claims: %v", err)
+	}
+
+	headerEncoded := base64.RawURLEncoding.EncodeToString(headerJSON)
+	claimsEncoded := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	signingInput := headerEncoded + "." + claimsEncoded
+
+	hash := sha512.Sum384([]byte(signingInput))
+	signature, err := rsa.SignPSS(rand.Reader, g.key, crypto.SHA384, hash[:], &rsa.PSSOptions{
+		SaltLength: rsa.PSSSaltLengthEqualsHash,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to sign JWT: %v", err)
+	}
+
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func (g *AuthenticationTokenGenerator) performFormRequest(formData url.Values) (*AuthenticationTokenResponse, error) {
+	req, err := http.NewRequest(http.MethodPost, g.authAPIURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth token request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("auth token request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read auth token response: %v", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("auth token request failed with HTTP %d: %s", resp.StatusCode, string(responseBody))
+	}
+
+	var tokenResponse AuthenticationTokenResponse
+	if err := json.Unmarshal(responseBody, &tokenResponse); err != nil {
+		return nil, fmt.Errorf("failed to deserialize authentication token response: %v", err)
+	}
+
+	return &tokenResponse, nil
+}
+
+// Builder provides a fluent API for constructing an AuthenticationTokenGenerator.
+type Builder struct {
+	sdkID         string
+	key           *rsa.PrivateKey
+	jwtIDSupplier func() string
+	authAPIURL    string
+	httpClient    requests.HttpClient
+}
+
+// NewBuilder creates a new Builder for AuthenticationTokenGenerator.
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+// WithSdkID sets the SDK ID for the generator.
+func (b *Builder) WithSdkID(sdkID string) *Builder {
+	b.sdkID = sdkID
+	return b
+}
+
+// WithKey sets the RSA private key for signing JWTs.
+func (b *Builder) WithKey(key *rsa.PrivateKey) *Builder {
+	b.key = key
+	return b
+}
+
+// WithJwtIDSupplier sets a custom function for generating JWT IDs.
+// By default, a UUID-like random string is used.
+func (b *Builder) WithJwtIDSupplier(supplier func() string) *Builder {
+	b.jwtIDSupplier = supplier
+	return b
+}
+
+// WithAuthAPIURL sets the authentication API URL.
+// By default, the YOTI_AUTH_URL environment variable is checked,
+// then falls back to DefaultAuthURL.
+func (b *Builder) WithAuthAPIURL(authAPIURL string) *Builder {
+	b.authAPIURL = authAPIURL
+	return b
+}
+
+// WithHTTPClient sets a custom HTTP client for making token requests.
+func (b *Builder) WithHTTPClient(httpClient requests.HttpClient) *Builder {
+	b.httpClient = httpClient
+	return b
+}
+
+func defaultJwtIDSupplier() string {
+	buf := make([]byte, 16)
+	_, _ = rand.Read(buf)
+	return fmt.Sprintf("%x-%x-%x-%x-%x", buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:])
+}
+
+// Build creates the AuthenticationTokenGenerator with the configured settings.
+func (b *Builder) Build() (*AuthenticationTokenGenerator, error) {
+	if b.sdkID == "" {
+		return nil, fmt.Errorf("SDK ID must not be empty")
+	}
+	if b.key == nil {
+		return nil, fmt.Errorf("private key must not be nil")
+	}
+
+	jwtIDSupplier := b.jwtIDSupplier
+	if jwtIDSupplier == nil {
+		jwtIDSupplier = defaultJwtIDSupplier
+	}
+
+	authAPIURL := b.authAPIURL
+	if authAPIURL == "" {
+		if envURL, exists := os.LookupEnv(EnvAuthURL); exists && envURL != "" {
+			authAPIURL = envURL
+		} else {
+			authAPIURL = DefaultAuthURL
+		}
+	}
+
+	httpClient := b.httpClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	return &AuthenticationTokenGenerator{
+		sdkID:         b.sdkID,
+		key:           b.key,
+		jwtIDSupplier: jwtIDSupplier,
+		authAPIURL:    authAPIURL,
+		httpClient:    httpClient,
+	}, nil
+}

--- a/digitalidentity/centralauth/token_generator_test.go
+++ b/digitalidentity/centralauth/token_generator_test.go
@@ -204,9 +204,7 @@ func parseFormValues(body string) (map[string]string, error) {
 	for _, pair := range pairs {
 		parts := strings.SplitN(pair, "=", 2)
 		if len(parts) == 2 {
-			key, _ := strings.CutPrefix(parts[0], "")
-			val, _ := strings.CutPrefix(parts[1], "")
-			result[key] = val
+			result[parts[0]] = parts[1]
 		}
 	}
 	return result, nil

--- a/digitalidentity/centralauth/token_generator_test.go
+++ b/digitalidentity/centralauth/token_generator_test.go
@@ -1,0 +1,213 @@
+package centralauth
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/getyoti/yoti-go-sdk/v3/test"
+	"gotest.tools/v3/assert"
+)
+
+type mockHTTPClient struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.do(req)
+}
+
+func TestBuilder_MissingSdkId(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	_, err := NewBuilder().WithKey(key).Build()
+	assert.ErrorContains(t, err, "SDK ID must not be empty")
+}
+
+func TestBuilder_MissingKey(t *testing.T) {
+	_, err := NewBuilder().WithSdkID("test-sdk-id").Build()
+	assert.ErrorContains(t, err, "private key must not be nil")
+}
+
+func TestBuilder_Success(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	gen, err := NewBuilder().WithSdkID("test-sdk-id").WithKey(key).Build()
+	assert.NilError(t, err)
+	assert.Check(t, gen != nil)
+}
+
+func TestBuilder_CustomAuthURL(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	gen, err := NewBuilder().
+		WithSdkID("test-sdk-id").
+		WithKey(key).
+		WithAuthAPIURL("https://custom.auth/v1/token").
+		Build()
+	assert.NilError(t, err)
+	assert.Equal(t, gen.authAPIURL, "https://custom.auth/v1/token")
+}
+
+func TestBuilder_DefaultAuthURL(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	gen, err := NewBuilder().WithSdkID("test-sdk-id").WithKey(key).Build()
+	assert.NilError(t, err)
+	assert.Equal(t, gen.authAPIURL, DefaultAuthURL)
+}
+
+func TestBuilder_CustomJwtIdSupplier(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	gen, err := NewBuilder().
+		WithSdkID("test-sdk-id").
+		WithKey(key).
+		WithJwtIDSupplier(func() string { return "fixed-id" }).
+		Build()
+	assert.NilError(t, err)
+	assert.Equal(t, gen.jwtIDSupplier(), "fixed-id")
+}
+
+func TestGenerate_EmptyScopes(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	gen, _ := NewBuilder().WithSdkID("test-sdk-id").WithKey(key).Build()
+	_, err := gen.Generate([]string{})
+	assert.ErrorContains(t, err, "scopes must not be empty")
+}
+
+func TestGenerate_NilScopes(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	gen, _ := NewBuilder().WithSdkID("test-sdk-id").WithKey(key).Build()
+	_, err := gen.Generate(nil)
+	assert.ErrorContains(t, err, "scopes must not be empty")
+}
+
+func TestGenerate_Success(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+
+	mockClient := &mockHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			// Verify request method and content type
+			assert.Equal(t, req.Method, http.MethodPost)
+			assert.Equal(t, req.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
+
+			// Verify form body
+			body, _ := io.ReadAll(req.Body)
+			bodyStr := string(body)
+			assert.Check(t, strings.Contains(bodyStr, "grant_type=client_credentials"))
+			assert.Check(t, strings.Contains(bodyStr, "scope=scope1+scope2"))
+			assert.Check(t, strings.Contains(bodyStr, "client_assertion_type="))
+			assert.Check(t, strings.Contains(bodyStr, "client_assertion="))
+
+			// Verify JWT structure (header.claims.signature)
+			// Extract client_assertion from form data
+			formValues, _ := io.ReadAll(strings.NewReader(bodyStr))
+			parsedForm, _ := parseFormValues(string(formValues))
+			jwtParts := strings.Split(parsedForm["client_assertion"], ".")
+			assert.Equal(t, len(jwtParts), 3)
+
+			return &http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(strings.NewReader(`{
+					"access_token": "test-token-123",
+					"expires_in": 3600,
+					"token_type": "Bearer",
+					"scope": "scope1 scope2"
+				}`)),
+			}, nil
+		},
+	}
+
+	gen, _ := NewBuilder().
+		WithSdkID("test-sdk-id").
+		WithKey(key).
+		WithAuthAPIURL("https://auth.test/v1/oauth/token").
+		WithHTTPClient(mockClient).
+		WithJwtIDSupplier(func() string { return "test-jwt-id" }).
+		Build()
+
+	resp, err := gen.Generate([]string{"scope1", "scope2"})
+	assert.NilError(t, err)
+	assert.Equal(t, resp.AccessToken, "test-token-123")
+	assert.Equal(t, resp.ExpiresIn, 3600)
+	assert.Equal(t, resp.TokenType, "Bearer")
+	assert.Equal(t, resp.Scope, "scope1 scope2")
+}
+
+func TestGenerate_HTTPError(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+
+	mockClient := &mockHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 401,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"invalid_client"}`)),
+			}, nil
+		},
+	}
+
+	gen, _ := NewBuilder().
+		WithSdkID("test-sdk-id").
+		WithKey(key).
+		WithAuthAPIURL("https://auth.test/v1/oauth/token").
+		WithHTTPClient(mockClient).
+		Build()
+
+	_, err := gen.Generate([]string{"scope1"})
+	assert.ErrorContains(t, err, "auth token request failed with HTTP 401")
+}
+
+func TestGenerate_NetworkError(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+
+	mockClient := &mockHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF
+		},
+	}
+
+	gen, _ := NewBuilder().
+		WithSdkID("test-sdk-id").
+		WithKey(key).
+		WithAuthAPIURL("https://auth.test/v1/oauth/token").
+		WithHTTPClient(mockClient).
+		Build()
+
+	_, err := gen.Generate([]string{"scope1"})
+	assert.ErrorContains(t, err, "auth token request failed")
+}
+
+func TestGenerate_InvalidResponseJSON(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+
+	mockClient := &mockHTTPClient{
+		do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(`not json`)),
+			}, nil
+		},
+	}
+
+	gen, _ := NewBuilder().
+		WithSdkID("test-sdk-id").
+		WithKey(key).
+		WithAuthAPIURL("https://auth.test/v1/oauth/token").
+		WithHTTPClient(mockClient).
+		Build()
+
+	_, err := gen.Generate([]string{"scope1"})
+	assert.ErrorContains(t, err, "failed to deserialize authentication token response")
+}
+
+// parseFormValues is a test helper to parse URL-encoded form data
+func parseFormValues(body string) (map[string]string, error) {
+	result := make(map[string]string)
+	pairs := strings.Split(body, "&")
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) == 2 {
+			key, _ := strings.CutPrefix(parts[0], "")
+			val, _ := strings.CutPrefix(parts[1], "")
+			result[key] = val
+		}
+	}
+	return result, nil
+}

--- a/digitalidentity/requests/auth_strategy.go
+++ b/digitalidentity/requests/auth_strategy.go
@@ -1,0 +1,86 @@
+// Package requests provides authentication strategies and HTTP request building
+// for the Yoti digital identity API.
+package requests
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+
+	"github.com/getyoti/yoti-go-sdk/v3/consts"
+)
+
+// AuthStrategy defines the interface for authentication mechanisms used when
+// making requests to the Yoti API. Implementations can provide either
+// signed-request authentication or bearer token (central auth) authentication.
+type AuthStrategy interface {
+	// CreateAuthHeaders returns the headers required for authentication.
+	// The httpMethod, endpoint, and body are provided to support signing-based
+	// strategies that need to compute a digest.
+	CreateAuthHeaders(httpMethod, endpoint string, body []byte) (map[string][]string, error)
+
+	// CreateQueryParams returns any query parameters required by the auth strategy.
+	// For signed requests this includes nonce, timestamp, and sdkID.
+	// For bearer token auth this returns an empty map.
+	CreateQueryParams() (map[string]string, error)
+}
+
+// BuildAuthRequest constructs an http.Request using the provided AuthStrategy
+// for authentication. It applies the strategy's headers and query params.
+func BuildAuthRequest(strategy AuthStrategy, httpMethod, baseURL, endpoint string, headers map[string][]string, body []byte) (*http.Request, error) {
+	queryParams, err := strategy.CreateQueryParams()
+	if err != nil {
+		return nil, err
+	}
+
+	// Build endpoint with query params
+	endpointWithParams := endpoint
+	if len(queryParams) > 0 {
+		separator := "?"
+		if strings.Contains(endpoint, "?") {
+			separator = "&"
+		}
+		for param, value := range queryParams {
+			endpointWithParams += separator + param + "=" + value
+			separator = "&"
+		}
+	}
+
+	authHeaders, err := strategy.CreateAuthHeaders(httpMethod, endpointWithParams, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct the HTTP request
+	var bodyReader *bytes.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	} else {
+		bodyReader = bytes.NewReader([]byte{})
+	}
+
+	request, err := http.NewRequest(httpMethod, baseURL+endpointWithParams, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply auth headers
+	for key, values := range authHeaders {
+		for _, value := range values {
+			request.Header.Add(key, value)
+		}
+	}
+
+	// Apply custom headers
+	for key, values := range headers {
+		for _, value := range values {
+			request.Header.Add(key, value)
+		}
+	}
+
+	// Add SDK identification headers
+	request.Header.Add("X-Yoti-SDK", consts.SDKIdentifier)
+	request.Header.Add("X-Yoti-SDK-Version", consts.SDKVersionIdentifier)
+
+	return request, nil
+}

--- a/digitalidentity/requests/auth_strategy.go
+++ b/digitalidentity/requests/auth_strategy.go
@@ -4,6 +4,7 @@ package requests
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -28,6 +29,10 @@ type AuthStrategy interface {
 // BuildAuthRequest constructs an http.Request using the provided AuthStrategy
 // for authentication. It applies the strategy's headers and query params.
 func BuildAuthRequest(strategy AuthStrategy, httpMethod, baseURL, endpoint string, headers map[string][]string, body []byte) (*http.Request, error) {
+	if strategy == nil {
+		return nil, errors.New("auth strategy must not be nil")
+	}
+
 	queryParams, err := strategy.CreateQueryParams()
 	if err != nil {
 		return nil, err

--- a/digitalidentity/requests/auth_strategy_test.go
+++ b/digitalidentity/requests/auth_strategy_test.go
@@ -1,0 +1,125 @@
+package requests
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/getyoti/yoti-go-sdk/v3/test"
+	"gotest.tools/v3/assert"
+)
+
+func TestBearerTokenStrategy_RejectsEmptyToken(t *testing.T) {
+	_, err := NewBearerTokenStrategy("")
+	assert.ErrorContains(t, err, "authentication token must not be empty")
+}
+
+func TestBearerTokenStrategy_CreateAuthHeaders(t *testing.T) {
+	strategy, err := NewBearerTokenStrategy("my-test-token")
+	assert.NilError(t, err)
+
+	headers, err := strategy.CreateAuthHeaders(http.MethodGet, "/v2/sessions", nil)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, headers, map[string][]string{
+		"Authorization": {"Bearer my-test-token"},
+	})
+}
+
+func TestBearerTokenStrategy_CreateQueryParams_Empty(t *testing.T) {
+	strategy, err := NewBearerTokenStrategy("my-test-token")
+	assert.NilError(t, err)
+
+	params, err := strategy.CreateQueryParams()
+	assert.NilError(t, err)
+	assert.Equal(t, len(params), 0)
+}
+
+func TestSignedRequestStrategy_RejectsNilKey(t *testing.T) {
+	_, err := NewSignedRequestStrategy(nil, "sdkId")
+	assert.ErrorContains(t, err, "private key must not be nil")
+}
+
+func TestSignedRequestStrategy_RejectsEmptySdkId(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	_, err := NewSignedRequestStrategy(key, "")
+	assert.ErrorContains(t, err, "client SDK ID must not be empty")
+}
+
+func TestSignedRequestStrategy_CreateAuthHeaders(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	strategy, err := NewSignedRequestStrategy(key, "test-sdk-id")
+	assert.NilError(t, err)
+
+	headers, err := strategy.CreateAuthHeaders(http.MethodGet, "/v2/sessions?nonce=abc&timestamp=123", nil)
+	assert.NilError(t, err)
+
+	// Should have X-Yoti-Auth-Digest and X-Yoti-Auth-Id
+	assert.Equal(t, len(headers["X-Yoti-Auth-Digest"]), 1)
+	assert.Equal(t, headers["X-Yoti-Auth-Id"][0], "test-sdk-id")
+
+	// Digest should be non-empty base64
+	assert.Check(t, len(headers["X-Yoti-Auth-Digest"][0]) > 0)
+}
+
+func TestSignedRequestStrategy_CreateQueryParams(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	strategy, err := NewSignedRequestStrategy(key, "test-sdk-id")
+	assert.NilError(t, err)
+
+	params, err := strategy.CreateQueryParams()
+	assert.NilError(t, err)
+
+	// Should contain nonce, timestamp, sdkID
+	assert.Check(t, params["nonce"] != "")
+	assert.Check(t, params["timestamp"] != "")
+	assert.Equal(t, params["sdkID"], "test-sdk-id")
+}
+
+func TestBuildAuthRequest_BearerToken(t *testing.T) {
+	strategy, err := NewBearerTokenStrategy("test-bearer-token")
+	assert.NilError(t, err)
+
+	request, err := BuildAuthRequest(strategy, http.MethodGet, "https://api.yoti.com", "/v2/sessions", JSONHeaders(), nil)
+	assert.NilError(t, err)
+
+	// Should have Authorization header with bearer token
+	assert.Equal(t, request.Header.Get("Authorization"), "Bearer test-bearer-token")
+
+	// Should NOT have X-Yoti-Auth-Digest
+	assert.Equal(t, request.Header.Get("X-Yoti-Auth-Digest"), "")
+
+	// Should have SDK headers
+	assert.Equal(t, request.Header.Get("X-Yoti-SDK"), "Go")
+	assert.Check(t, request.Header.Get("X-Yoti-SDK-Version") != "")
+
+	// Should have JSON headers
+	assert.Equal(t, request.Header.Get("Content-Type"), "application/json")
+
+	// URL should have no query params (bearer doesn't add them)
+	assert.Equal(t, request.URL.RawQuery, "")
+	assert.Equal(t, request.URL.Path, "/v2/sessions")
+}
+
+func TestBuildAuthRequest_SignedRequest(t *testing.T) {
+	key := test.GetValidKey("../../test/test-key.pem")
+	strategy, err := NewSignedRequestStrategy(key, "test-sdk-id")
+	assert.NilError(t, err)
+
+	request, err := BuildAuthRequest(strategy, http.MethodPost, "https://api.yoti.com", "/v2/sessions", JSONHeaders(), []byte(`{"policy":{}}`))
+	assert.NilError(t, err)
+
+	// Should have X-Yoti-Auth-Digest
+	assert.Check(t, request.Header.Get("X-Yoti-Auth-Digest") != "")
+
+	// Should have X-Yoti-Auth-Id
+	assert.Equal(t, request.Header.Get("X-Yoti-Auth-Id"), "test-sdk-id")
+
+	// Should NOT have Authorization bearer header
+	assert.Equal(t, request.Header.Get("Authorization"), "")
+
+	// URL should have query params (nonce, timestamp, sdkID)
+	query := request.URL.Query()
+	assert.Check(t, query.Get("nonce") != "")
+	assert.Check(t, query.Get("timestamp") != "")
+	assert.Equal(t, query.Get("sdkID"), "test-sdk-id")
+}

--- a/digitalidentity/requests/bearer_token_strategy.go
+++ b/digitalidentity/requests/bearer_token_strategy.go
@@ -1,0 +1,33 @@
+package requests
+
+import (
+	"errors"
+)
+
+// BearerTokenStrategy implements AuthStrategy using a Bearer token for
+// central auth. It sets the Authorization header with the provided token
+// and does not add any query parameters.
+type BearerTokenStrategy struct {
+	token string
+}
+
+// NewBearerTokenStrategy creates a new BearerTokenStrategy with the given token.
+// Returns an error if the token is empty.
+func NewBearerTokenStrategy(token string) (*BearerTokenStrategy, error) {
+	if token == "" {
+		return nil, errors.New("authentication token must not be empty")
+	}
+	return &BearerTokenStrategy{token: token}, nil
+}
+
+// CreateAuthHeaders returns an Authorization header with a Bearer token.
+func (s *BearerTokenStrategy) CreateAuthHeaders(httpMethod, endpoint string, body []byte) (map[string][]string, error) {
+	return map[string][]string{
+		"Authorization": {"Bearer " + s.token},
+	}, nil
+}
+
+// CreateQueryParams returns an empty map as bearer auth does not require query parameters.
+func (s *BearerTokenStrategy) CreateQueryParams() (map[string]string, error) {
+	return map[string]string{}, nil
+}

--- a/digitalidentity/requests/signed_request_strategy.go
+++ b/digitalidentity/requests/signed_request_strategy.go
@@ -1,14 +1,8 @@
 package requests
 
 import (
-	"crypto"
-	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"strconv"
-	"time"
 )
 
 // SignedRequestStrategy implements AuthStrategy using Yoti's signed-request
@@ -32,11 +26,14 @@ func NewSignedRequestStrategy(key *rsa.PrivateKey, clientSdkID string) (*SignedR
 }
 
 // CreateAuthHeaders generates the X-Yoti-Auth-Digest and X-Yoti-Auth-Id headers
-// by signing the request digest with the RSA private key.
+// by signing the request digest with the RSA private key. The digest
+// generation and signing are delegated to SignedRequest, which already
+// implements the digest/signature scheme required by the Yoti API.
 func (s *SignedRequestStrategy) CreateAuthHeaders(httpMethod, endpoint string, body []byte) (map[string][]string, error) {
-	digest := generateDigest(httpMethod, endpoint, body)
+	msg := SignedRequest{Key: s.key, HTTPMethod: httpMethod, Body: body}
+	digest := msg.generateDigest(endpoint)
 
-	signedDigest, err := signDigest(s.key, []byte(digest))
+	signedDigest, err := msg.signDigest([]byte(digest))
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign digest: %v", err)
 	}
@@ -50,48 +47,14 @@ func (s *SignedRequestStrategy) CreateAuthHeaders(httpMethod, endpoint string, b
 // CreateQueryParams returns the nonce, timestamp, and sdkID query parameters
 // required for signed-request authentication.
 func (s *SignedRequestStrategy) CreateQueryParams() (map[string]string, error) {
-	nonce, err := generateNonce()
+	nonce, err := getNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate nonce: %v", err)
 	}
 
 	return map[string]string{
 		"nonce":     nonce,
-		"timestamp": generateTimestamp(),
+		"timestamp": getTimestamp(),
 		"sdkID":     s.clientSdkID,
 	}, nil
-}
-
-func generateDigest(httpMethod, endpoint string, body []byte) string {
-	if body != nil {
-		return fmt.Sprintf(
-			"%s&%s&%s",
-			httpMethod,
-			endpoint,
-			base64.StdEncoding.EncodeToString(body),
-		)
-	}
-	return fmt.Sprintf("%s&%s", httpMethod, endpoint)
-}
-
-func signDigest(key *rsa.PrivateKey, digest []byte) (string, error) {
-	hash := sha256.Sum256(digest)
-	signed, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hash[:])
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(signed), nil
-}
-
-func generateNonce() (string, error) {
-	nonce := make([]byte, 16)
-	_, err := rand.Read(nonce)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%X-%X-%X-%X-%X", nonce[0:4], nonce[4:6], nonce[6:8], nonce[8:10], nonce[10:]), nil
-}
-
-func generateTimestamp() string {
-	return strconv.FormatInt(time.Now().Unix()*1000, 10)
 }

--- a/digitalidentity/requests/signed_request_strategy.go
+++ b/digitalidentity/requests/signed_request_strategy.go
@@ -1,0 +1,97 @@
+package requests
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// SignedRequestStrategy implements AuthStrategy using Yoti's signed-request
+// authentication. It generates a digest signature using the RSA private key
+// and includes nonce, timestamp, and sdkID as query parameters.
+type SignedRequestStrategy struct {
+	key         *rsa.PrivateKey
+	clientSdkID string
+}
+
+// NewSignedRequestStrategy creates a new SignedRequestStrategy with the given
+// RSA private key and SDK ID.
+func NewSignedRequestStrategy(key *rsa.PrivateKey, clientSdkID string) (*SignedRequestStrategy, error) {
+	if key == nil {
+		return nil, fmt.Errorf("private key must not be nil")
+	}
+	if clientSdkID == "" {
+		return nil, fmt.Errorf("client SDK ID must not be empty")
+	}
+	return &SignedRequestStrategy{key: key, clientSdkID: clientSdkID}, nil
+}
+
+// CreateAuthHeaders generates the X-Yoti-Auth-Digest and X-Yoti-Auth-Id headers
+// by signing the request digest with the RSA private key.
+func (s *SignedRequestStrategy) CreateAuthHeaders(httpMethod, endpoint string, body []byte) (map[string][]string, error) {
+	digest := generateDigest(httpMethod, endpoint, body)
+
+	signedDigest, err := signDigest(s.key, []byte(digest))
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign digest: %v", err)
+	}
+
+	return map[string][]string{
+		"X-Yoti-Auth-Digest": {signedDigest},
+		"X-Yoti-Auth-Id":     {s.clientSdkID},
+	}, nil
+}
+
+// CreateQueryParams returns the nonce, timestamp, and sdkID query parameters
+// required for signed-request authentication.
+func (s *SignedRequestStrategy) CreateQueryParams() (map[string]string, error) {
+	nonce, err := generateNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %v", err)
+	}
+
+	return map[string]string{
+		"nonce":     nonce,
+		"timestamp": generateTimestamp(),
+		"sdkID":     s.clientSdkID,
+	}, nil
+}
+
+func generateDigest(httpMethod, endpoint string, body []byte) string {
+	if body != nil {
+		return fmt.Sprintf(
+			"%s&%s&%s",
+			httpMethod,
+			endpoint,
+			base64.StdEncoding.EncodeToString(body),
+		)
+	}
+	return fmt.Sprintf("%s&%s", httpMethod, endpoint)
+}
+
+func signDigest(key *rsa.PrivateKey, digest []byte) (string, error) {
+	hash := sha256.Sum256(digest)
+	signed, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hash[:])
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(signed), nil
+}
+
+func generateNonce() (string, error) {
+	nonce := make([]byte, 16)
+	_, err := rand.Read(nonce)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%X-%X-%X-%X-%X", nonce[0:4], nonce[4:6], nonce[6:8], nonce[8:10], nonce[10:]), nil
+}
+
+func generateTimestamp() string {
+	return strconv.FormatInt(time.Now().Unix()*1000, 10)
+}

--- a/digitalidentity/service.go
+++ b/digitalidentity/service.go
@@ -20,12 +20,12 @@ const identitySessionQrCodeCreation = "/v2/sessions/%s/qr-codes"
 const identitySessionQrCodeRetrieval = "/v2/qr-codes/%s"
 const identitySessionReceiptRetrieval = "/v2/receipts/%s"
 const identitySessionReceiptKeyRetrieval = "/v2/wrapped-item-keys/%s"
-const errorFailedToGetSignedRequest = "failed to get signed request: %v"
+const errorFailedToBuildRequest = "failed to build request: %v"
 const errorFailedToExecuteRequest = "failed to execute request: %v"
 const errorFailedToReadBody = "failed to read response body: %v"
 
 // CreateShareSession creates session using the supplied session specification
-func CreateShareSession(httpClient requests.HttpClient, shareSessionRequest *ShareSessionRequest, clientSdkId, apiUrl string, key *rsa.PrivateKey) (*ShareSession, error) {
+func CreateShareSession(httpClient requests.HttpClient, shareSessionRequest *ShareSessionRequest, apiURL string, strategy requests.AuthStrategy) (*ShareSession, error) {
 	endpoint := identitySessionCreationEndpoint
 
 	payload, err := shareSessionRequest.MarshalJSON()
@@ -33,17 +33,9 @@ func CreateShareSession(httpClient requests.HttpClient, shareSessionRequest *Sha
 		return nil, err
 	}
 
-	request, err := requests.SignedRequest{
-		Key:        key,
-		HTTPMethod: http.MethodPost,
-		BaseURL:    apiUrl,
-		Endpoint:   endpoint,
-		Headers:    requests.AuthHeader(clientSdkId),
-		Body:       payload,
-		Params:     map[string]string{"sdkID": clientSdkId},
-	}.Request()
+	request, err := requests.BuildAuthRequest(strategy, http.MethodPost, apiURL, endpoint, requests.JSONHeaders(), payload)
 	if err != nil {
-		return nil, fmt.Errorf(errorFailedToGetSignedRequest, err)
+		return nil, fmt.Errorf(errorFailedToBuildRequest, err)
 	}
 
 	response, err := requests.Execute(httpClient, request)
@@ -63,19 +55,12 @@ func CreateShareSession(httpClient requests.HttpClient, shareSessionRequest *Sha
 }
 
 // GetShareSession get session info using the supplied sessionID parameter
-func GetShareSession(httpClient requests.HttpClient, sessionID string, clientSdkId, apiUrl string, key *rsa.PrivateKey) (*ShareSession, error) {
+func GetShareSession(httpClient requests.HttpClient, sessionID string, apiURL string, strategy requests.AuthStrategy) (*ShareSession, error) {
 	endpoint := fmt.Sprintf(identitySessionRetrieval, sessionID)
 
-	request, err := requests.SignedRequest{
-		Key:        key,
-		HTTPMethod: http.MethodGet,
-		BaseURL:    apiUrl,
-		Endpoint:   endpoint,
-		Headers:    requests.AuthHeader(clientSdkId),
-		Params:     map[string]string{"sdkID": clientSdkId},
-	}.Request()
+	request, err := requests.BuildAuthRequest(strategy, http.MethodGet, apiURL, endpoint, requests.JSONHeaders(), nil)
 	if err != nil {
-		return nil, fmt.Errorf(errorFailedToGetSignedRequest, err)
+		return nil, fmt.Errorf(errorFailedToBuildRequest, err)
 	}
 
 	response, err := requests.Execute(httpClient, request)
@@ -94,20 +79,12 @@ func GetShareSession(httpClient requests.HttpClient, sessionID string, clientSdk
 }
 
 // CreateShareQrCode generates a sharing qr code using the supplied sessionID parameter
-func CreateShareQrCode(httpClient requests.HttpClient, sessionID string, clientSdkId, apiUrl string, key *rsa.PrivateKey) (*QrCode, error) {
+func CreateShareQrCode(httpClient requests.HttpClient, sessionID string, apiURL string, strategy requests.AuthStrategy) (*QrCode, error) {
 	endpoint := fmt.Sprintf(identitySessionQrCodeCreation, sessionID)
 
-	request, err := requests.SignedRequest{
-		Key:        key,
-		HTTPMethod: http.MethodPost,
-		BaseURL:    apiUrl,
-		Endpoint:   endpoint,
-		Headers:    requests.AuthHeader(clientSdkId),
-		Body:       nil,
-		Params:     map[string]string{"sdkID": clientSdkId},
-	}.Request()
+	request, err := requests.BuildAuthRequest(strategy, http.MethodPost, apiURL, endpoint, requests.JSONHeaders(), nil)
 	if err != nil {
-		return nil, fmt.Errorf(errorFailedToGetSignedRequest, err)
+		return nil, fmt.Errorf(errorFailedToBuildRequest, err)
 	}
 
 	response, err := requests.Execute(httpClient, request)
@@ -126,18 +103,12 @@ func CreateShareQrCode(httpClient requests.HttpClient, sessionID string, clientS
 }
 
 // GetShareSessionQrCode is used to fetch the qr code by  id.
-func GetShareSessionQrCode(httpClient requests.HttpClient, qrCodeId string, clientSdkId, apiUrl string, key *rsa.PrivateKey) (fetchedQrCode ShareSessionQrCode, err error) {
-	endpoint := fmt.Sprintf(identitySessionQrCodeRetrieval, qrCodeId)
-	headers := requests.AuthHeader(clientSdkId)
-	request, err := requests.SignedRequest{
-		Key:        key,
-		HTTPMethod: http.MethodGet,
-		BaseURL:    apiUrl,
-		Endpoint:   endpoint,
-		Headers:    headers,
-	}.Request()
+func GetShareSessionQrCode(httpClient requests.HttpClient, qrCodeID string, apiURL string, strategy requests.AuthStrategy) (fetchedQrCode ShareSessionQrCode, err error) {
+	endpoint := fmt.Sprintf(identitySessionQrCodeRetrieval, qrCodeID)
+
+	request, err := requests.BuildAuthRequest(strategy, http.MethodGet, apiURL, endpoint, requests.JSONHeaders(), nil)
 	if err != nil {
-		return fetchedQrCode, fmt.Errorf(errorFailedToGetSignedRequest, err)
+		return fetchedQrCode, fmt.Errorf(errorFailedToBuildRequest, err)
 	}
 
 	response, err := requests.Execute(httpClient, request)
@@ -156,21 +127,14 @@ func GetShareSessionQrCode(httpClient requests.HttpClient, qrCodeId string, clie
 	return fetchedQrCode, err
 }
 
-// GetReceipt fetches receipt info using a receipt id.
-func getReceipt(httpClient requests.HttpClient, receiptId string, clientSdkId, apiUrl string, key *rsa.PrivateKey) (receipt ReceiptResponse, err error) {
-	receiptUrl := requests.Base64ToBase64URL(receiptId)
-	endpoint := fmt.Sprintf(identitySessionReceiptRetrieval, receiptUrl)
+// getReceipt fetches receipt info using a receipt id.
+func getReceipt(httpClient requests.HttpClient, receiptID string, apiURL string, strategy requests.AuthStrategy) (receipt ReceiptResponse, err error) {
+	receiptURL := requests.Base64ToBase64URL(receiptID)
+	endpoint := fmt.Sprintf(identitySessionReceiptRetrieval, receiptURL)
 
-	headers := requests.AuthHeader(clientSdkId)
-	request, err := requests.SignedRequest{
-		Key:        key,
-		HTTPMethod: http.MethodGet,
-		BaseURL:    apiUrl,
-		Endpoint:   endpoint,
-		Headers:    headers,
-	}.Request()
+	request, err := requests.BuildAuthRequest(strategy, http.MethodGet, apiURL, endpoint, requests.JSONHeaders(), nil)
 	if err != nil {
-		return receipt, fmt.Errorf(errorFailedToGetSignedRequest, err)
+		return receipt, fmt.Errorf(errorFailedToBuildRequest, err)
 	}
 
 	response, err := requests.Execute(httpClient, request)
@@ -189,19 +153,13 @@ func getReceipt(httpClient requests.HttpClient, receiptId string, clientSdkId, a
 	return receipt, err
 }
 
-// GetReceiptItemKey retrieves the receipt item key for a receipt item key id.
-func getReceiptItemKey(httpClient requests.HttpClient, receiptItemKeyId string, clientSdkId, apiUrl string, key *rsa.PrivateKey) (receiptItemKey ReceiptItemKeyResponse, err error) {
-	endpoint := fmt.Sprintf(identitySessionReceiptKeyRetrieval, receiptItemKeyId)
-	headers := requests.AuthHeader(clientSdkId)
-	request, err := requests.SignedRequest{
-		Key:        key,
-		HTTPMethod: http.MethodGet,
-		BaseURL:    apiUrl,
-		Endpoint:   endpoint,
-		Headers:    headers,
-	}.Request()
+// getReceiptItemKey retrieves the receipt item key for a receipt item key id.
+func getReceiptItemKey(httpClient requests.HttpClient, receiptItemKeyID string, apiURL string, strategy requests.AuthStrategy) (receiptItemKey ReceiptItemKeyResponse, err error) {
+	endpoint := fmt.Sprintf(identitySessionReceiptKeyRetrieval, receiptItemKeyID)
+
+	request, err := requests.BuildAuthRequest(strategy, http.MethodGet, apiURL, endpoint, requests.JSONHeaders(), nil)
 	if err != nil {
-		return receiptItemKey, fmt.Errorf(errorFailedToGetSignedRequest, err)
+		return receiptItemKey, fmt.Errorf(errorFailedToBuildRequest, err)
 	}
 
 	response, err := requests.Execute(httpClient, request)
@@ -220,8 +178,8 @@ func getReceiptItemKey(httpClient requests.HttpClient, receiptItemKeyId string, 
 	return receiptItemKey, err
 }
 
-func GetShareReceipt(httpClient requests.HttpClient, receiptId string, clientSdkId, apiUrl string, key *rsa.PrivateKey) (receipt SharedReceiptResponse, err error) {
-	receiptResponse, err := getReceipt(httpClient, receiptId, clientSdkId, apiUrl, key)
+func GetShareReceipt(httpClient requests.HttpClient, receiptID string, apiURL string, strategy requests.AuthStrategy, key *rsa.PrivateKey) (receipt SharedReceiptResponse, err error) {
+	receiptResponse, err := getReceipt(httpClient, receiptID, apiURL, strategy)
 	if err != nil {
 		return receipt, fmt.Errorf("failed to get receipt: %v", err)
 	}
@@ -238,7 +196,7 @@ func GetShareReceipt(httpClient requests.HttpClient, receiptId string, clientSdk
 
 	itemKeyId := receiptResponse.WrappedItemKeyId
 
-	encryptedItemKeyResponse, err := getReceiptItemKey(httpClient, itemKeyId, clientSdkId, apiUrl, key)
+	encryptedItemKeyResponse, err := getReceiptItemKey(httpClient, itemKeyId, apiURL, strategy)
 	if err != nil {
 		return receipt, fmt.Errorf("failed to get receipt item key: %v", err)
 	}

--- a/digitalidentity/service_test.go
+++ b/digitalidentity/service_test.go
@@ -4,15 +4,24 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"github.com/getyoti/yoti-go-sdk/v3/yotiprotoattr"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/getyoti/yoti-go-sdk/v3/digitalidentity/requests"
 	"github.com/getyoti/yoti-go-sdk/v3/test"
+	"github.com/getyoti/yoti-go-sdk/v3/yotiprotoattr"
 	"gotest.tools/v3/assert"
 )
+
+func mustSignedStrategy(key *rsa.PrivateKey, sdkID string) requests.AuthStrategy {
+	s, err := requests.NewSignedRequestStrategy(key, sdkID)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
 
 type mockHTTPClient struct {
 	do func(*http.Request) (*http.Response, error)
@@ -49,7 +58,7 @@ func ExampleCreateShareSession() {
 		return
 	}
 
-	result, err := CreateShareSession(client, &session, "sdkId", "https://apiurl", key)
+	result, err := CreateShareSession(client, &session, "https://apiurl", mustSignedStrategy(key, "sdkId"))
 
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())
@@ -92,7 +101,7 @@ func createShareSessionWithErrorResponse(statusCode int, responseBody string) (*
 		return nil, err
 	}
 
-	return CreateShareSession(client, &session, "sdkId", "https://apiurl", key)
+	return CreateShareSession(client, &session, "https://apiurl", mustSignedStrategy(key, "sdkId"))
 }
 
 func TestGetShareSession(t *testing.T) {
@@ -109,7 +118,7 @@ func TestGetShareSession(t *testing.T) {
 		},
 	}
 
-	_, err := GetShareSession(client, mockSessionID, mockClientSdkId, mockApiUrl, key)
+	_, err := GetShareSession(client, mockSessionID, mockApiUrl, mustSignedStrategy(key, mockClientSdkId))
 	assert.NilError(t, err)
 
 }
@@ -127,7 +136,7 @@ func TestCreateShareQrCode(t *testing.T) {
 		},
 	}
 
-	_, err := CreateShareQrCode(client, mockSessionID, "sdkId", "https://apiurl", key)
+	_, err := CreateShareQrCode(client, mockSessionID, "https://apiurl", mustSignedStrategy(key, "sdkId"))
 	assert.NilError(t, err)
 }
 
@@ -145,7 +154,7 @@ func TestGetQrCode(t *testing.T) {
 		},
 	}
 
-	_, err := GetShareSessionQrCode(client, mockQrId, mockClientSdkId, mockApiUrl, key)
+	_, err := GetShareSessionQrCode(client, mockQrId, mockApiUrl, mustSignedStrategy(key, mockClientSdkId))
 	assert.NilError(t, err)
 
 }
@@ -173,7 +182,7 @@ func TestGetShareReceipt_GetReceiptError(t *testing.T) {
 		},
 	}
 
-	_, err := GetShareReceipt(client, "receiptId", "sdkId", "https://apiurl", key)
+	_, err := GetShareReceipt(client, "receiptId", "https://apiurl", mustSignedStrategy(key, "sdkId"), key)
 	assert.ErrorContains(t, err, "failed to get receipt")
 }
 
@@ -199,7 +208,7 @@ func TestGetShareReceipt_GetReceiptItemKeyError(t *testing.T) {
 		},
 	}
 
-	_, err := GetShareReceipt(client, "receiptId", "sdkId", "https://apiurl", key)
+	_, err := GetShareReceipt(client, "receiptId", "https://apiurl", mustSignedStrategy(key, "sdkId"), key)
 	assert.ErrorContains(t, err, "failed to get receipt")
 }
 
@@ -217,7 +226,7 @@ func TestGetFailureReceipt(t *testing.T) {
 		},
 	}
 
-	r, err := GetShareReceipt(client, mockQrId, mockClientSdkId, mockApiUrl, key)
+	r, err := GetShareReceipt(client, mockQrId, mockApiUrl, mustSignedStrategy(key, mockClientSdkId), key)
 	assert.Equal(t, len(r.ErrorReason.RequirementsNotMetDetails), 1)
 	assert.NilError(t, err)
 


### PR DESCRIPTION
## Summary

Adds central auth (Bearer token) support to the Go SDK alongside existing signed-request authentication, allowing Relying Businesses to choose their authentication scheme.

### Modified: DigitalIdentityClient (`digital_identity_client.go`)

- Added `AuthToken` field (mutually exclusive with `SdkID`/`Key`)
- Added `NewDigitalIdentityClientWithToken(authToken string)` constructor
- Added `GetAuthStrategy()` method with mutual exclusion validation
- All client methods now resolve auth strategy internally before making requests

### Modified: Service Functions (`digitalidentity/service.go`)

- All service functions (`CreateShareSession`, `GetShareSession`, `CreateShareQrCode`, `GetShareSessionQrCode`, `GetShareReceipt`) now accept `AuthStrategy` instead of raw `clientSdkId + key` parameters
- `GetShareReceipt` retains `key *rsa.PrivateKey` parameter for receipt decryption (separate from auth)

## Usage

### Bearer Token (Central Auth)

```go
// Option 1: Use a pre-generated token
client, err := yoti.NewDigitalIdentityClientWithToken("your-bearer-token")

// Option 2: Generate a token using OAuth2 client_credentials
generator, err := centralauth.NewBuilder().
    WithSdkId("your-sdk-id").
    WithKey(rsaPrivateKey).
    Build()

tokenResp, err := generator.Generate([]string{"profile:read", "sessions:create"})
client, err := yoti.NewDigitalIdentityClientWithToken(tokenResp.AccessToken)