### PR TITLE
Sdk 2813 go support digital i ds in idv

### DIFF
--- a/docscan/session/create/filter/document_restrictions_filter.go
+++ b/docscan/session/create/filter/document_restrictions_filter.go
@@ -93,7 +93,7 @@ func (b *RequestedDocumentRestrictionsFilterBuilder) WithAllowDigitalIDs(allowDi
 
 // WithAllowedProviders sets the list of allowed digital ID providers on the filter, replacing any previously set value
 func (b *RequestedDocumentRestrictionsFilterBuilder) WithAllowedProviders(allowedProviders []*DigitalIDProvider) *RequestedDocumentRestrictionsFilterBuilder {
-	b.allowedProviders = allowedProviders
+	b.allowedProviders = append([]*DigitalIDProvider(nil), allowedProviders...)
 	return b
 }
 

--- a/docscan/session/create/filter/document_restrictions_filter.go
+++ b/docscan/session/create/filter/document_restrictions_filter.go
@@ -8,6 +8,8 @@ type RequestedDocumentRestrictionsFilter struct {
 	documents              []*RequestedDocumentRestriction
 	allowExpiredDocuments  *bool
 	allowNonLatinDocuments *bool
+	allowDigitalIDs        *bool
+	allowedProviders       []*DigitalIDProvider
 }
 
 // Type is the type of the document restriction filter
@@ -23,12 +25,16 @@ func (r *RequestedDocumentRestrictionsFilter) MarshalJSON() ([]byte, error) {
 		Documents              []*RequestedDocumentRestriction `json:"documents"`
 		AllowExpiredDocuments  *bool                           `json:"allow_expired_documents,omitempty"`
 		AllowNonLatinDocuments *bool                           `json:"allow_non_latin_documents,omitempty"`
+		AllowDigitalIDs        *bool                           `json:"allow_digital_ids,omitempty"`
+		AllowedProviders       []*DigitalIDProvider            `json:"allowed_providers,omitempty"`
 	}{
 		Type:                   r.Type(),
 		Inclusion:              r.inclusion,
 		Documents:              r.documents,
 		AllowExpiredDocuments:  r.allowExpiredDocuments,
 		AllowNonLatinDocuments: r.allowNonLatinDocuments,
+		AllowDigitalIDs:        r.allowDigitalIDs,
+		AllowedProviders:       r.allowedProviders,
 	})
 }
 
@@ -38,6 +44,8 @@ type RequestedDocumentRestrictionsFilterBuilder struct {
 	documents              []*RequestedDocumentRestriction
 	allowExpiredDocuments  *bool
 	allowNonLatinDocuments *bool
+	allowDigitalIDs        *bool
+	allowedProviders       []*DigitalIDProvider
 }
 
 // NewRequestedDocumentRestrictionsFilterBuilder creates a new RequestedDocumentRestrictionsFilterBuilder
@@ -77,12 +85,32 @@ func (b *RequestedDocumentRestrictionsFilterBuilder) WithAllowNonLatinDocuments(
 	return b
 }
 
