### PR TITLE
SDK-2761: Go - Support handled_check_limit property for checks in IDV sandbox - go

### DIFF
--- a/docscan/sandbox/request/check/check.go
+++ b/docscan/sandbox/request/check/check.go
@@ -5,12 +5,14 @@ import (
 )
 
 type check struct {
-	Result checkResult `json:"result"`
+	Result            checkResult `json:"result"`
+	HandledCheckLimit *int        `json:"handled_check_limit,omitempty"`
 }
 
 type checkBuilder struct {
-	recommendation *report.Recommendation
-	breakdowns     []*report.Breakdown
+	recommendation    *report.Recommendation
+	breakdowns        []*report.Breakdown
+	handledCheckLimit *int
 }
 
 type checkResult struct {
@@ -30,6 +32,10 @@ func (b *checkBuilder) withBreakdown(breakdown *report.Breakdown) {
 	b.breakdowns = append(b.breakdowns, breakdown)
 }
 
+func (b *checkBuilder) withHandledCheckLimit(limit int) {
+	b.handledCheckLimit = &limit
+}
+
 func (b *checkBuilder) build() *check {
 	return &check{
 		Result: checkResult{
@@ -38,5 +44,6 @@ func (b *checkBuilder) build() *check {
 				Breakdown:      b.breakdowns,
 			},
 		},
+		HandledCheckLimit: b.handledCheckLimit,
 	}
 }

--- a/docscan/sandbox/request/check/check.go
+++ b/docscan/sandbox/request/check/check.go
@@ -33,7 +33,8 @@ func (b *checkBuilder) withBreakdown(breakdown *report.Breakdown) {
 }
 
 func (b *checkBuilder) withHandledCheckLimit(limit int) {
-	b.handledCheckLimit = &limit
+	b.handledCheckLimit = new(int)
+	*b.handledCheckLimit = limit
 }
 
 func (b *checkBuilder) build() *check {

--- a/docscan/sandbox/request/check/document_authenticity_check.go
+++ b/docscan/sandbox/request/check/document_authenticity_check.go
@@ -38,6 +38,12 @@ func (b *DocumentAuthenticityCheckBuilder) WithDocumentFilter(filter *filter.Doc
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check response is used before advancing to the next
+func (b *DocumentAuthenticityCheckBuilder) WithHandledCheckLimit(limit int) *DocumentAuthenticityCheckBuilder {
+	b.withHandledCheckLimit(limit)
+	return b
+}
+
 // Build creates a new DocumentAuthenticityCheck
 func (b *DocumentAuthenticityCheckBuilder) Build() (*DocumentAuthenticityCheck, error) {
 	return &DocumentAuthenticityCheck{

--- a/docscan/sandbox/request/check/document_face_match_check.go
+++ b/docscan/sandbox/request/check/document_face_match_check.go
@@ -38,6 +38,12 @@ func (b *DocumentFaceMatchCheckBuilder) WithDocumentFilter(filter *filter.Docume
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check response is used before advancing to the next
+func (b *DocumentFaceMatchCheckBuilder) WithHandledCheckLimit(limit int) *DocumentFaceMatchCheckBuilder {
+	b.withHandledCheckLimit(limit)
+	return b
+}
+
 // Build creates a new DocumentFaceMatchCheck
 func (b *DocumentFaceMatchCheckBuilder) Build() (*DocumentFaceMatchCheck, error) {
 	return &DocumentFaceMatchCheck{

--- a/docscan/sandbox/request/check/document_text_data_check.go
+++ b/docscan/sandbox/request/check/document_text_data_check.go
@@ -61,6 +61,12 @@ func (b *DocumentTextDataCheckBuilder) WithDocumentFields(documentFields map[str
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check response is used before advancing to the next
+func (b *DocumentTextDataCheckBuilder) WithHandledCheckLimit(limit int) *DocumentTextDataCheckBuilder {
+	b.withHandledCheckLimit(limit)
+	return b
+}
+
 // Build creates a new DocumentTextDataCheck
 func (b *DocumentTextDataCheckBuilder) Build() (*DocumentTextDataCheck, error) {
 	docCheck := b.documentCheckBuilder.build()

--- a/docscan/sandbox/request/check/handled_check_limit_test.go
+++ b/docscan/sandbox/request/check/handled_check_limit_test.go
@@ -63,6 +63,17 @@ func TestHandledCheckLimit_IncludedWhenSet(t *testing.T) {
 	}
 
 	assertHandledCheckLimitInJSON(t, c, 5)
+
+	// Zero is a valid limit and must still be serialized (should not be omitted).
+	cZero, err := NewThirdPartyIdentityCheckBuilder().
+		WithRecommendation(recommendation).
+		WithHandledCheckLimit(0).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error building check (zero limit): %v", err)
+	}
+
+	assertHandledCheckLimitInJSON(t, cZero, 0)
 }
 
 func TestHandledCheckLimit_OmittedWhenNotSet(t *testing.T) {

--- a/docscan/sandbox/request/check/handled_check_limit_test.go
+++ b/docscan/sandbox/request/check/handled_check_limit_test.go
@@ -1,0 +1,230 @@
+package check
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/check/report"
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/sandbox/request/filter"
+)
+
+// ExampleDocumentAuthenticityCheckBuilder_withHandledCheckLimit shows handled_check_limit serialization
+func ExampleDocumentAuthenticityCheckBuilder_withHandledCheckLimit() {
+	recommendation, err := report.NewRecommendationBuilder().
+		WithValue("some_value").
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	docFilter, err := filter.NewDocumentFilterBuilder().Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	check, err := NewDocumentAuthenticityCheckBuilder().
+		WithRecommendation(recommendation).
+		WithDocumentFilter(docFilter).
+		WithHandledCheckLimit(3).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(check)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"result":{"report":{"recommendation":{"value":"some_value"}}},"handled_check_limit":3,"document_filter":{"document_types":[],"country_codes":[]}}
+}
+
+func TestHandledCheckLimit_IncludedWhenSet(t *testing.T) {
+	recommendation, err := report.NewRecommendationBuilder().
+		WithValue("APPROVE").
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error building recommendation: %v", err)
+	}
+
+	c, err := NewThirdPartyIdentityCheckBuilder().
+		WithRecommendation(recommendation).
+		WithHandledCheckLimit(5).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error building check: %v", err)
+	}
+
+	assertHandledCheckLimitInJSON(t, c, 5)
+}
+
+func TestHandledCheckLimit_OmittedWhenNotSet(t *testing.T) {
+	recommendation, err := report.NewRecommendationBuilder().
+		WithValue("APPROVE").
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error building recommendation: %v", err)
+	}
+
+	c, err := NewThirdPartyIdentityCheckBuilder().
+		WithRecommendation(recommendation).
+		Build()
+	if err != nil {
+		t.Fatalf("unexpected error building check: %v", err)
+	}
+
+	assertHandledCheckLimitAbsentFromJSON(t, c)
+}
+
+func TestHandledCheckLimit_DocumentAuthenticityCheck(t *testing.T) {
+	rec := mustBuildRecommendation(t)
+	c, err := NewDocumentAuthenticityCheckBuilder().WithRecommendation(rec).WithHandledCheckLimit(2).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitInJSON(t, c, 2)
+	c2, err := NewDocumentAuthenticityCheckBuilder().WithRecommendation(rec).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitAbsentFromJSON(t, c2)
+}
+
+func TestHandledCheckLimit_DocumentFaceMatchCheck(t *testing.T) {
+	rec := mustBuildRecommendation(t)
+	c, err := NewDocumentFaceMatchCheckBuilder().WithRecommendation(rec).WithHandledCheckLimit(2).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitInJSON(t, c, 2)
+	c2, err := NewDocumentFaceMatchCheckBuilder().WithRecommendation(rec).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitAbsentFromJSON(t, c2)
+}
+
+func TestHandledCheckLimit_DocumentTextDataCheck(t *testing.T) {
+	rec := mustBuildRecommendation(t)
+	c, err := NewDocumentTextDataCheckBuilder().WithRecommendation(rec).WithHandledCheckLimit(2).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitInJSON(t, c, 2)
+	c2, err := NewDocumentTextDataCheckBuilder().WithRecommendation(rec).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitAbsentFromJSON(t, c2)
+}
+
+func TestHandledCheckLimit_IDDocumentComparisonCheck(t *testing.T) {
+	rec := mustBuildRecommendation(t)
+	c, err := NewIDDocumentComparisonCheckBuilder().WithRecommendation(rec).WithHandledCheckLimit(2).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitInJSON(t, c, 2)
+	c2, err := NewIDDocumentComparisonCheckBuilder().WithRecommendation(rec).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitAbsentFromJSON(t, c2)
+}
+
+func TestHandledCheckLimit_SupplementaryDocumentTextDataCheck(t *testing.T) {
+	rec := mustBuildRecommendation(t)
+	c, err := NewSupplementaryDocumentTextDataCheckBuilder().WithRecommendation(rec).WithHandledCheckLimit(2).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitInJSON(t, c, 2)
+	c2, err := NewSupplementaryDocumentTextDataCheckBuilder().WithRecommendation(rec).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitAbsentFromJSON(t, c2)
+}
+
+func TestHandledCheckLimit_ThirdPartyIdentityCheck(t *testing.T) {
+	rec := mustBuildRecommendation(t)
+	c, err := NewThirdPartyIdentityCheckBuilder().WithRecommendation(rec).WithHandledCheckLimit(2).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitInJSON(t, c, 2)
+	c2, err := NewThirdPartyIdentityCheckBuilder().WithRecommendation(rec).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitAbsentFromJSON(t, c2)
+}
+
+func TestHandledCheckLimit_ZoomLivenessCheck(t *testing.T) {
+	rec := mustBuildRecommendation(t)
+	c, err := NewZoomLivenessCheckBuilder().WithRecommendation(rec).WithHandledCheckLimit(2).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitInJSON(t, c, 2)
+	c2, err := NewZoomLivenessCheckBuilder().WithRecommendation(rec).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitAbsentFromJSON(t, c2)
+}
+
+func TestHandledCheckLimit_StaticLivenessCheck(t *testing.T) {
+	rec := mustBuildRecommendation(t)
+	c, err := NewStaticLivenessCheckBuilder().WithRecommendation(rec).WithHandledCheckLimit(2).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitInJSON(t, c, 2)
+	c2, err := NewStaticLivenessCheckBuilder().WithRecommendation(rec).Build()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertHandledCheckLimitAbsentFromJSON(t, c2)
+}
+
+func mustBuildRecommendation(t *testing.T) *report.Recommendation {
+	t.Helper()
+	rec, err := report.NewRecommendationBuilder().WithValue("APPROVE").Build()
+	if err != nil {
+		t.Fatalf("unexpected error building recommendation: %v", err)
+	}
+	return rec
+}
+
+func assertHandledCheckLimitInJSON(t *testing.T, v interface{}, limit int) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling: %v", err)
+	}
+	jsonStr := string(data)
+	expected := fmt.Sprintf(`"handled_check_limit":%d`, limit)
+	if !strings.Contains(jsonStr, expected) {
+		t.Errorf("expected JSON to contain %s, got: %s", expected, jsonStr)
+	}
+}
+
+func assertHandledCheckLimitAbsentFromJSON(t *testing.T, v interface{}) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling: %v", err)
+	}
+	jsonStr := string(data)
+	if strings.Contains(jsonStr, "handled_check_limit") {
+		t.Errorf("expected JSON to omit handled_check_limit, got: %s", jsonStr)
+	}
+}

--- a/docscan/sandbox/request/check/id_document_comparison_check.go
+++ b/docscan/sandbox/request/check/id_document_comparison_check.go
@@ -40,6 +40,12 @@ func (b *IDDocumentComparisonCheckBuilder) WithSecondaryDocumentFilter(filter *f
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check response is used before advancing to the next
+func (b *IDDocumentComparisonCheckBuilder) WithHandledCheckLimit(limit int) *IDDocumentComparisonCheckBuilder {
+	b.withHandledCheckLimit(limit)
+	return b
+}
+
 // Build creates a new IDDocumentComparisonCheck
 func (b *IDDocumentComparisonCheckBuilder) Build() (*IDDocumentComparisonCheck, error) {
 	return &IDDocumentComparisonCheck{

--- a/docscan/sandbox/request/check/static_liveness_check.go
+++ b/docscan/sandbox/request/check/static_liveness_check.go
@@ -27,6 +27,12 @@ func (b *StaticLivenessCheckBuilder) WithBreakdown(breakdown *report.Breakdown) 
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check response is used before advancing to the next
+func (b *StaticLivenessCheckBuilder) WithHandledCheckLimit(limit int) *StaticLivenessCheckBuilder {
+	b.withHandledCheckLimit(limit)
+	return b
+}
+
 // Build creates a new LivenessCheck
 func (b *StaticLivenessCheckBuilder) Build() (*LivenessCheck, error) {
 	livenessCheck := b.livenessCheckBuilder.

--- a/docscan/sandbox/request/check/supplementary_document_text_data_check.go
+++ b/docscan/sandbox/request/check/supplementary_document_text_data_check.go
@@ -61,6 +61,12 @@ func (b *SupplementaryDocumentTextDataCheckBuilder) WithDocumentFields(documentF
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check response is used before advancing to the next
+func (b *SupplementaryDocumentTextDataCheckBuilder) WithHandledCheckLimit(limit int) *SupplementaryDocumentTextDataCheckBuilder {
+	b.withHandledCheckLimit(limit)
+	return b
+}
+
 // Build creates a new SupplementaryDocumentTextDataCheck
 func (b *SupplementaryDocumentTextDataCheckBuilder) Build() (*SupplementaryDocumentTextDataCheck, error) {
 	docCheck := b.documentCheckBuilder.build()

--- a/docscan/sandbox/request/check/third_party_identity_check.go
+++ b/docscan/sandbox/request/check/third_party_identity_check.go
@@ -35,3 +35,9 @@ func (b *ThirdPartyIdentityCheckBuilder) WithRecommendation(recommendation *repo
 	b.checkBuilder.withRecommendation(recommendation)
 	return b
 }
+
+// WithHandledCheckLimit sets the number of times this check response is used before advancing to the next
+func (b *ThirdPartyIdentityCheckBuilder) WithHandledCheckLimit(limit int) *ThirdPartyIdentityCheckBuilder {
+	b.withHandledCheckLimit(limit)
+	return b
+}

--- a/docscan/sandbox/request/check/zoom_liveness_check.go
+++ b/docscan/sandbox/request/check/zoom_liveness_check.go
@@ -27,6 +27,12 @@ func (b *ZoomLivenessCheckBuilder) WithBreakdown(breakdown *report.Breakdown) *Z
 	return b
 }
 
+// WithHandledCheckLimit sets the number of times this check response is used before advancing to the next
+func (b *ZoomLivenessCheckBuilder) WithHandledCheckLimit(limit int) *ZoomLivenessCheckBuilder {
+	b.withHandledCheckLimit(limit)
+	return b
+}
+
 // Build creates a new LivenessCheck
 func (b *ZoomLivenessCheckBuilder) Build() (*LivenessCheck, error) {
 	livenessCheck := b.livenessCheckBuilder.


### PR DESCRIPTION
## Summary

Adds support for the `handled_check_limit` property on IDV sandbox check-report builders. The field is serialised as `handled_check_limit` in JSON (using `omitempty` so it is absent when not set), matching the behaviour expected by the Yoti IDV sandbox API. All eight concrete check-report builder types expose a new public `WithHandledCheckLimit(int)` method.

## Changes

- **`docscan/sandbox/request/check/check.go`** — Added `HandledCheckLimit *int` (`json:"handled_check_limit,omitempty"`) to the base `check` struct and a `withHandledCheckLimit(limit int)` helper on `checkBuilder`.
- **`docscan/sandbox/request/check/document_authenticity_check.go`** — Exposed `WithHandledCheckLimit(int)` on `DocumentAuthenticityCheckBuilder`.
- **`docscan/sandbox/request/check/document_face_match_check.go`** — Exposed `WithHandledCheckLimit(int)` on `DocumentFaceMatchCheckBuilder`.
- **`docscan/sandbox/request/check/document_text_data_check.go`** — Exposed `WithHandledCheckLimit(int)` on `DocumentTextDataCheckBuilder`.
- **`docscan/sandbox/request/check/id_document_comparison_check.go`** — Exposed `WithHandledCheckLimit(int)` on `IDDocumentComparisonCheckBuilder`.
- **`docscan/sandbox/request/check/supplementary_document_text_data_check.go`** — Exposed `WithHandledCheckLimit(int)` on `SupplementaryDocumentTextDataCheckBuilder`.
- **`docscan/sandbox/request/check/third_party_identity_check.go`** — Exposed `WithHandledCheckLimit(int)` on `ThirdPartyIdentityCheckBuilder`.
- **`docscan/sandbox/request/check/zoom_liveness_check.go`** — Exposed `WithHandledCheckLimit(int)` on `ZoomLivenessCheckBuilder`.
- **`docscan/sandbox/request/check/static_liveness_check.go`** — Exposed `WithHandledCheckLimit(int)` on `StaticLivenessCheckBuilder`.
- **`docscan/sandbox/request/check/handled_check_limit_test.go`** — New test file with per-type tests confirming the field is included in JSON when set and omitted when not set, plus a runnable Example function.

## QA Test Steps

1. **Setup** — Clone the repo, check out this branch, and ensure Go tooling is available (`go version`).
2. **Unit tests** — Run `go test ./docscan/sandbox/request/check/...` and confirm all tests pass, including the new `TestHandledCheckLimit_*` cases.
3. **Happy path — field present** — Call any builder (e.g. `NewDocumentAuthenticityCheckBuilder()`) with `.WithHandledCheckLimit(3)`, marshal to JSON, and verify `"handled_check_limit":3` appears in the output.
4. **Happy path — field absent** — Call the same builder without `.WithHandledCheckLimit(...)`, marshal to JSON, and verify `handled_check_limit` is NOT present in the output.
5. **Edge case — zero value** — Call `.WithHandledCheckLimit(0)`, marshal, and verify `"handled_check_limit":0` IS present (zero is a valid limit, not omitted).
6. **All check types** — Repeat steps 3-4 for each of the eight builder types to ensure consistent behaviour.
7. **Regression** — Run the full test suite (`go test ./...`) to confirm no existing tests are broken.

## Notes

- `*int` is used instead of `int` so that the zero value (0) can be distinguished from "not set" while still allowing `omitempty` to elide the field when nil.
- No changes to non-sandbox (production) code paths; this is sandbox-only.
- Follow-up work may be needed in other SDK languages if the same property is required there.

---

*Related Jira:* SDK-2761
*Auto-generated by Claude dynamic workflow*