### PR TITLE
feat(SDK-2613): support configuration for IDV shortened flow

### DIFF
--- a/docscan/constants/constants.go
+++ b/docscan/constants/constants.go
@@ -43,4 +43,12 @@ const (
 	Early          string = "EARLY"
 	JustInTime     string = "JUST_IN_TIME"
 	FaceComparison string = "FACE_COMPARISON"
+
+	IDDocumentEducationScreen            string = "ID_DOCUMENT_EDUCATION"
+	IDDocumentRequirementsScreen         string = "ID_DOCUMENT_REQUIREMENTS"
+	SupplementaryDocumentEducationScreen string = "SUPPLEMENTARY_DOCUMENT_EDUCATION"
+	ZoomLivenessEducationScreen          string = "ZOOM_LIVENESS_EDUCATION"
+	StaticLivenessEducationScreen        string = "STATIC_LIVENESS_EDUCATION"
+	FaceCaptureEducationScreen           string = "FACE_CAPTURE_EDUCATION"
+	FlowCompletionScreen                 string = "FLOW_COMPLETION"
 )

--- a/docscan/session/create/sdk_config.go
+++ b/docscan/session/create/sdk_config.go
@@ -23,6 +23,7 @@ type SDKConfig struct {
 	PrimaryColourDarkMode string                 `json:"primary_colour_dark_mode,omitempty"`
 	BiometricConsentFlow  string                 `json:"biometric_consent_flow,omitempty"`
 	BrandId               string                 `json:"brand_id,omitempty"`
+	SuppressedScreens     []string               `json:"suppressed_screens,omitempty"`
 
 	allowHandOffSet bool `json:"-"`
 }
@@ -46,6 +47,7 @@ func (c SDKConfig) MarshalJSON() ([]byte, error) {
 		PrimaryColourDarkMode string                 `json:"primary_colour_dark_mode,omitempty"`
 		BiometricConsentFlow  string                 `json:"biometric_consent_flow,omitempty"`
 		BrandId               string                 `json:"brand_id,omitempty"`
+		SuppressedScreens     []string               `json:"suppressed_screens,omitempty"`
 	}
 
 	var allowHandOff *bool
@@ -70,6 +72,7 @@ func (c SDKConfig) MarshalJSON() ([]byte, error) {
 		PrimaryColourDarkMode: c.PrimaryColourDarkMode,
 		BiometricConsentFlow:  c.BiometricConsentFlow,
 		BrandId:               c.BrandId,
+		SuppressedScreens:     c.SuppressedScreens,
 	}
 
 	return json.Marshal(payload)
@@ -102,6 +105,7 @@ type SdkConfigBuilder struct {
 	primaryColourDarkMode                string
 	biometricConsentFlow                 string
 	brandId                              string
+	suppressedScreens                    []string
 }
 
 // WithAllowedCaptureMethods sets the allowed capture methods on the builder
@@ -233,25 +237,37 @@ func (b *SdkConfigBuilder) WithBrandId(brandId string) *SdkConfigBuilder {
 	return b
 }
 