+// WithAllowDigitalIDs sets a bool value to allowDigitalIDs on the filter
+func (b *RequestedDocumentRestrictionsFilterBuilder) WithAllowDigitalIDs(allowDigitalIDs bool) *RequestedDocumentRestrictionsFilterBuilder {
+	b.allowDigitalIDs = &allowDigitalIDs
+	return b
+}
+
+// WithAllowedProviders sets the list of allowed digital ID providers on the filter, replacing any previously set value
+func (b *RequestedDocumentRestrictionsFilterBuilder) WithAllowedProviders(allowedProviders []*DigitalIDProvider) *RequestedDocumentRestrictionsFilterBuilder {
+	b.allowedProviders = allowedProviders
+	return b
+}
+
+// WithAllowedProvider adds a single allowed digital ID provider to the filter
+func (b *RequestedDocumentRestrictionsFilterBuilder) WithAllowedProvider(allowedProvider *DigitalIDProvider) *RequestedDocumentRestrictionsFilterBuilder {
+	b.allowedProviders = append(b.allowedProviders, allowedProvider)
+	return b
+}
+
 // Build creates a new RequestedDocumentRestrictionsFilter
 func (b *RequestedDocumentRestrictionsFilterBuilder) Build() (*RequestedDocumentRestrictionsFilter, error) {
 	return &RequestedDocumentRestrictionsFilter{
-		b.inclusion,
-		b.documents,
-		b.allowExpiredDocuments,
-		b.allowNonLatinDocuments,
+		inclusion:              b.inclusion,
+		documents:              b.documents,
+		allowExpiredDocuments:  b.allowExpiredDocuments,
+		allowNonLatinDocuments: b.allowNonLatinDocuments,
+		allowDigitalIDs:        b.allowDigitalIDs,
+		allowedProviders:       b.allowedProviders,
 	}, nil
 }

--- a/docscan/session/create/filter/document_restrictions_filter_test.go
+++ b/docscan/session/create/filter/document_restrictions_filter_test.go
@@ -138,3 +138,64 @@ func ExampleRequestedDocumentRestrictionsFilterBuilder_withDenyNonLatinDocuments
 	fmt.Println(string(data))
 	// Output: {"type":"DOCUMENT_RESTRICTIONS","inclusion":"","documents":[],"allow_non_latin_documents":false}
 }
+
+func ExampleRequestedDocumentRestrictionsFilterBuilder_withAllowDigitalIDs() {
+	restriction, err := NewRequestedDocumentRestrictionsFilterBuilder().
+		WithAllowDigitalIDs(true).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"DOCUMENT_RESTRICTIONS","inclusion":"","documents":[],"allow_digital_ids":true}
+}
+
+func ExampleRequestedDocumentRestrictionsFilterBuilder_withAllowedProviders() {
+	restriction, err := NewRequestedDocumentRestrictionsFilterBuilder().
+		WithAllowedProviders([]*DigitalIDProvider{
+			{Name: "DIGILOCKER"},
+			{Name: "EPHIL_ID_QR"},
+		}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"DOCUMENT_RESTRICTIONS","inclusion":"","documents":[],"allowed_providers":[{"name":"DIGILOCKER"},{"name":"EPHIL_ID_QR"}]}
+}
+
+func ExampleRequestedDocumentRestrictionsFilterBuilder_withAllowedProvider() {
+	restriction, err := NewRequestedDocumentRestrictionsFilterBuilder().
+		WithAllowedProvider(&DigitalIDProvider{Name: "DIGILOCKER"}).
+		WithAllowedProvider(&DigitalIDProvider{Name: "EPHIL_ID_QR"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"DOCUMENT_RESTRICTIONS","inclusion":"","documents":[],"allowed_providers":[{"name":"DIGILOCKER"},{"name":"EPHIL_ID_QR"}]}
+}

--- a/docscan/session/create/filter/document_restrictions_filter_test.go
+++ b/docscan/session/create/filter/document_restrictions_filter_test.go
@@ -3,6 +3,9 @@ package filter
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 func ExampleRequestedDocumentRestrictionsFilterBuilder_ForIncludeList() {
@@ -198,4 +201,30 @@ func ExampleRequestedDocumentRestrictionsFilterBuilder_withAllowedProvider() {
 
 	fmt.Println(string(data))
 	// Output: {"type":"DOCUMENT_RESTRICTIONS","inclusion":"","documents":[],"allowed_providers":[{"name":"DIGILOCKER"},{"name":"EPHIL_ID_QR"}]}
+}
+
+// TestRequestedDocumentRestrictionsFilterBuilder_WithAllowedProviders_DoesNotAliasCallerSlice guards
+// against the built filter changing if the caller mutates (via append) the slice they passed in,
+// which can happen silently when the passed-in slice has spare capacity.
+func TestRequestedDocumentRestrictionsFilterBuilder_WithAllowedProviders_DoesNotAliasCallerSlice(t *testing.T) {
+	callerSlice := make([]*DigitalIDProvider, 2, 4)
+	callerSlice[0] = &DigitalIDProvider{Name: "A"}
+	callerSlice[1] = &DigitalIDProvider{Name: "B"}
+
+	restriction, err := NewRequestedDocumentRestrictionsFilterBuilder().
+		WithAllowedProviders(callerSlice).
+		WithAllowedProvider(&DigitalIDProvider{Name: "C"}).
+		Build()
+	assert.NilError(t, err)
+
+	before, err := json.Marshal(restriction)
+	assert.NilError(t, err)
+
+	// Mutating the caller's own slice must not affect the already-built filter.
+	_ = append(callerSlice, &DigitalIDProvider{Name: "should-not-appear"})
+
+	after, err := json.Marshal(restriction)
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(before), string(after))
 }

--- a/docscan/session/create/filter/orthogonal_restrictions_filter.go
+++ b/docscan/session/create/filter/orthogonal_restrictions_filter.go
@@ -55,6 +55,8 @@ func NewRequestedOrthogonalRestrictionsFilterBuilder() *RequestedOrthogonalRestr
 		typeRestriction:        nil,
 		allowExpiredDocuments:  nil,
 		allowNonLatinDocuments: nil,
+		allowDigitalIDs:        nil,
+		allowedProviders:       nil,
 	}
 }
 
@@ -114,7 +116,7 @@ func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithAllowDigitalIDs(allow
 
 // WithAllowedProviders sets the list of allowed digital ID providers on the filter, replacing any previously set value
 func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithAllowedProviders(allowedProviders []*DigitalIDProvider) *RequestedOrthogonalRestrictionsFilterBuilder {
-	b.allowedProviders = allowedProviders
+	b.allowedProviders = append([]*DigitalIDProvider(nil), allowedProviders...)
 	return b
 }
 

--- a/docscan/session/create/filter/orthogonal_restrictions_filter.go
+++ b/docscan/session/create/filter/orthogonal_restrictions_filter.go
@@ -8,6 +8,8 @@ type RequestedOrthogonalRestrictionsFilter struct {
 	typeRestriction        *TypeRestriction
 	allowExpiredDocuments  *bool
 	allowNonLatinDocuments *bool
+	allowDigitalIDs        *bool
+	allowedProviders       []*DigitalIDProvider
 }
 
 // Type returns the type of the RequestedOrthogonalRestrictionsFilter
@@ -18,17 +20,21 @@ func (r RequestedOrthogonalRestrictionsFilter) Type() string {
 // MarshalJSON returns the JSON encoding
 func (r RequestedOrthogonalRestrictionsFilter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Type                   string              `json:"type"`
-		CountryRestriction     *CountryRestriction `json:"country_restriction,omitempty"`
-		TypeRestriction        *TypeRestriction    `json:"type_restriction,omitempty"`
-		AllowExpiredDocuments  *bool               `json:"allow_expired_documents,omitempty"`
-		AllowNonLatinDocuments *bool               `json:"allow_non_latin_documents,omitempty"`
+		Type                   string               `json:"type"`
+		CountryRestriction     *CountryRestriction  `json:"country_restriction,omitempty"`
+		TypeRestriction        *TypeRestriction     `json:"type_restriction,omitempty"`
+		AllowExpiredDocuments  *bool                `json:"allow_expired_documents,omitempty"`
+		AllowNonLatinDocuments *bool                `json:"allow_non_latin_documents,omitempty"`
+		AllowDigitalIDs        *bool                `json:"allow_digital_ids,omitempty"`
+		AllowedProviders       []*DigitalIDProvider `json:"allowed_providers,omitempty"`
 	}{
 		CountryRestriction:     r.countryRestriction,
 		TypeRestriction:        r.typeRestriction,
 		Type:                   r.Type(),
 		AllowExpiredDocuments:  r.allowExpiredDocuments,
 		AllowNonLatinDocuments: r.allowNonLatinDocuments,
+		AllowDigitalIDs:        r.allowDigitalIDs,
+		AllowedProviders:       r.allowedProviders,
 	})
 }
 