+// WithSuppressedScreens sets the screens to omit from the IDV flow, replacing any previously set value
+func (b *SdkConfigBuilder) WithSuppressedScreens(suppressedScreens []string) *SdkConfigBuilder {
+	b.suppressedScreens = suppressedScreens
+	return b
+}
+
+// WithSuppressedScreen adds a single screen to omit from the IDV flow
+func (b *SdkConfigBuilder) WithSuppressedScreen(suppressedScreen string) *SdkConfigBuilder {
+	b.suppressedScreens = append(b.suppressedScreens, suppressedScreen)
+	return b
+}
+
 // Build builds the SDKConfig struct using the supplied values
 func (b *SdkConfigBuilder) Build() (*SDKConfig, error) {
 	sdkConf := &SDKConfig{
-		b.allowedCaptureMethods,
-		b.primaryColour,
-		b.secondaryColour,
-		b.fontColour,
-		b.locale,
-		b.presetIssuingCountry,
-		b.successUrl,
-		b.errorUrl,
-		b.privacyPolicyUrl,
-		nil,
-		b.allowHandOff,
-		b.darkMode,
-		b.primaryColourDarkMode,
-		b.biometricConsentFlow,
-		b.brandId,
-		b.allowHandOffSet,
+		AllowedCaptureMethods: b.allowedCaptureMethods,
+		PrimaryColour:         b.primaryColour,
+		SecondaryColour:       b.secondaryColour,
+		FontColour:            b.fontColour,
+		Locale:                b.locale,
+		PresetIssuingCountry:  b.presetIssuingCountry,
+		SuccessUrl:            b.successUrl,
+		ErrorUrl:              b.errorUrl,
+		PrivacyPolicyUrl:      b.privacyPolicyUrl,
+		AllowHandOff:          b.allowHandOff,
+		DarkMode:              b.darkMode,
+		PrimaryColourDarkMode: b.primaryColourDarkMode,
+		BiometricConsentFlow:  b.biometricConsentFlow,
+		BrandId:               b.brandId,
+		SuppressedScreens:     b.suppressedScreens,
+		allowHandOffSet:       b.allowHandOffSet,
 	}
 
 	if b.idDocumentTextDataExtractionAttempts != nil {

--- a/docscan/session/create/sdk_config_test.go
+++ b/docscan/session/create/sdk_config_test.go
@@ -3,6 +3,8 @@ package create
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/getyoti/yoti-go-sdk/v3/docscan/constants"
 )
 
 func ExampleSdkConfigBuilder_Build() {
@@ -295,4 +297,93 @@ func ExampleSdkConfigBuilder_WithPrimaryColourDarkMode() {
 
 	fmt.Println(string(data))
 	// Output: {"primary_colour_dark_mode":"SOME_COLOUR"}
+}
+
+func ExampleSdkConfigBuilder_WithSuppressedScreens() {
+	sdkConfig, err := NewSdkConfigBuilder().
+		WithSuppressedScreens([]string{
+			constants.IDDocumentEducationScreen,
+			constants.IDDocumentRequirementsScreen,
+			constants.SupplementaryDocumentEducationScreen,
+			constants.ZoomLivenessEducationScreen,
+			constants.StaticLivenessEducationScreen,
+			constants.FaceCaptureEducationScreen,
+			constants.FlowCompletionScreen,
+		}).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sdkConfig)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"suppressed_screens":["ID_DOCUMENT_EDUCATION","ID_DOCUMENT_REQUIREMENTS","SUPPLEMENTARY_DOCUMENT_EDUCATION","ZOOM_LIVENESS_EDUCATION","STATIC_LIVENESS_EDUCATION","FACE_CAPTURE_EDUCATION","FLOW_COMPLETION"]}
+}
+
+func ExampleSdkConfigBuilder_WithSuppressedScreens_replacesPreviousValue() {
+	sdkConfig, err := NewSdkConfigBuilder().
+		WithSuppressedScreens([]string{constants.FlowCompletionScreen}).
+		WithSuppressedScreens([]string{constants.IDDocumentEducationScreen}).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sdkConfig)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"suppressed_screens":["ID_DOCUMENT_EDUCATION"]}
+}
+
+func ExampleSdkConfigBuilder_WithSuppressedScreen() {
+	sdkConfig, err := NewSdkConfigBuilder().
+		WithSuppressedScreen(constants.FlowCompletionScreen).
+		WithSuppressedScreen(constants.IDDocumentEducationScreen).
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sdkConfig)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {"suppressed_screens":["FLOW_COMPLETION","ID_DOCUMENT_EDUCATION"]}
+}
+
+func ExampleSdkConfigBuilder_Build_suppressedScreensOmittedWhenNotSet() {
+	sdkConfig, err := NewSdkConfigBuilder().
+		Build()
+
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	data, err := json.Marshal(sdkConfig)
+	if err != nil {
+		fmt.Printf("error: %s", err.Error())
+		return
+	}
+
+	fmt.Println(string(data))
+	// Output: {}
 }


### PR DESCRIPTION
## Summary

Adds support for `suppressed_screens` in `sdk_config`, letting a Relying Business list the screens to omit from the IDV flow for a shortened experience (e.g. education/requirements screens, `FLOW_COMPLETION`).

## Changes

- **`docscan/constants/constants.go`** — added the 7 screen-name constants from the ticket: `IDDocumentEducationScreen`, `IDDocumentRequirementsScreen`, `SupplementaryDocumentEducationScreen`, `ZoomLivenessEducationScreen`, `StaticLivenessEducationScreen`, `FaceCaptureEducationScreen`, `FlowCompletionScreen`.
- **`docscan/session/create/sdk_config.go`**:
  - `SDKConfig` gains `SuppressedScreens []string`, serialized as `suppressed_screens` (omitted when unset).
  - `SdkConfigBuilder` gains `WithSuppressedScreens(...)` (replaces the list) and `WithSuppressedScreen(...)` (appends a single screen)
  - `Build()`'s `SDKConfig` struct literal converted from positional to keyed, since the positional form breaks (or fails to compile) silently whenever a field is inserted anywhere but the end.
- **`docscan/session/create/sdk_config_test.go`** — added tests covering: full list of all 7 screens, `WithSuppressedScreens` replacing a previous value, `WithSuppressedScreen` appending, and the field being omitted when not set.

## Usage

```go
sdkConfig, err := create.NewSdkConfigBuilder().
    WithSuppressedScreens([]string{
        constants.IDDocumentEducationScreen,
        constants.FlowCompletionScreen,
    }).
    Build()