@@ -38,6 +44,8 @@ type RequestedOrthogonalRestrictionsFilterBuilder struct {
 	typeRestriction        *TypeRestriction
 	allowExpiredDocuments  *bool
 	allowNonLatinDocuments *bool
+	allowDigitalIDs        *bool
+	allowedProviders       []*DigitalIDProvider
 }
 
 // NewRequestedOrthogonalRestrictionsFilterBuilder creates a new RequestedOrthogonalRestrictionsFilterBuilder
@@ -98,12 +106,32 @@ func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithExpiredDocuments(allo
 	return b
 }
 
+// WithAllowDigitalIDs sets a bool value to allowDigitalIDs on the filter
+func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithAllowDigitalIDs(allowDigitalIDs bool) *RequestedOrthogonalRestrictionsFilterBuilder {
+	b.allowDigitalIDs = &allowDigitalIDs
+	return b
+}
+
+// WithAllowedProviders sets the list of allowed digital ID providers on the filter, replacing any previously set value
+func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithAllowedProviders(allowedProviders []*DigitalIDProvider) *RequestedOrthogonalRestrictionsFilterBuilder {
+	b.allowedProviders = allowedProviders
+	return b
+}
+
+// WithAllowedProvider adds a single allowed digital ID provider to the filter
+func (b *RequestedOrthogonalRestrictionsFilterBuilder) WithAllowedProvider(allowedProvider *DigitalIDProvider) *RequestedOrthogonalRestrictionsFilterBuilder {
+	b.allowedProviders = append(b.allowedProviders, allowedProvider)
+	return b
+}
+
 // Build creates a new RequestedOrthogonalRestrictionsFilter
 func (b *RequestedOrthogonalRestrictionsFilterBuilder) Build() (*RequestedOrthogonalRestrictionsFilter, error) {
 	return &RequestedOrthogonalRestrictionsFilter{
-		b.countryRestriction,
-		b.typeRestriction,
-		b.allowExpiredDocuments,
-		b.allowNonLatinDocuments,
+		countryRestriction:     b.countryRestriction,
+		typeRestriction:        b.typeRestriction,
+		allowExpiredDocuments:  b.allowExpiredDocuments,
+		allowNonLatinDocuments: b.allowNonLatinDocuments,
+		allowDigitalIDs:        b.allowDigitalIDs,
+		allowedProviders:       b.allowedProviders,
 	}, nil
 }

--- a/docscan/session/create/filter/orthogonal_restrictions_filter_test.go
+++ b/docscan/session/create/filter/orthogonal_restrictions_filter_test.go
@@ -156,3 +156,64 @@ func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withDenyNonLatinDocumen
 	fmt.Println(string(data))
 	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allow_non_latin_documents":false}
 }
+
+func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withAllowDigitalIDs() {
+	restriction, err := NewRequestedOrthogonalRestrictionsFilterBuilder().
+		WithAllowDigitalIDs(true).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allow_digital_ids":true}
+}
+
+func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withAllowedProviders() {
+	restriction, err := NewRequestedOrthogonalRestrictionsFilterBuilder().
+		WithAllowedProviders([]*DigitalIDProvider{
+			{Name: "DIGILOCKER"},
+			{Name: "EPHIL_ID_QR"},
+		}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allowed_providers":[{"name":"DIGILOCKER"},{"name":"EPHIL_ID_QR"}]}
+}
+
+func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withAllowedProvider() {
+	restriction, err := NewRequestedOrthogonalRestrictionsFilterBuilder().
+		WithAllowedProvider(&DigitalIDProvider{Name: "DIGILOCKER"}).
+		WithAllowedProvider(&DigitalIDProvider{Name: "EPHIL_ID_QR"}).
+		Build()
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(restriction)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allowed_providers":[{"name":"DIGILOCKER"},{"name":"EPHIL_ID_QR"}]}
+}

--- a/docscan/session/create/filter/orthogonal_restrictions_filter_test.go
+++ b/docscan/session/create/filter/orthogonal_restrictions_filter_test.go
@@ -3,6 +3,9 @@ package filter
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 func ExampleRequestedOrthogonalRestrictionsFilterBuilder_WithIncludedCountries() {
@@ -216,4 +219,30 @@ func ExampleRequestedOrthogonalRestrictionsFilterBuilder_withAllowedProvider() {
 
 	fmt.Println(string(data))
 	// Output: {"type":"ORTHOGONAL_RESTRICTIONS","allowed_providers":[{"name":"DIGILOCKER"},{"name":"EPHIL_ID_QR"}]}
+}
+
+// TestRequestedOrthogonalRestrictionsFilterBuilder_WithAllowedProviders_DoesNotAliasCallerSlice guards
+// against the built filter changing if the caller mutates (via append) the slice they passed in,
+// which can happen silently when the passed-in slice has spare capacity.
+func TestRequestedOrthogonalRestrictionsFilterBuilder_WithAllowedProviders_DoesNotAliasCallerSlice(t *testing.T) {
+	callerSlice := make([]*DigitalIDProvider, 2, 4)
+	callerSlice[0] = &DigitalIDProvider{Name: "A"}
+	callerSlice[1] = &DigitalIDProvider{Name: "B"}
+
+	restriction, err := NewRequestedOrthogonalRestrictionsFilterBuilder().
+		WithAllowedProviders(callerSlice).
+		WithAllowedProvider(&DigitalIDProvider{Name: "C"}).
+		Build()
+	assert.NilError(t, err)
+
+	before, err := json.Marshal(restriction)
+	assert.NilError(t, err)
+
+	// Mutating the caller's own slice must not affect the already-built filter.
+	_ = append(callerSlice, &DigitalIDProvider{Name: "should-not-appear"})
+
+	after, err := json.Marshal(restriction)
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(before), string(after))
 }

--- a/docscan/session/create/filter/restriction.go
+++ b/docscan/session/create/filter/restriction.go
@@ -11,3 +11,8 @@ type CountryRestriction struct {
 	Inclusion    string   `json:"inclusion"`
 	CountryCodes []string `json:"country_codes"`
 }
+
+// DigitalIDProvider is a digital identity provider allowed to satisfy a required document
+type DigitalIDProvider struct {
+	Name string `json:"name"`
+}

--- a/docscan/session/retrieve/capture_response_test.go
+++ b/docscan/session/retrieve/capture_response_test.go
@@ -45,10 +45,63 @@ func TestCaptureResponse_UnmarshalJSON(t *testing.T) {
 	assert.Assert(t, ok)
 }
 
+func TestCaptureResponse_UnmarshalJSON_SupportedCountries(t *testing.T) {
+	jsonData := []byte(`{
+		"biometric_consent": "given",
+		"required_resources": [
+			{
+				"type": "ID_DOCUMENT",
+				"id": "id1",
+				"state": "pending",
+				"supported_countries": [
+					{
+						"code": "IND",
+						"supported_documents": [
+							{"type": "AADHAAR", "providers": ["DIGILOCKER"]}
+						]
+					}
+				]
+			}
+		]
+	}`)
+
+	var c CaptureResponse
+	err := json.Unmarshal(jsonData, &c)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(c.RequiredResources))
+
+	idDocument, ok := c.RequiredResources[0].(*RequiredIdDocumentResourceResponse)
+	assert.Assert(t, ok)
+
+	assert.Equal(t, 1, len(idDocument.SupportedCountries))
+	assert.Equal(t, "IND", idDocument.SupportedCountries[0].Code)
+	assert.Equal(t, 1, len(idDocument.SupportedCountries[0].SupportedDocuments))
+	assert.Equal(t, "AADHAAR", idDocument.SupportedCountries[0].SupportedDocuments[0].Type)
+	assert.Equal(t, 1, len(idDocument.SupportedCountries[0].SupportedDocuments[0].Providers))
+	assert.Equal(t, "DIGILOCKER", idDocument.SupportedCountries[0].SupportedDocuments[0].Providers[0])
+}
+
+func TestCaptureResponse_UnmarshalJSON_SupportedCountriesOmitted(t *testing.T) {
+	jsonData := []byte(`{
+		"biometric_consent": "given",
+		"required_resources": [
+			{"type": "ID_DOCUMENT", "id": "id1", "state": "pending"}
+		]
+	}`)
+
+	var c CaptureResponse
+	err := json.Unmarshal(jsonData, &c)
+	assert.NilError(t, err)
+
+	idDocument, ok := c.RequiredResources[0].(*RequiredIdDocumentResourceResponse)
+	assert.Assert(t, ok)
+	assert.Equal(t, 0, len(idDocument.SupportedCountries))
+}
+
 func TestCaptureResponse_Getters(t *testing.T) {
 	c := CaptureResponse{
 		RequiredResources: []RequiredResourceResponse{
-			&RequiredIdDocumentResourceResponse{BaseRequiredResource{Type: "ID_DOCUMENT", ID: "id1"}},
+			&RequiredIdDocumentResourceResponse{BaseRequiredResource: BaseRequiredResource{Type: "ID_DOCUMENT", ID: "id1"}},
 			&RequiredSupplementaryDocumentResourceResponse{BaseRequiredResource{Type: "SUPPLEMENTARY_DOCUMENT", ID: "id2"}},
 			&RequiredZoomLivenessResourceResponse{BaseRequiredResource{Type: "LIVENESS", ID: "id3", LivenessType: "ZOOM"}},
 			&RequiredStaticLivenessResourceResponse{BaseRequiredResource{Type: "LIVENESS", ID: "id4", LivenessType: "STATIC"}},

--- a/docscan/session/retrieve/digital_id_share_response.go
+++ b/docscan/session/retrieve/digital_id_share_response.go
@@ -1,0 +1,21 @@
+package retrieve
+
+import "time"
+
+// DigitalIDShareResponse represents a digital ID share performed in a session
+type DigitalIDShareResponse struct {
+	ID             string                       `json:"id"`
+	DocumentType   string                       `json:"document_type"`
+	IssuingCountry string                       `json:"issuing_country"`
+	Provider       string                       `json:"provider"`
+	CreatedAt      *time.Time                   `json:"created_at"`
+	LastUpdated    *time.Time                   `json:"last_updated"`
+	ResourceID     string                       `json:"resource_id"`
+	Error          *DigitalIDShareErrorResponse `json:"error"`
+}
+
+// DigitalIDShareErrorResponse represents the error of a failed digital ID share
+type DigitalIDShareErrorResponse struct {
+	Code        string `json:"code"`
+	Description string `json:"description"`
+}

--- a/docscan/session/retrieve/get_session_result.go
+++ b/docscan/session/retrieve/get_session_result.go
@@ -22,6 +22,7 @@ type GetSessionResult struct {
 	IdentityProfilePreview              *IdentityProfilePreview          `json:"identity_profile_preview"`
 	AdvancedIdentityProfilePreview      *AdvancedIdentityProfilePreview  `json:"advanced_identity_profile_preview"`
 	ImportTokenResponse                 *ImportTokenResponse             `json:"import_token"`
+	DigitalIDShares                     []*DigitalIDShareResponse        `json:"digital_id_shares"`
 	authenticityChecks                  []*AuthenticityCheckResponse
 	faceMatchChecks                     []*FaceMatchCheckResponse
 	textDataChecks                      []*TextDataCheckResponse

--- a/docscan/session/retrieve/get_session_result_test.go
+++ b/docscan/session/retrieve/get_session_result_test.go
@@ -299,3 +299,52 @@ func TestGetSessionResult_UnmarshalJSON_AdvancedIdentityProfilePreview(t *testin
 	assert.Equal(t, identityProfilePreview.Media.ID, "3fa85f64-5717-4562-b3fc-2c963f66afa6")
 	assert.Equal(t, identityProfilePreview.Media.Type, "IMAGE")
 }
+
+func TestGetSessionResult_UnmarshalJSON_DigitalIDShares(t *testing.T) {
+	raw := []byte(`{
+		"digital_id_shares": [
+			{
+				"id": "share-1",
+				"document_type": "DIGITAL_AADHAAR",
+				"issuing_country": "IND",
+				"provider": "DIGILOCKER",
+				"created_at": "2023-01-04T13:42:34Z",
+				"last_updated": "2023-01-04T13:42:35Z",
+				"resource_id": "resource-1",
+				"error": null
+			},
+			{
+				"id": "share-2",
+				"document_type": "DIGITAL_AADHAAR",
+				"issuing_country": "IND",
+				"provider": "DIGILOCKER",
+				"created_at": "2023-01-04T13:43:00Z",
+				"last_updated": "2023-01-04T13:43:01Z",
+				"resource_id": "resource-2",
+				"error": {
+					"code": "SHARE_FAILED",
+					"description": "the share was not completed successfully"
+				}
+			}
+		]
+	}`)
+
+	var result retrieve.GetSessionResult
+	err := result.UnmarshalJSON(raw)
+	assert.NilError(t, err)
+
+	assert.Equal(t, 2, len(result.DigitalIDShares))
+
+	first := result.DigitalIDShares[0]
+	assert.Equal(t, "share-1", first.ID)
+	assert.Equal(t, "DIGILOCKER", first.Provider)
+	assert.Equal(t, "resource-1", first.ResourceID)
+	assert.Assert(t, first.CreatedAt != nil)
+	assert.Assert(t, first.LastUpdated != nil)
+	assert.Assert(t, first.Error == nil)
+
+	second := result.DigitalIDShares[1]
+	assert.Assert(t, second.Error != nil)
+	assert.Equal(t, "SHARE_FAILED", second.Error.Code)
+	assert.Equal(t, "the share was not completed successfully", second.Error.Description)
+}

--- a/docscan/session/retrieve/id_document_resource_response.go
+++ b/docscan/session/retrieve/id_document_resource_response.go
@@ -14,7 +14,7 @@ type IDDocumentResourceResponse struct {
 	// IssuingCountry is the issuing country of the identity document
 	IssuingCountry string `json:"issuing_country"`
 	// Provider is the digital ID provider the document was sourced from, e.g. "DIGILOCKER". Only present for a digital ID.
-	Provider string `json:"provider"`
+	Provider string `json:"provider,omitempty"`
 	// Pages are the individual pages of the identity document
 	Pages []*PageResponse `json:"pages"`
 	// DocumentFields are the associated document fields of a document

--- a/docscan/session/retrieve/id_document_resource_response.go
+++ b/docscan/session/retrieve/id_document_resource_response.go
@@ -13,6 +13,8 @@ type IDDocumentResourceResponse struct {
 	DocumentType string `json:"document_type"`
 	// IssuingCountry is the issuing country of the identity document
 	IssuingCountry string `json:"issuing_country"`
+	// Provider is the digital ID provider the document was sourced from, e.g. "DIGILOCKER". Only present for a digital ID.
+	Provider string `json:"provider"`
 	// Pages are the individual pages of the identity document
 	Pages []*PageResponse `json:"pages"`
 	// DocumentFields are the associated document fields of a document

--- a/docscan/session/retrieve/id_document_resource_response_test.go
+++ b/docscan/session/retrieve/id_document_resource_response_test.go
@@ -42,3 +42,19 @@ func TestIDDocumentResourceResponse_UnmarshalJSON_Invalid(t *testing.T) {
 	err := result.UnmarshalJSON([]byte("some-invalid-json"))
 	assert.ErrorContains(t, err, "invalid character")
 }
+
+func TestIDDocumentResourceResponse_UnmarshalJSON_Provider(t *testing.T) {
+	var result IDDocumentResourceResponse
+	err := json.Unmarshal([]byte(`{"id":"some-id","document_type":"DIGITAL_AADHAAR","provider":"DIGILOCKER"}`), &result)
+	assert.NilError(t, err)
+
+	assert.Equal(t, "DIGILOCKER", result.Provider)
+}
+
+func TestIDDocumentResourceResponse_UnmarshalJSON_ProviderOmittedForNonDigitalID(t *testing.T) {
+	var result IDDocumentResourceResponse
+	err := json.Unmarshal([]byte(`{"id":"some-id","document_type":"PASSPORT"}`), &result)
+	assert.NilError(t, err)
+
+	assert.Equal(t, "", result.Provider)
+}

--- a/docscan/session/retrieve/id_document_resource_response_test.go
+++ b/docscan/session/retrieve/id_document_resource_response_test.go
@@ -2,6 +2,7 @@ package retrieve
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -57,4 +58,16 @@ func TestIDDocumentResourceResponse_UnmarshalJSON_ProviderOmittedForNonDigitalID
 	assert.NilError(t, err)
 
 	assert.Equal(t, "", result.Provider)
+}
+
+func TestIDDocumentResourceResponse_MarshalJSON_ProviderOmittedWhenUnset(t *testing.T) {
+	idDocumentResource := &IDDocumentResourceResponse{
+		ResourceResponse: &ResourceResponse{ID: "some-id"},
+		DocumentType:     "PASSPORT",
+	}
+
+	data, err := json.Marshal(idDocumentResource)
+	assert.NilError(t, err)
+
+	assert.Assert(t, !strings.Contains(string(data), "provider"), "expected provider to be omitted, got: %s", data)
 }

--- a/docscan/session/retrieve/required_resource_test.go
+++ b/docscan/session/retrieve/required_resource_test.go
@@ -8,7 +8,7 @@ import (
 func TestResource_StringMethods(t *testing.T) {
 	resources := []RequiredResourceResponse{
 		&RequiredIdDocumentResourceResponse{
-			BaseRequiredResource{
+			BaseRequiredResource: BaseRequiredResource{
 				Type:  "ID_DOCUMENT",
 				ID:    "id1",
 				State: "state1",

--- a/docscan/session/retrieve/required_resources_types.go
+++ b/docscan/session/retrieve/required_resources_types.go
@@ -2,6 +2,7 @@ package retrieve
 
 type RequiredIdDocumentResourceResponse struct {
 	BaseRequiredResource
+	SupportedCountries []*SupportedCountryResponse `json:"supported_countries"`
 }
 
 func (r *RequiredIdDocumentResourceResponse) String() string {

--- a/docscan/session/retrieve/supported_country_response.go
+++ b/docscan/session/retrieve/supported_country_response.go
@@ -1,0 +1,13 @@
+package retrieve
+
+// SupportedCountryResponse represents a country and its supported documents for a required resource
+type SupportedCountryResponse struct {
+	Code               string                       `json:"code"`
+	SupportedDocuments []*SupportedDocumentResponse `json:"supported_documents"`
+}
+
+// SupportedDocumentResponse represents a supported document type and the providers that can fulfil it
+type SupportedDocumentResponse struct {
+	Type      string   `json:"type"`
+	Providers []string `json:"providers"`
+}


### PR DESCRIPTION
## Summary

Adds Go SDK support for the three concretely-specified areas of "Digital IDs in IDV" (parent ticket SDK-2811): enabling/restricting digital ID providers when creating a session, fetching digital ID shares and the provider on ID_DOCUMENT resources, and fetching supported providers per document type via the session-configuration endpoint.